### PR TITLE
First set of CloudWatch actions and probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 -   support for Python 3.7
+-   support for cloudwatch probes and actions
 
 ## [0.8.0][]
 

--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -183,5 +183,7 @@ def load_exported_activities() -> List[DiscoveredActivities]:
     activities.extend(discover_probes("chaosaws.asg.probes"))
     activities.extend(discover_actions("chaosaws.awslambda.actions"))
     activities.extend(discover_probes("chaosaws.awslambda.probes"))
+    activities.extend(discover_actions("chaosaws.cloudwatch.actions"))
+    activities.extend(discover_probes("chaosaws.cloudwatch.probes"))
 
     return activities

--- a/chaosaws/cloudwatch/actions.py
+++ b/chaosaws/cloudwatch/actions.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Dict, List
+
+import boto3
+from chaoslib.types import Configuration, Secrets
+
+from chaosaws import aws_client
+from chaosaws.types import AWSResponse
+from logzero import logger
+
+__all__ = ["delete_rule", "disable_rule", "enable_rule",
+           "put_rule", "put_rule_targets", "remove_rule_targets"]
+
+
+def put_rule(rule_name: str, schedule_expression: str = None,
+             event_pattern: str = None, state: str = None,
+             description: str = None, role_arn: str = None,
+             configuration: Configuration = None,
+             secrets: Secrets = None) -> AWSResponse:
+    """
+    Creates or updates a CloudWatch event rule.
+
+    Please refer to https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/events.html#CloudWatchEvents.Client.put_rule
+    for details on input arguments.
+    """  # noqa: E501
+    client = aws_client("events", configuration, secrets)
+    kwargs = {
+        'Name': rule_name,
+    }
+    if schedule_expression is not None:
+        kwargs['ScheduleExpression'] = schedule_expression
+    if event_pattern is not None:
+        kwargs['EventPattern'] = event_pattern
+    if state is not None:
+        kwargs['State'] = state
+    if description is not None:
+        kwargs['Description'] = description
+    if role_arn is not None:
+        kwargs['RoleArn'] = role_arn
+    return client.put_rule(**kwargs)
+
+
+def put_rule_targets(rule_name: str, targets: List[Dict[str, Any]],
+                     configuration: Configuration = None,
+                     secrets: Secrets = None) -> AWSResponse:
+    """
+    Creates or update CloudWatch event rule targets.
+
+    Please refer to https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/events.html#CloudWatchEvents.Client.put_targets
+    for details on input arguments.
+    """  # noqa: E501
+    client = aws_client("events", configuration, secrets)
+    return client.put_targets(Rule=rule_name, Targets=targets)
+
+
+def disable_rule(rule_name: str,
+                 configuration: Configuration = None,
+                 secrets: Secrets = None) -> AWSResponse:
+    """
+    Disables a CloudWatch rule.
+    """
+    client = aws_client("events", configuration, secrets)
+    return client.disable_rule(Name=rule_name)
+
+
+def enable_rule(rule_name: str, configuration: Configuration = None,
+                secrets: Secrets = None) -> AWSResponse:
+    """
+    Enables a CloudWatch rule.
+    """
+    client = aws_client("events", configuration, secrets)
+    return client.enable_rule(Name=rule_name)
+
+
+def delete_rule(rule_name: str, force: bool = False,
+                configuration: Configuration = None,
+                secrets: Secrets = None) -> AWSResponse:
+    """
+    Deletes a CloudWatch rule.
+
+    All rule targets must be removed before deleting the rule.
+    Set input argument force to True to force all rule targets to be deleted.
+    """
+    client = aws_client("events", configuration, secrets)
+    if force:
+        target_ids = _get_rule_target_ids(rule_name, client)
+        _remove_rule_targets(rule_name, target_ids, client)
+    return client.delete_rule(Name=rule_name)
+
+
+def remove_rule_targets(rule_name: str, target_ids: List[str] = None,
+                        configuration: Configuration = None,
+                        secrets: Secrets = None) -> AWSResponse:
+    """
+    Removes CloudWatch rule targets. If no target ids are provided all targets will be removed.
+    """  # noqa: E501
+    client = aws_client("events", configuration, secrets)
+    if target_ids is None:
+        target_ids = _get_rule_target_ids(rule_name, client)
+    return _remove_rule_targets(rule_name, target_ids, client)
+
+
+###############################################################################
+# Private functions
+###############################################################################
+def _remove_rule_targets(rule_name: str, target_ids: str,
+                         client: boto3.client):
+    """
+    Removes provided CloudWatch rule targets.
+    """
+    logger.debug(
+        "Removing {} targets from rule {}: {}".format(
+            len(target_ids), rule_name, target_ids)
+    )
+    return client.remove_targets(Rule=rule_name, Ids=target_ids)
+
+
+def _get_rule_target_ids(rule_name: str, client: boto3.client,
+                         limit: int = None):
+    """
+    Return all targets for a provided CloudWatch rule name.
+    """
+    request_kwargs = {
+        'Rule': rule_name
+    }
+    if limit is not None:
+        request_kwargs['Limit'] = limit
+    targets = []
+    while True:
+        response = client.list_targets_by_rule(**request_kwargs)
+        targets += response['Targets']
+        next_token = response.get('NextToken')
+        if next_token is None:
+            break
+        request_kwargs['NextToken'] = next_token
+    return [t['Id'] for t in targets]

