### PR TITLE
initial elbv2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.6.0...HEAD
+[Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.7.0...HEAD
+
+### Added
+
+-   support for elbv2 with basic probes and action
 
 ## [0.7.0][]
 

--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -177,4 +177,6 @@ def load_exported_activities() -> List[DiscoveredActivities]:
     activities.extend(discover_probes("chaosaws.iam.probes"))
     activities.extend(discover_actions("chaosaws.eks.actions"))
     activities.extend(discover_probes("chaosaws.eks.probes"))
+    activities.extend(discover_actions("chaosaws.elbv2.actions"))
+    activities.extend(discover_probes("chaosaws.elbv2.probes"))
     return activities

--- a/chaosaws/elbv2/actions.py
+++ b/chaosaws/elbv2/actions.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+import random
+from collections import Counter
+from copy import deepcopy
+from typing import Any, Dict, List
+
+import boto3
+from logzero import logger
+
+from chaosaws import aws_client
+from chaosaws.types import AWSResponse
+from chaoslib.exceptions import FailedActivity
+from chaoslib.types import Configuration, Secrets
+
+__all__ = ["deregister_target"]
+
+
+def deregister_target(tg_name: str,
+                      configuration: Configuration = None,
+                      secrets: Secrets = None) -> AWSResponse:
+    """
+    Deregisters one random target from target group
+    """
+    client = aws_client('elbv2', configuration, secrets)
+    tg_arn = get_target_group_arns(tg_names=[tg_name], client=client)
+    tg_health = get_targets_health_description(tg_arns=tg_arn, client=client)
+    random_target = random.choice(tg_health[tg_name]
+                                  ['TargetHealthDescriptions'])['Target']['Id']
+    logger.debug("Deregistering target {} from target group {}".format(
+        random_target, tg_name))
+
+    return client.deregister_targets(TargetGroupArn=tg_arn[tg_name],
+                                     Targets=[{'Id': random_target}])
+
+###############################################################################
+# Private functions
+###############################################################################
+
+
+def get_target_group_arns(tg_names: List[str],
+                          client: boto3.client) -> Dict:
+    """
+    Return list of target group ARNs based on list of target group names
+
+    return structure:
+    {
+        "TargetGroupName": "TargetGroupArn",
+        ....
+    }
+    """
+    logger.debug("Target group name(s): {} Looking for ARN"
+                 .format(str(tg_names)))
+    res = client.describe_target_groups(Names=tg_names)
+    tg_arns = {}
+
+    for tg in res['TargetGroups']:
+        tg_arns[tg['TargetGroupName']] = tg['TargetGroupArn']
+    logger.debug("Target groups ARN: {}".format(str(tg_arns)))
+
+    return tg_arns
+
+
+def get_targets_health_description(tg_arns: Dict,
+                                   client: boto3.client) -> Dict:
+    """
+    Return TargetHealthDescriptions by targetgroups
+    Structure:
+    {
+        "TargetGroupName": {
+            "TargetGroupArn": value,
+            "TargetHealthDescriptions": TargetHealthDescriptions[]
+        },
+        ....
+    }
+    """
+    logger.debug("Target group ARN: {} Getting health descriptions"
+                 .format(str(tg_arns)))
+    tg_health_descr = {}
+
+    for tg in tg_arns:
+        tg_health_descr[tg] = {}
+        tg_health_descr[tg]['TargetGroupArn'] = tg_arns[tg]
+        tg_health_descr[tg]['TargetHealthDescriptions'] = \
+            client.describe_target_health(TargetGroupArn=tg_arns[tg])[
+            'TargetHealthDescriptions']
+    logger.debug("Health descriptions for target group(s) are: {}"
+                 .format(str(tg_health_descr)))
+
+    return tg_health_descr

--- a/chaosaws/elbv2/probes.py
+++ b/chaosaws/elbv2/probes.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+from collections import Counter
+from typing import Any, Dict, List
+
+import boto3
+from logzero import logger
+
+from chaosaws import aws_client
+from chaosaws.types import AWSResponse
+from chaoslib.types import Configuration, Secrets
+
+__all__ = ["targets_health_count"]
+
+
+def targets_health_count(tg_names: List[str],
+                         configuration: Configuration = None,
+                         secrets: Secrets = None) -> AWSResponse:
+    """
+    Count of healthy/unhealthy targets per targetgroup
+    """
+    client = aws_client('elbv2', configuration, secrets)
+
+    return get_targets_health_count(tg_names=tg_names,
+                                    client=client)
+
+
+###############################################################################
+# Private functions
+###############################################################################
+def get_target_group_arns(tg_names: List[str],
+                          client: boto3.client) -> Dict:
+    """
+    Return list of target group ARNs based on list of target group names
+
+    return structure:
+    {
+        "TargetGroupName": "TargetGroupArn",
+        ....
+    }
+    """
+    logger.debug("Target group name(s): {} Looking for ARN"
+                 .format(str(tg_names)))
+    res = client.describe_target_groups(Names=tg_names)
+    tg_arns = {}
+
+    for tg in res['TargetGroups']:
+        tg_arns[tg['TargetGroupName']] = tg['TargetGroupArn']
+    logger.debug("Target groups ARNs: {}".format(str(tg_arns)))
+
+    return tg_arns
+
+
+def get_targets_health_description(tg_arns: Dict,
+                                   client: boto3.client) -> Dict:
+    """
+    Return TargetHealthDescriptions by targetgroups
+    Structure:
+    {
+        "TargetGroupName": {
+            "TargetGroupArn": value,
+            "TargetHealthDescriptions": TargetHealthDescriptions[]
+        },
+        ....
+    }
+    """
+    logger.debug("Target group ARN: {} Getting health descriptions"
+                 .format(str(tg_arns)))
+    tg_health_descr = {}
+
+    for tg in tg_arns:
+        tg_health_descr[tg] = {}
+        tg_health_descr[tg]['TargetGroupArn'] = tg_arns[tg]
+        tg_health_descr[tg]['TargetHealthDescriptions'] = \
+            client.describe_target_health(TargetGroupArn=tg_arns[tg])[
+            'TargetHealthDescriptions']
+    logger.debug("Health descriptions for target group(s) are: {}"
+                 .format(str(tg_health_descr)))
+
+    return tg_health_descr
+
+
+def get_targets_health_count(tg_names: List[str],
+                             client: boto3.client) -> Dict:
+    """
+    Return number of healthy/unhealthy targets per target group
+    Structure:
+    {
+        "TargetGroupName": {
+            "healthy": 3,
+            "unhealthy": 1
+        },
+        ....
+    }
+    """
+    logger.debug("Looking for number of health targets for targetgroups: {}"
+                 .format(str(tg_names)))
+    tg_arns = get_target_group_arns(tg_names=tg_names, client=client)
+    tg_health = get_targets_health_description(tg_arns=tg_arns, client=client)
+    tg_targets_health_count = {}
+
+    for tg in tg_health:
+        cnt = Counter()
+
+        for health_descr in tg_health[tg]['TargetHealthDescriptions']:
+            cnt[health_descr['TargetHealth']['State']] += 1
+        tg_targets_health_count[tg] = dict(cnt)
+    logger.debug("Healthy targets by targetgroup: {}"
+                 .format(str(tg_targets_health_count)))
+
+    return tg_targets_health_count

--- a/tests/elbv2/test_elbv2_actions.py
+++ b/tests/elbv2/test_elbv2_actions.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import MagicMock, patch
+
+from chaosaws.elbv2.actions import deregister_target
+
+
+@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+def test_deregister_target(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tg_name = 'TestTargetGroup1'
+    tg_arn = """
+    arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/TestTargetGroup1/1234567890abcdef
+    """
+    target_id = 'i-0123456789abcdef0'
+    client.describe_target_groups.return_value = {"TargetGroups": [
+        {
+            'TargetGroupArn': tg_arn,
+            'TargetGroupName': tg_name
+        }
+    ]}
+    client.describe_target_health.return_value = {
+        'TargetHealthDescriptions': [{
+            'Target': {'Id': target_id}
+        }]
+    }
+    response = deregister_target(tg_name=tg_name)
+    client.deregister_targets.assert_called_with(
+        TargetGroupArn=tg_arn, Targets=[{'Id': target_id}])

--- a/tests/elbv2/test_elbv2_probes.py
+++ b/tests/elbv2/test_elbv2_probes.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import MagicMock, patch
+
+from chaosaws.elbv2.probes import targets_health_count
+
+
+@patch('chaosaws.elbv2.probes.aws_client', autospec=True)
+def test_targets_health_count(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tg_names = ['TestTargetGroup1', 'TestTargetGroup2']
+    client.describe_target_groups.return_value = {"TargetGroups": [
+        {
+            'TargetGroupArn': """
+            arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/TestTargetGroup1/1234567890abcdef
+            """,
+            'TargetGroupName': 'TestTargetGroup1'
+        },
+        {
+            'TargetGroupArn': """
+            arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/TestTargetGroup2/234567890abcdef0
+            """,
+            'TargetGroupName': 'TestTargetGroup2'
+        }
+    ]}
+    client.describe_target_health.side_effect = [
+        {
+            'TargetHealthDescriptions': [{
+                'TargetHealth': {'State': 'healthy'}
+            }]
+        },
+        {
+            'TargetHealthDescriptions': [{
+                'TargetHealth': {'State': 'unhealthy'}
+            }]
+        }
+    ]
+    desired_response = {
+        "TestTargetGroup1": {
+            "healthy": 1
+        },
+        "TestTargetGroup2": {
+            "unhealthy": 1
+        }
+    }
+    response = targets_health_count(tg_names=tg_names)
+    assert response == desired_response


### PR DESCRIPTION
Initial support for elbv2.

Basic action to deregister random instance from target group and a probe that returns number of healthy instances per target group.

I can't imagine much actions for elbv2, but I plan to further extend probes.

Signed-off-by: Dmitry Batiievskyi <dmitriy@batiyevsky.org>