### PR TITLE
asg paginator support and fix for 'inservice' instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 -   support for elbv2 with basic probes and action
 -   support for asg with basic probes
+-   fix asg probe to support pagination
 
 ## [0.7.0][]
 

--- a/chaosaws/asg/probes.py
+++ b/chaosaws/asg/probes.py
@@ -3,12 +3,11 @@ from collections import Counter
 from typing import Any, Dict, List
 
 import boto3
-from logzero import logger
-
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
+from logzero import logger
 
 __all__ = ["desired_equals_healthy", "desired_equals_healthy_tags"]
 
@@ -61,23 +60,30 @@ def desired_equals_healthy_tags(tags: List[Dict[str, str]],
 
     client = aws_client('autoscaling', configuration, secrets)
 
-    asg_descrs = client.describe_auto_scaling_groups()
-
     # The following is needed because AWS API does not support filters
     # on auto-scaling groups
 
+    # fetch all ASGs using paginator
+    page_iterator = client.get_paginator(
+        'describe_auto_scaling_groups').paginate(
+        PaginationConfig={'PageSize': 100})
+    asg_descrs = {'AutoScalingGroups': []}
+
+    for page in page_iterator:
+        asg_descrs['AutoScalingGroups'].extend(page['AutoScalingGroups'])
+
     filter_set = set(map(lambda x: "=".join([x['Key'], x['Value']]), tags))
 
-    group_sets = map(lambda g: {
+    group_sets = list(map(lambda g: {
         'Name': g['AutoScalingGroupName'],
         'Tags': set(map(
             lambda t: "=".join([t['Key'], t['Value']]), g['Tags'])
-        )}, asg_descrs['AutoScalingGroups'])
+        )}, asg_descrs['AutoScalingGroups']))
 
     filtered_groups = [g['Name']
                        for g in group_sets if filter_set.issubset(g['Tags'])]
 
