### PR TITLE
probes to wait for ASG to change state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 [25]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/issues/25
 [instlifecycledocs]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-purchasing-options.html
 
+-   add probes to wait for auto-scaling group to have healthy/unhealthy instance
+    and a probe to check if there is any ongoing scaling activity
+
 ## [0.7.1][]
 
 [0.7.1]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.7.0...0.7.1

--- a/tests/asg/test_asg_probes.py
+++ b/tests/asg/test_asg_probes.py
@@ -1,10 +1,52 @@
 # -*- coding: utf-8 -*-
+from sys import maxsize
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from chaosaws.asg.probes import (desired_equals_healthy,
-                                 desired_equals_healthy_tags)
+                                 desired_equals_healthy_tags,
+                                 is_scaling_in_progress,
+                                 wait_desired_equals_healthy,
+                                 wait_desired_equals_healthy_tags,
+                                 wait_desired_not_equals_healthy_tags)
 from chaoslib.exceptions import FailedActivity
+
+
+def test_desired_equals_healthy_needs_asg_names():
+    with pytest.raises(FailedActivity) as x:
+        desired_equals_healthy([])
+    assert "Non-empty list of auto scaling groups is required" in str(x)
+
+
+def test_wait_desired_equals_healthy_asg_names():
+    with pytest.raises(FailedActivity) as x:
+        wait_desired_equals_healthy([])
+    assert "Non-empty list of auto scaling groups is required" in str(x)
+
+
+def test_desired_equals_healthy_tags_needs_tags():
+    with pytest.raises(FailedActivity) as x:
+        desired_equals_healthy_tags([])
+    assert "Non-empty tags is required" in str(x)
+
+
+def test_wait_desired_equals_healthy_tags_needs_tags():
+    with pytest.raises(FailedActivity) as x:
+        wait_desired_equals_healthy_tags([])
+    assert "Non-empty tags is required" in str(x)
+
+
+def test_wait_desired_not_equals_healthy_tags_needs_tags():
+    with pytest.raises(FailedActivity) as x:
+        wait_desired_not_equals_healthy_tags([])
+    assert "Non-empty tags is required" in str(x)
+
+
+def test_is_scaling_in_progress():
+    with pytest.raises(FailedActivity) as x:
+        is_scaling_in_progress([])
+    assert "Non-empty tags is required" in str(x)
 
 
 @patch('chaosaws.asg.probes.aws_client', autospec=True)
@@ -53,10 +95,42 @@ def test_desired_equals_healthy_empty(aws_client):
     assert desired_equals_healthy(asg_names=asg_names) is False
 
 
-def test_desired_equals_healthy_needs_asg_names():
-    with pytest.raises(FailedActivity) as x:
-        desired_equals_healthy([])
-    assert "Non-empty list of auto scaling groups is required" in str(x)
+@patch('chaosaws.asg.probes.aws_client', autospec=True)
+def test_wait_desired_equals_healthy_true(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    asg_names = ['AutoScalingGroup1']
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [{
+            "DesiredCapacity": 1,
+            "Instances": [{
+                "HealthStatus": "Healthy",
+                "LifecycleState": "InService"
+            }]
+        }]
+    }
+    assert wait_desired_equals_healthy(
+        asg_names=asg_names, timeout=0.1) in [0, 2]
+
+
+@patch('chaosaws.asg.probes.aws_client', autospec=True)
+def test_wait_desired_equals_healthy_timeout(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    asg_names = ['AutoScalingGroup1']
+    client.describe_auto_scaling_groups.response = [
+        {
+            "AutoScalingGroups": [{
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "Initializing"
+                }]
+            }]
+        }
+    ]
+    assert wait_desired_equals_healthy(
+        asg_names=asg_names, timeout=0) is maxsize
 
 
 @patch('chaosaws.asg.probes.aws_client', autospec=True)
@@ -199,3 +273,360 @@ def test_desired_equals_healthy_tags_false(aws_client):
             }]
     }]
     assert desired_equals_healthy_tags(tags=tags) is False
