### PR TITLE
Spot instances support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.6.0...HEAD
 
+## [0.7.0][]
+
+[0.7.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.6.0...0.7.0
+
+### Added
+
+-   add `count_instances` probe which can be used to count of all instances matching filters
+
+### Changed
+
+-   Refactoring to support spot instances termination along with cancelling spot request
+
 ## [0.6.0][]
 
 [0.6.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.5.2...0.6.0

--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -16,7 +16,7 @@ import requests
 from chaosaws.types import AWSResponse
 
 
-__version__ = '0.6.0'
+__version__ = '0.7.0'
 __all__ = ["__version__", "discover", "aws_client", "signed_api_call"]
 
 

--- a/chaosaws/ec2/actions.py
+++ b/chaosaws/ec2/actions.py
@@ -11,6 +11,8 @@ from logzero import logger
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
+from collections import defaultdict
+
 
 __all__ = ["stop_instance", "stop_instances"]
 
@@ -38,17 +40,20 @@ def stop_instance(instance_id: str = None, az: str = None, force: bool = False,
         filters = deepcopy(filters) if filters else []
         if az:
             filters.append({'Name': 'availability-zone', 'Values': [az]})
-        instance_id = pick_random_instance(filters, client)
+        instance_types = pick_random_instance(filters, client)
 
-        if not instance_id:
+        if not instance_types:
             raise FailedActivity(
                 "No instances in availability zone: {}".format(az))
+    else:
+        instance_types = get_instance_type_by_id(instance_id, client)
 
     logger.debug(
         "Picked EC2 instance '{}' from AZ '{}' to be stopped".format(
-            instance_id, az))
+            instance_types, az))
 
-    return client.stop_instances(InstanceIds=[instance_id], Force=force)
+    return stop_instances_any_type(instance_types=instance_types,
+                                   force=force, client=client)
 
 
 def stop_instances(instance_ids: List[str] = None, az: str = None,
@@ -66,44 +71,46 @@ def stop_instances(instance_ids: List[str] = None, az: str = None,
             "To stop EC2 instances, you must specify either the instance ids,"
             " an AZ to pick random instances from, or a set of filters.")
 
+    if az and not instance_ids and not filters:
+        logger.warn("""Based on configuration provided I am going to stop all
+                    instances in AZ {} !.""".format(az))
+
     client = aws_client('ec2', configuration, secrets)
 
     if not instance_ids:
         filters = deepcopy(filters) if filters else []
         if az:
             filters.append({'Name': 'availability-zone', 'Values': [az]})
-        instance_ids = list_instance_ids(filters, client)
+        instance_types = list_instances_by_type(filters, client)
 
-        if not instance_ids:
+        if not instance_types:
             raise FailedActivity(
                 "No instances in availability zone: {}".format(az))
+    else:
+        instance_types = get_instance_type_by_id(instance_ids, client)
 
     logger.debug(
         "Picked EC2 instances '{}' from AZ '{}' to be stopped".format(
-            ', '.join(instance_ids), az))
+            str(instance_types), az))
 
-    return client.stop_instances(InstanceIds=instance_ids, Force=force)
+    return stop_instances_any_type(instance_types=instance_types,
+                                   force=force, client=client)
 
 
 ###############################################################################
 # Private functions
 ###############################################################################
-def list_instance_ids(filters: List[Dict[str, Any]],
-                      client: boto3.client) -> List[str]:
+def list_instances_by_type(filters: List[Dict[str, Any]],
+                           client: boto3.client) -> List[str]:
     """
-    Return of all instance ids matching the given filters.
+    Return all instance ids matching the given filters by type
+    (InstanceLifecycle) ie spot, ondemand, etc.
     """
     logger.debug("EC2 instances query: {}".format(str(filters)))
     res = client.describe_instances(Filters=filters)
     logger.debug("Instances matching the filter query: {}".format(str(res)))
-    instance_ids = []
 