--- a/chaosaws/cloudwatch/probes.py
+++ b/chaosaws/cloudwatch/probes.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from chaoslib.exceptions import FailedActivity
+from chaoslib.types import Configuration, Secrets
+
+from chaosaws import aws_client
+
+__all__ = ["get_alarm_state_value"]
+
+
+def get_alarm_state_value(alarm_name: str,
+                          configuration: Configuration = None,
+                          secrets: Secrets = None) -> str:
+    """
+    Return the state value of an alarm.
+
+    The possbile alarm state values are described in the documentation
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html#CloudWatch.Client.describe_alarms
+    """  # noqa: E501
+    client = aws_client("cloudwatch", configuration, secrets)
+    response = client.describe_alarms(AlarmNames=[alarm_name])
+    if len(response["MetricAlarms"]) == 0:
+        raise FailedActivity(
+            "CloudWatch alarm name {} not found".format(alarm_name)
+        )
+    return response["MetricAlarms"][0]["StateValue"]

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ packages = [
     'chaosaws.iam',
     'chaosaws.elbv2',
     'chaosaws.asg',
-    'chaosaws.awslambda'
+    'chaosaws.awslambda',
+    'chaosaws.cloudwatch'
 ]
 
 needs_pytest = set(['pytest', 'test']).intersection(sys.argv)

