### PR TITLE
ECS requires using the boto3 client type instead of resource

### DIFF
--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -29,7 +29,7 @@ def aws_client(resource_name: str, configuration: Configuration=None,
         creds["aws_secret_access_key"] = secrets.get("aws_secret_access_key")
         creds["aws_session_token"] = secrets.get("aws_session_token")
 
-    return boto3.resource(resource_name, region_name=region, **creds)
+    return boto3.client(resource_name, region_name=region, **creds)
 
 
 def discover(discover_system: bool = True) -> Discovery:


### PR DESCRIPTION
Manually tested that EC2 still works with this change

Signed-off-by: Brian Devins <brian.devins@coxautoinc.com>