-    logger.debug("filtered_groups: {}".format(filtered_groups))
+    logger.debug("filtered groups: {}".format(filtered_groups))
 
     if filtered_groups:
         groups_descr = client.describe_auto_scaling_groups(
@@ -85,8 +91,6 @@ def desired_equals_healthy_tags(tags: List[Dict[str, str]],
     else:
         raise FailedActivity(
             "No auto-scaling groups matched the tags provided")
-
-    logger.debug("groups_descr: {}".format(groups_descr))
 
     return is_desired_equals_healthy(groups_descr)
 
@@ -101,7 +105,8 @@ def is_desired_equals_healthy(groups_descr: Dict):
         healthy_cnt = Counter()
 
         for instance in group_descr['Instances']:
-            healthy_cnt[instance['HealthStatus']] += 1
+            if instance['LifecycleState'] == 'InService':
+                healthy_cnt[instance['HealthStatus']] += 1
 
         if healthy_cnt['Healthy']:
             if group_descr['DesiredCapacity'] == healthy_cnt['Healthy']:

--- a/chaosaws/ec2/probes.py
+++ b/chaosaws/ec2/probes.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 from typing import Any, Dict, List
 
-from chaoslib.types import Configuration, Secrets
-
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
+from chaoslib.types import Configuration, Secrets
 
 __all__ = ["describe_instances", "count_instances"]
 
@@ -16,9 +15,11 @@ def describe_instances(filters: List[Dict[str, Any]],
     Describe instances following the specified filters.
 
     Please refer to http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_instances
+
     for details on said filters.
     """  # noqa: E501
     client = aws_client('ec2', configuration, secrets)
+
     return client.describe_instances(Filters=filters)
 
 
@@ -29,8 +30,10 @@ def count_instances(filters: List[Dict[str, Any]],
     Return count of instances matching the specified filters.
 
     Please refer to http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_instances
+
     for details on said filters.
     """  # noqa: E501
     client = aws_client('ec2', configuration, secrets)
     result = client.describe_instances(Filters=filters)
-    return (len(result['Reservations']))
+
+    return len(result['Reservations'])

--- a/tests/asg/test_asg_probes.py
+++ b/tests/asg/test_asg_probes.py
@@ -2,7 +2,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from chaosaws.asg.probes import (desired_equals_healthy,
                                  desired_equals_healthy_tags)
 from chaoslib.exceptions import FailedActivity
@@ -17,7 +16,8 @@ def test_desired_equals_healthy_true(aws_client):
         "AutoScalingGroups": [{
             "DesiredCapacity": 1,
             "Instances": [{
-                "HealthStatus": "Healthy"
+                "HealthStatus": "Healthy",
+                "LifecycleState": "InService"
             }]
         }]
     }
@@ -33,7 +33,8 @@ def test_desired_equals_healthy_false(aws_client):
         "AutoScalingGroups": [{
             "DesiredCapacity": 1,
             "Instances": [{
-                "HealthStatus": "Unhealthy"
+                "HealthStatus": "Unhealthy",
+                "LifecycleState": "InService"
             }]
         }]
     }
@@ -58,89 +59,37 @@ def test_desired_equals_healthy_needs_asg_names():
     assert "Non-empty list of auto scaling groups is required" in str(x)
 
 
-def desired_equals_healthy_tags_true_sideeffect(*args, **kwargs):
-    if 'AutoScalingGroupNames' not in kwargs:
-        return {
-            "AutoScalingGroups": [
-                {
-                    'AutoScalingGroupName': 'AutoScalingGroup1',
-                    "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Healthy"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'Application',
-                        'Value': 'mychaosapp'
-                    }]
-                },
-                {
-                    'AutoScalingGroupName': 'AutoScalingGroup2',
-                    "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Unhealthy"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'Application',
-                        'Value': 'NOTmychaosapp'
-                    }]
-                },
-                {
-                    'AutoScalingGroupName': 'AutoScalingGroup3',
-                    "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Unhealthy"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'NOTApplication',
-                        'Value': 'mychaosapp'
-                    }]
-                }
-            ]
-        }
-    else:
-        return {
-            "AutoScalingGroups": [
-                {
-                    'AutoScalingGroupName': 'AutoScalingGroup1',
-                    "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Healthy"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'Application',
-                        'Value': 'mychaosapp'
-                    }]
-                }
-            ]
-        }
-
-
 @patch('chaosaws.asg.probes.aws_client', autospec=True)
 def test_desired_equals_healthy_tags_true(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
-    client.describe_auto_scaling_groups.side_effect = \
-        desired_equals_healthy_tags_true_sideeffect
-    assert desired_equals_healthy_tags(tags=tags) is True
-
-
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
-def test_desired_equals_healthy_tags_false(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
-    client.describe_auto_scaling_groups.return_value = {
+    client.describe_auto_scaling_groups.return_value = \
+        {
+            "AutoScalingGroups": [
+                {
+                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "DesiredCapacity": 1,
+                    "Instances": [{
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService"
+                    }],
+                    'Tags': [{
+                        'ResourceId': 'AutoScalingGroup1',
+                        'Key': 'Application',
+                        'Value': 'mychaosapp'
+                    }]
+                }
+            ]
+        }
+    client.get_paginator.return_value.paginate.return_value = [{
         "AutoScalingGroups": [
             {
                 'AutoScalingGroupName': 'AutoScalingGroup1',
                 "DesiredCapacity": 1,
                 "Instances": [{
-                    "HealthStatus": "Unhealthy"
+                    "HealthStatus": "Healthy",
+                    "LifecycleState": "InService"
                 }],
                 'Tags': [{
                     'ResourceId': 'AutoScalingGroup1',
@@ -152,26 +101,101 @@ def test_desired_equals_healthy_tags_false(aws_client):
                 'AutoScalingGroupName': 'AutoScalingGroup2',
                 "DesiredCapacity": 1,
                 "Instances": [{
-                    "HealthStatus": "Unhealthy"
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
                 }],
                 'Tags': [{
                     'ResourceId': 'AutoScalingGroup1',
                     'Key': 'Application',
                     'Value': 'NOTmychaosapp'
                 }]
-            },
+            }
+        ]},
+        {
+        "AutoScalingGroups": [
             {
                 'AutoScalingGroupName': 'AutoScalingGroup3',
                 "DesiredCapacity": 1,
                 "Instances": [{
-                    "HealthStatus": "Unhealthy"
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
                 }],
                 'Tags': [{
                     'ResourceId': 'AutoScalingGroup1',
                     'Key': 'NOTApplication',
                     'Value': 'mychaosapp'
                 }]
+            }]
+    }]
+    assert desired_equals_healthy_tags(tags=tags) is True
+
+
+@patch('chaosaws.asg.probes.aws_client', autospec=True)
+def test_desired_equals_healthy_tags_false(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
+    client.describe_auto_scaling_groups.return_value = \
+        {
+            "AutoScalingGroups": [
+                {
+                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "DesiredCapacity": 1,
+                    "Instances": [{
+                        "HealthStatus": "Unhealthy",
+                        "LifecycleState": "InService"
+                    }],
+                    'Tags': [{
+                        'ResourceId': 'AutoScalingGroup1',
+                        'Key': 'Application',
+                        'Value': 'mychaosapp'
+                    }]
+                }
+            ]
+        }
+    client.get_paginator.return_value.paginate.return_value = [{
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup1',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'mychaosapp'
+                }]
+            },
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup2',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'NOTmychaosapp'
+                }]
             }
-        ]
-    }
+        ]},
+        {
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup3',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'NOTApplication',
+                    'Value': 'mychaosapp'
+                }]
+            }]
+    }]
     assert desired_equals_healthy_tags(tags=tags) is False

