### PR TITLE
Stop normal instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.7.1...HEAD
 
+### Changed
+
+-   make sure instances with no explicit lifecycle can be stopped. They are
+    assumed to be in the `normal` lifecycle as per the last
+    [line of the AWS documentation][]. [#25][25]
+
+[25]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/issues/25
+[instlifecycledocs]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-purchasing-options.html
+
 ## [0.7.1][]
 
 [0.7.1]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.7.0...0.7.1

--- a/tests/ec2/test_ec2_actions.py
+++ b/tests/ec2/test_ec2_actions.py
@@ -180,3 +180,34 @@ def test_stop_instance_by_specific_filters(aws_client):
     client.describe_instances.assert_called_with(Filters=called_filters)
     client.stop_instances.assert_called_with(
         InstanceIds=[inst_1_id], Force=False)
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+def test_stop_instance_with_no_lifecycle(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    inst_id = "i-1234567890abcdef0"
+    client.describe_instances.return_value = {
+        'Reservations':
+        [{'Instances': [{'InstanceId': inst_id}]}]
+    }
+    stop_instance(inst_id)
+    client.stop_instances.assert_called_with(
+        InstanceIds=[inst_id], Force=False)
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+def test_stop_normal_instance(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    inst_id = "i-1234567890abcdef0"
+    client.describe_instances.return_value = {
+        'Reservations':
+        [{'Instances': [{
+            'InstanceId': inst_id,
+            'InstanceLifecycle': 'normal'
+        }]}]
+    }
+    stop_instance(inst_id)
+    client.stop_instances.assert_called_with(
+        InstanceIds=[inst_id], Force=False)


### PR DESCRIPTION
I think the issue is that for OnDemand and Reserved instance, the API does not specify the lifecycle state (no `InstanceLifecycle` field).

This is expressed on the last line of https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-purchasing-options.html

So, I'm assuming `"normal"` by default when it's missing.

Closes #25

Signed-off-by: Sylvain Hellegouarch <sh@defuze.org>