+
+
+@patch('chaosaws.asg.probes.aws_client', autospec=True)
+def test_wait_desired_equals_healthy_tags_true(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
+    client.describe_auto_scaling_groups.return_value = \
+        {
+            "AutoScalingGroups": [
+                {
+                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "DesiredCapacity": 1,
+                    "Instances": [{
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService"
+                    }],
+                    'Tags': [{
+                        'ResourceId': 'AutoScalingGroup1',
+                        'Key': 'Application',
+                        'Value': 'mychaosapp'
+                    }]
+                }
+            ]
+        }
+    client.get_paginator.return_value.paginate.return_value = [{
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup1',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Healthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'mychaosapp'
+                }]
+            },
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup2',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'NOTmychaosapp'
+                }]
+            }
+        ]},
+        {
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup3',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'NOTApplication',
+                    'Value': 'mychaosapp'
+                }]
+            }]
+    }]
+    assert wait_desired_equals_healthy_tags(tags=tags, timeout=0.1) in [0, 2]
+
+
+@patch('chaosaws.asg.probes.aws_client', autospec=True)
+def test_wait_desired_equals_healthy_tags_false(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
+    client.describe_auto_scaling_groups.return_value = \
+        {
+            "AutoScalingGroups": [
+                {
+                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "DesiredCapacity": 1,
+                    "Instances": [{
+                        "HealthStatus": "Unhealthy",
+                        "LifecycleState": "InService"
+                    }],
+                    'Tags': [{
+                        'ResourceId': 'AutoScalingGroup1',
+                        'Key': 'Application',
+                        'Value': 'mychaosapp'
+                    }]
+                }
+            ]
+        }
+    client.get_paginator.return_value.paginate.return_value = [{
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup1',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'mychaosapp'
+                }]
+            },
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup2',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'NOTmychaosapp'
+                }]
+            }
+        ]},
+        {
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup3',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'NOTApplication',
+                    'Value': 'mychaosapp'
+                }]
+            }]
+    }]
+    assert wait_desired_equals_healthy_tags(tags=tags, timeout=0) is maxsize
+
+
+@patch('chaosaws.asg.probes.aws_client', autospec=True)
+def test_wait_desired_not_equals_healthy_tags_true(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
+    client.describe_auto_scaling_groups.return_value = \
+        {
+            "AutoScalingGroups": [
+                {
+                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "DesiredCapacity": 1,
+                    "Instances": [{
+                        "HealthStatus": "Unhealthy",
+                        "LifecycleState": "InService"
+                    }],
+                    'Tags': [{
+                        'ResourceId': 'AutoScalingGroup1',
+                        'Key': 'Application',
+                        'Value': 'mychaosapp'
+                    }]
+                }
+            ]
+        }
+    client.get_paginator.return_value.paginate.return_value = [{
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup1',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'mychaosapp'
+                }]
+            },
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup2',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'NOTmychaosapp'
+                }]
+            }
+        ]},
+        {
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup3',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'mychaosapp'
+                }]
+            }]
+    }]
+    assert wait_desired_not_equals_healthy_tags(
+        tags=tags, timeout=0.2) in [0, 2]
+
+
+@patch('chaosaws.asg.probes.aws_client', autospec=True)
+def test_wait_desired_not_equals_healthy_tags_false(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
+    client.describe_auto_scaling_groups.return_value = \
+        {
+            "AutoScalingGroups": [
+                {
+                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "DesiredCapacity": 1,
+                    "Instances": [{
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService"
+                    }],
+                    'Tags': [{
+                        'ResourceId': 'AutoScalingGroup1',
+                        'Key': 'Application',
+                        'Value': 'mychaosapp'
+                    }]
+                }
+            ]
+        }
+    client.get_paginator.return_value.paginate.return_value = [{
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup1',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'mychaosapp'
+                }]
+            },
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup2',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Unhealthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'NOTmychaosapp'
+                }]
+            }
+        ]
+    }]
+    assert wait_desired_not_equals_healthy_tags(
+        tags=tags, timeout=0) is maxsize
+
+
+@patch('chaosaws.asg.probes.aws_client', autospec=True)
+def test_is_scaling_in_progress_true(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
+    client.describe_auto_scaling_groups.return_value = \
+        {
+            "AutoScalingGroups": [
+                {
+                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "DesiredCapacity": 1,
+                    "Instances": [{
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "OutOfService"
+                    }],
+                    'Tags': [{
+                        'ResourceId': 'AutoScalingGroup1',
+                        'Key': 'Application',
+                        'Value': 'mychaosapp'
+                    }]
+                }
+            ]
+        }
+    client.get_paginator.return_value.paginate.return_value = [{
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup1',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Healthy",
+                    "LifecycleState": "OutOfService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'mychaosapp'
+                }]
+            }
+        ]
+    }]
+    assert is_scaling_in_progress(tags=tags) is True
+
+
+@patch('chaosaws.asg.probes.aws_client', autospec=True)
+def test_is_scaling_in_progress_false(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
+    client.describe_auto_scaling_groups.return_value = \
+        {
+            "AutoScalingGroups": [
+                {
+                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "DesiredCapacity": 1,
+                    "Instances": [{
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService"
+                    }],
+                    'Tags': [{
+                        'ResourceId': 'AutoScalingGroup1',
+                        'Key': 'Application',
+                        'Value': 'mychaosapp'
+                    }]
+                }
+            ]
+        }
+    client.get_paginator.return_value.paginate.return_value = [{
+        "AutoScalingGroups": [
+            {
+                'AutoScalingGroupName': 'AutoScalingGroup1',
+                "DesiredCapacity": 1,
+                "Instances": [{
+                    "HealthStatus": "Healthy",
+                    "LifecycleState": "InService"
+                }],
+                'Tags': [{
+                    'ResourceId': 'AutoScalingGroup1',
+                    'Key': 'Application',
+                    'Value': 'mychaosapp'
+                }]
+            }
+        ]
+    }]
+    assert is_scaling_in_progress(tags=tags) is False


### PR DESCRIPTION
The idea behind new probes is to provide more details on the state of AWS resources and make sure ASG reacts to changed state of the instance before running further actions/probes:
* wait until ASG recovers from instance failure by adding new instance and record how long it took to do that
* wait until ASG marks instance unhealthy and record how long it took to do that
* identify and record if there was any other scaling activity before experiment was started

Signed-off-by: Dmitry Batiievskyi <dmitriy@batiyevsky.org>