--- a/tests/cloudwatch/test_cloudwatch_actions.py
+++ b/tests/cloudwatch/test_cloudwatch_actions.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import MagicMock, patch
+
+from chaosaws.cloudwatch.actions import (put_rule,
+                                         put_rule_targets,
+                                         disable_rule,
+                                         enable_rule,
+                                         delete_rule,
+                                         remove_rule_targets)
+
+
+@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+def test_cloudwatch_put_rule(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    rule_name = 'my-rule'
+    schedule_expression = 'rate(5 minutes)'
+    state = 'ENABLED'
+    description = 'My 5 minute rule'
+    role_arn = 'iam:role:for:my:rule'
+    put_rule(rule_name,
+                        schedule_expression=schedule_expression,
+                        state=state,
+                        description=description,
+                        role_arn=role_arn)
+    client.put_rule.assert_called_with(
+        Name=rule_name,
+        ScheduleExpression=schedule_expression,
+        State=state,
+        Description=description,
+        RoleArn=role_arn)
+
+
+@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+def test_cloudwatch_put_rule_targets(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    rule_name = 'my-rule'
+    targets = [
+        {
+            'Id': '1234',
+            'Arn': 'arn:aws:lambda:eu-central-1:'
+            '101010101010:function:MyFunction'
+        }
+    ]
+    put_rule_targets(rule_name, targets)
+    client.put_targets.assert_called_with(Rule=rule_name, Targets=targets)
+
+
+@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+def test_cloudwatch_disable_rule(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    rule_name = 'my-rule'
+    disable_rule(rule_name)
+    client.disable_rule.assert_called_with(Name=rule_name)
+
+
+@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+def test_cloudwatch_enable_rule(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    rule_name = 'my-rule'
+    enable_rule(rule_name)
+    client.enable_rule.assert_called_with(Name=rule_name)
+
+
+@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+def test_cloudwatch_delete_rule(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    rule_name = 'my-rule'
+    delete_rule(rule_name)
+    client.delete_rule.assert_called_with(Name=rule_name)
+    client.remove_targets.assert_not_called()
+
+
+@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+def test_cloudwatch_delete_rule_force(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    target_ids = ['1', '2', '3']
+    client.list_targets_by_rule.return_value = {
+        'Targets': [{'Id': t} for t in target_ids]
+    }
+    rule_name = 'my-rule'
+    delete_rule(rule_name, force=True)
+    client.delete_rule.assert_called_with(Name=rule_name)
+    client.list_targets_by_rule.assert_called_with(Rule=rule_name)
+    client.remove_targets.assert_called_with(Rule=rule_name, Ids=target_ids)
+
+
+@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+def test_cloudwatch_remove_rule_targets(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    rule_name = 'my-rule'
+    target_ids = ['1', '2', '3']
+    remove_rule_targets(rule_name, target_ids)
+    client.remove_targets.assert_called_with(Rule=rule_name, Ids=target_ids)
+
+
+@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+def test_cloudwatch_remove_rule_targets_all(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    rule_name = 'my-rule'
+    target_ids = ['1', '2', '3']
+    client.list_targets_by_rule.return_value = {
+        'Targets': [{'Id': t} for t in target_ids]
+    }
+    remove_rule_targets(rule_name, target_ids=None)
+    client.remove_targets.assert_called_with(Rule=rule_name, Ids=target_ids)
+    client.list_targets_by_rule.assert_called_with(Rule=rule_name)
+    client.remove_targets.assert_called_with(Rule=rule_name, Ids=target_ids)

--- a/tests/cloudwatch/test_cloudwatch_probes.py
+++ b/tests/cloudwatch/test_cloudwatch_probes.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import MagicMock, patch
+from chaosaws.cloudwatch.probes import get_alarm_state_value
+from chaoslib.exceptions import FailedActivity
+import pytest
+
+
+@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+def test_cloudwatch_get_alarm_state_value_ok(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    alarm_name = 'my-alarm'
+    client.describe_alarms.return_value = {
+        'MetricAlarms': [
+            {
+                'AlarmName': alarm_name,
+                'StateValue': 'OK'
+            }
+        ]
+    }
+    result = get_alarm_state_value(alarm_name)
+    assert result == 'OK'
+    client.describe_alarms.assert_called_with(AlarmNames=[alarm_name])
+
+
+@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+def test_cloudwatch_get_alarm_state_value_not_found(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    alarm_name = 'my-alarm'
+    client.describe_alarms.return_value = {
+        'MetricAlarms': []
+    }
+    with pytest.raises(FailedActivity):
+        get_alarm_state_value(alarm_name)
+    client.describe_alarms.assert_called_with(AlarmNames=[alarm_name])


### PR DESCRIPTION
This pull request adds the following CloudWatch actions and probes:

Probes:
- Get state value of an alarm

Actions:
- Put rule
- Put rule targets
- Disable rule
- Enable rule
- Delete rule
- Remove rule targets