--- a/tests/ec2/test_ec2_actions.py
+++ b/tests/ec2/test_ec2_actions.py
@@ -32,7 +32,7 @@ def test_stop_spot_instance(aws_client):
     client.cancel_spot_instance_requests.assert_called_with(
         SpotInstanceRequestIds=[spot_request_id])
     client.terminate_instances.assert_called_with(
-        InstanceIds=[inst_id], Force=False)
+        InstanceIds=[inst_id])
 
 
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
@@ -59,7 +59,7 @@ def test_stop_spot_instance_can_be_forced(aws_client):
     client.cancel_spot_instance_requests.assert_called_with(
         SpotInstanceRequestIds=[spot_request_id])
     client.terminate_instances.assert_called_with(
-        InstanceIds=[inst_id], Force=True)
+        InstanceIds=[inst_id])
 
 
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
@@ -77,7 +77,7 @@ def test_stop_instances(aws_client):
     client.cancel_spot_instance_requests.assert_called_with(
         SpotInstanceRequestIds=[spot_request_id])
     client.terminate_instances.assert_called_with(
-        InstanceIds=[inst_ids[1]], Force=False)
+        InstanceIds=[inst_ids[1]])
 
 
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
@@ -118,7 +118,7 @@ def test_stop_all_instances_in_az(aws_client):
     client.cancel_spot_instance_requests.assert_called_with(
         SpotInstanceRequestIds=[spot_request_id])
     client.terminate_instances.assert_called_with(
-        InstanceIds=[inst_2_id], Force=False)
+        InstanceIds=[inst_2_id])
 
 
 def test_stop_all_instances_needs_instance_id_or_az():


### PR DESCRIPTION
Fix the asg probe to use pagination so it works correctly when there is more than 50 ASGs (default page size). Also it should only care about instances with 'inservice' state

Also test fixes and minor formatting fixes

With this I think we are ready for a release

Signed-off-by: Dmitry Batiievskyi <dmitriy@batiyevsky.org>