### PR TITLE
Add self-healing tests action and probe around task stop (+ clean up previous code)

### DIFF
--- a/chaosaws/ecs/actions.py
+++ b/chaosaws/ecs/actions.py
@@ -20,7 +20,8 @@ def stop_task(cluster: str = None, task_id: str = None, service: str = None,
               configuration: Configuration = None,
               secrets: Secrets = None) -> AWSResponse:
     """
-    Stop a given ECS task instance. If no task_id provided, a random task of the given service is stopped.
+    Stop a given ECS task instance. If no task_id provided, a random task of
+    the given service is stopped.
 
     You can specify a cluster by its ARN identifier or, if not provided, the
     default cluster will be picked up.
@@ -53,10 +54,10 @@ def delete_service(service: str = None, cluster: str = None,
     """
     client = aws_client("ecs", configuration, secrets)
     if not service:
-        services = list_services(cluster=cluster, client=client)
+        services = list_services_arns(cluster=cluster, client=client)
         if not services:
             raise FailedActivity(
-                    "No ECS services found in cluster: {}".format(
+                "No ECS services found in cluster: {}".format(
                     cluster))
 
         # should we filter the number of services to take into account?
@@ -65,7 +66,7 @@ def delete_service(service: str = None, cluster: str = None,
                                        pattern=service_pattern)
             if not services:
                 raise FailedActivity(
-                        "No ECS services matching pattern: {}".format(
+                    "No ECS services matching pattern: {}".format(
                         service_pattern))
 
         service = random.choice(services)
@@ -111,12 +112,13 @@ def deregister_container_instance(cluster: str,
                                                 containerInstance=instance_id,
                                                 force=force)
 
+
 ###############################################################################
 # Private functions
 ###############################################################################
-def list_services(cluster: str, client: boto3.client) -> List[str]:
+def list_services_arns(cluster: str, client: boto3.client) -> List[str]:
     """
-    Return of all services in the given cluster.
+    Return of all services arns in the given cluster.
     """
     res = client.list_services(cluster=cluster, maxResults=10)
     services = res["serviceArns"][:]
@@ -141,13 +143,15 @@ def filter_services(services: List[str], pattern: str) -> List[str]:
 
 
 def list_tasks(cluster: str, service: str, client: boto3.client) -> List[str]:
-    res = client.list_tasks(cluster=cluster, serviceName=service, maxResults=100)
+    res = client.list_tasks(cluster=cluster, serviceName=service,
+                            maxResults=100)
     tasks = res['taskArns'][:]
     while True:
         next_token = res.get("nextToken")
         if not next_token:
             break
 
-        res = client.list_tasks(cluster=cluster, serviceName=service, nextToken=next_token, maxResults=100)
+        res = client.list_tasks(cluster=cluster, serviceName=service,
+                                nextToken=next_token, maxResults=100)
         tasks.extend(res["taskArns"])
     return tasks

--- a/chaosaws/ecs/probes.py
+++ b/chaosaws/ecs/probes.py
@@ -4,7 +4,7 @@ from chaoslib.types import Configuration, Secrets
 
 from chaosaws import aws_client
 
-__all__ = ["service_is_deploying"]
+__all__ = ["service_is_deploying", "are_all_desired_tasks_running"]
 
 
 def service_is_deploying(cluster: str,
@@ -24,3 +24,14 @@ def service_is_deploying(cluster: str,
         raise FailedActivity('Error retrieving service data from AWS')
 
     return len(response['services'][0]['deployments']) > 1
+
+
+def are_all_desired_tasks_running(cluster: str, service: str,
+                                  configuration: Configuration = None,
+                                  secrets: Secrets = None) -> bool:
+    """
+    Checks to make sure desired and running tasks counts are even
+    """
+    client = aws_client("ecs", configuration, secrets)
+    response = client.describe_services(cluster=cluster, services=[service])
+    return response['services'][0]['desiredCount'] == response['services'][0]['runningCount']

--- a/chaosaws/ecs/probes.py
+++ b/chaosaws/ecs/probes.py
@@ -30,8 +30,9 @@ def are_all_desired_tasks_running(cluster: str, service: str,
                                   configuration: Configuration = None,
                                   secrets: Secrets = None) -> bool:
     """
-    Checks to make sure desired and running tasks counts are even
+    Checks to make sure desired and running tasks counts are equal
     """
     client = aws_client("ecs", configuration, secrets)
     response = client.describe_services(cluster=cluster, services=[service])
-    return response['services'][0]['desiredCount'] == response['services'][0]['runningCount']
+    service = response['services'][0]
+    return service['desiredCount'] == service['runningCount']

--- a/tests/ecs/test_ecs_actions.py
+++ b/tests/ecs/test_ecs_actions.py
@@ -6,13 +6,13 @@ from chaosaws.ecs.actions import stop_task, delete_service, \
 
 
 @patch('chaosaws.ecs.actions.aws_client', autospec=True)
-def test_stop_instance(aws_client):
+def test_stop_task(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     cluster = "ecs-cluster"
     task_id = "16fd2706-8baf-433b-82eb-8c7fada847da"
     reason = "unit test"
-    response = stop_task(cluster, task_id, reason)
+    response = stop_task(cluster=cluster, task_id=task_id, reason=reason)
     client.stop_task.assert_called_with(
         cluster=cluster, task=task_id, reason=reason)
 

--- a/tests/ecs/test_ecs_actions.py
+++ b/tests/ecs/test_ecs_actions.py
@@ -16,6 +16,23 @@ def test_stop_task(aws_client):
     client.stop_task.assert_called_with(
         cluster=cluster, task=task_id, reason=reason)
 
+@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+def test_stop_task(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    cluster = "ecs-cluster"
+    service = "arn:aws:ecs:us-east-1:012345678910:service/my-http-service"
+    reason = "unit test"
+    client.list_tasks.side_effect = [
+        {'taskArns': ["arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"], 'nextToken': 'token0'},
+        {'taskArns': ["arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"], 'nextToken': None}
+    ]
+    response = stop_task(cluster=cluster, service=service, reason=reason)
+
+    args, kwargs = client.stop_task.call_args
+    assert kwargs["task"] in ("16fd2706-8baf-433b-82eb-8c7fada847da",
+    "84th9568-3tth-55g1-35ki-4o9amby245lk")
+
 
 @patch('chaosaws.ecs.actions.aws_client', autospec=True)
 def test_delete_service(aws_client):


### PR DESCRIPTION
Could be use with the following experiment flow:
* steady_state: are_all_desired_tasks_running(myService) == true
* methods: stop_task(myService) + pauses 15s after

Signed-off-by: Antoine Carat <acarat@oui.sncf>