-    # reservations are instances that were started together
-    for reservation in res['Reservations']:
-        for inst in reservation['Instances']:
-            instance_ids.append(inst['InstanceId'])
-
-    return instance_ids
+    return get_instance_type_from_response(res)
 
 
 def pick_random_instance(filters: List[Dict[str, Any]],
@@ -112,5 +119,78 @@ def pick_random_instance(filters: List[Dict[str, Any]],
     Select an instance at random based on the returned list of instances
     matching the given filter.
     """
-    instance_ids = list_instance_ids(filters, client)
-    return random.choice(instance_ids)
+    instances_type = list_instances_by_type(filters, client)
+    random_id = random.choice([item for sublist in instances_type.values()
+                              for item in sublist])
+    for inst_type in instances_type:
+        if random_id in instances_type[inst_type]:
+            return {inst_type: [random_id]}
+
+
+def get_instance_type_from_response(response: Dict) -> Dict:
+    """
+    Transform list of instance IDs to a dict with IDs by instance type
+    """
+    instances_type = defaultdict(List)
+    # reservations are instances that were started together
+    for reservation in response['Reservations']:
+        for inst in reservation['Instances']:
+            if inst['InstanceLifecycle'] not in instances_type.keys():
+                # adding empty list (value) for new instance type (key)
+                instances_type[inst['InstanceLifecycle']] = []
+            instances_type[inst['InstanceLifecycle']].append(
+                    inst['InstanceId'])
+    return instances_type
+
+
+def get_spot_request_ids_from_response(response: Dict) -> List[str]:
+    """
+    Return list of all spot request ids from AWS response object
+    (DescribeInstances)
+    """
+    spot_request_ids = []
+    for reservation in response['Reservations']:
+        for inst in reservation['Instances']:
+            if inst['InstanceLifecycle'] == 'spot':
+                spot_request_ids.append(inst['SpotInstanceRequestId'])
+    return spot_request_ids
+
+
+def get_instance_type_by_id(instance_ids: List[str],
+                            client: boto3.client) -> Dict:
+    """
+    Return dict object with instance ids grouped by instance types
+    """
+    instances_type = defaultdict(List)
+    res = client.describe_instances(InstanceIds=instance_ids)
+    return get_instance_type_from_response(res)
+
+
+def stop_instances_any_type(instance_types: dict, force, client: boto3.client):
+    """
+    Stop instances regardless of the instance type (ondemand, spot)
+    """
+    if 'normal' in instance_types:
+        logger.debug("Stopping instances: {}".format(instance_types['normal']))
+        client.stop_instances(InstanceIds=instance_types['normal'],
+                              Force=force)
+    if 'spot' in instance_types:
+        # TODO: proper support for spot fleets
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet.html
+
+        # To properly stop spot instances have to cancel spot requests first
+        spot_request_ids = get_spot_request_ids_from_response(
+                client.describe_instances(InstanceIds=instance_types['spot']))
+
+        logger.debug("Canceling spot requests: {}".format(spot_request_ids))
+        client.cancel_spot_instance_requests(
+                SpotInstanceRequestIds=spot_request_ids)
+        logger.debug("Terminating spot instances: {}".format(
+            instance_types['spot']))
+        client.terminate_instances(InstanceIds=instance_types['spot'],
+                                   Force=force)
+    if 'scheduled' in instance_types:
+        # TODO: add support for scheduled inststances
+        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-scheduled-instances.html
+
+        raise FailedActivity("Scheduled instances support is not implemented")

--- a/chaosaws/ec2/probes.py
+++ b/chaosaws/ec2/probes.py
@@ -6,7 +6,7 @@ from chaoslib.types import Configuration, Secrets
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ["describe_instances"]
+__all__ = ["describe_instances", "count_instances"]
 
 
 def describe_instances(filters: List[Dict[str, Any]],
@@ -20,3 +20,17 @@ def describe_instances(filters: List[Dict[str, Any]],
     """  # noqa: E501
     client = aws_client('ec2', configuration, secrets)
     return client.describe_instances(Filters=filters)
+
+
+def count_instances(filters: List[Dict[str, Any]],
+                    configuration: Configuration = None,
+                    secrets: Secrets = None) -> AWSResponse:
+    """
+    Return count of instances matching the specified filters.
+
+    Please refer to http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_instances
+    for details on said filters.
+    """  # noqa: E501
+    client = aws_client('ec2', configuration, secrets)
+    result = client.describe_instances(Filters=filters)
+    return (len(result['Reservations']))

--- a/tests/ec2/test_ec2_probes.py
+++ b/tests/ec2/test_ec2_probes.py
@@ -11,3 +11,12 @@ def test_describe_instances(aws_client):
     filters = [{'Name': 'availability-zone', 'Values': ["us-west-1"]}]
     describe_instances(filters)
     client.describe_instances.assert_called_with(Filters=filters)
+
+
+@patch('chaosaws.ec2.probes.aws_client', autospec=True)
+def test_count_instances(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    filters = [{'Name': 'availability-zone', 'Values': ["us-west-1"]}]
+    describe_instances(filters)
+    client.describe_instances.assert_called_with(Filters=filters)


### PR DESCRIPTION
Hi,

This is proposal of refactoring I did to support different instance types ('spot' is implemented here, 'scheduled' will be super easy to add) as original implementation didn't have support for spot.

The idea is to introduce internal dict with instance ids grouped by type ('normal', 'spot') instead of just list with instance IDs. Interfaces not changed and implementation is fully backward compatible.

The difference is that for spot we need to cancel spot request first (in case spot request type is 'permanent' and to keep things clean) and terminate the instance as 'stop' action is not supported for spot due to it's temporary nature.

Tests are added/modified for spot instances support.

Also adding count_instances probe with a simple test, this can be further extended to validate if filter returns more than X instances.

All tests passing, style check has no issues.