### PR TITLE
Add cloudwatch probe for get_metric_statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   support for cloudwatch probes and actions
 -   support for invoking lambdas
 -   support for getting and updating lambda timeout and memory size limits
+-   probe for cloudwatch metric statistics
 
 ## [0.8.0][]
 

--- a/chaosaws/cloudwatch/probes.py
+++ b/chaosaws/cloudwatch/probes.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime, timedelta
+
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
+from logzero import logger
 
 from chaosaws import aws_client
 
-__all__ = ["get_alarm_state_value"]
+__all__ = ["get_alarm_state_value", "get_metric_statistics"]
 
 
 def get_alarm_state_value(alarm_name: str,
@@ -23,3 +26,75 @@ def get_alarm_state_value(alarm_name: str,
             "CloudWatch alarm name {} not found".format(alarm_name)
         )
     return response["MetricAlarms"][0]["StateValue"]
+
+
+def get_metric_statistics(namespace: str, metric_name: str,
+                          dimension_name: str, dimension_value: str,
+                          duration: int = 60, offset: int = 0,
+                          statistic: str = None,
+                          extended_statistic: str = None,
+                          unit: str = None,
+                          configuration: Configuration = None,
+                          secrets: Secrets = None):
+    """
+    Get the value of a statistical calculation for a given metric.
+
+    The period for which the calculation will be performed is specified by a duration and
+    an offset from the current time. Both are specified in seconds.
+
+    Example: A duration of 60 seconds and an offset of 30 seconds will yield a
+    statistical value based on the time interval between 30 and 90 seconds in the past.
+
+    More information about input parameters are available in the documentation
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html#CloudWatch.Client.get_metric_statistics
+    """  # noqa: E501
+    client = aws_client("cloudwatch", configuration, secrets)
+
+    if statistic is None and extended_statistic is None:
+        raise FailedActivity(
+            'You must supply argument for statistic or extended_statistic'
+        )
+
+    end_time = datetime.utcnow() - timedelta(seconds=offset)
+    start_time = end_time - timedelta(seconds=duration)
+    request_kwargs = {
+        'Namespace': namespace,
+        'MetricName': metric_name,
+        'Dimensions': [{
+            'Name': dimension_name,
+            'Value': dimension_value
+        }],
+        'StartTime': start_time,
+        'EndTime': end_time,
+        'Period': duration
+    }
+
+    if statistic is not None:
+        request_kwargs['Statistics'] = [statistic]
+    if extended_statistic is not None:
+        request_kwargs['ExtendedStatistics'] = [extended_statistic]
+    if unit is not None:
+        request_kwargs['Unit'] = unit
+
+    logger.debug('Request arguments: {}'.format(request_kwargs))
+    response = client.get_metric_statistics(**request_kwargs)
+
+    datapoints = response['Datapoints']
+    if len(datapoints) == 0:
+        raise FailedActivity(
+            "No datapoints found for metric {}.{}.{}.{}".format(
+                namespace, metric_name, dimension_name, dimension_value
+            )
+        )
+
+    datapoint = datapoints[0]
+    logger.debug('Response: {}'.format(response))
+    try:
+        if statistic is not None:
+            return datapoint[statistic]
+        elif extended_statistic is not None:
+            return datapoint['ExtendedStatistics'][extended_statistic]
+    except Exception as x:
+        raise FailedActivity(
+            "Unable to parse response '{}': '{}'".format(response, str(x))
+        )

--- a/tests/cloudwatch/test_cloudwatch_probes.py
+++ b/tests/cloudwatch/test_cloudwatch_probes.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
-from chaosaws.cloudwatch.probes import get_alarm_state_value
-from chaoslib.exceptions import FailedActivity
+
 import pytest
+from chaoslib.exceptions import FailedActivity
+
+from chaosaws.cloudwatch.probes import (get_alarm_state_value,
+                                        get_metric_statistics)
 
 
 @patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
@@ -34,3 +38,176 @@ def test_cloudwatch_get_alarm_state_value_not_found(aws_client):
     with pytest.raises(FailedActivity):
         get_alarm_state_value(alarm_name)
     client.describe_alarms.assert_called_with(AlarmNames=[alarm_name])
+
+
+@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
+@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+def test_cloudwatch_get_metric_statistics_ok(aws_client,
+                                             mock_datetime):
+    client = MagicMock()
+    aws_client.return_value = client
+    mock_datetime.utcnow.return_value = datetime(2015, 1, 1, 15, 15,
+                                                 tzinfo=timezone.utc)
+
+    namespace = 'AWS/Lambda'
+    metric_name = 'Invocations'
+    dimension_name = 'FunctionName'
+    dimension_value = 'MyFunction'
+    duration = 120
+    offset = 60
+    statistic = 'Sum'
+    extended_statistic = None
+    unit = 'Count'
+    client.get_metric_statistics.return_value = {
+        'Datapoints': [{statistic: 4753.0}]
+    }
+
+    result = get_metric_statistics(namespace=namespace,
+                                   metric_name=metric_name,
+                                   dimension_name=dimension_name,
+                                   dimension_value=dimension_value,
+                                   duration=duration,
+                                   offset=offset,
+                                   statistic=statistic,
+                                   extended_statistic=extended_statistic,
+                                   unit=unit)
+
+    assert result == 4753.0
+    client.get_metric_statistics.assert_called_with(
+        Namespace=namespace,
+        MetricName=metric_name,
+        Dimensions=[{'Name': dimension_name, 'Value': dimension_value}],
+        Period=duration,
+        StartTime=datetime(2015, 1, 1, 15, 12, tzinfo=timezone.utc),
+        EndTime=datetime(2015, 1, 1, 15, 14, tzinfo=timezone.utc),
+        Statistics=[statistic],
+        Unit=unit
+    )
+
+
+@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
+@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+def test_cloudwatch_get_metric_statistics_extended_ok(aws_client,
+                                                      mock_datetime):
+    client = MagicMock()
+    aws_client.return_value = client
+    mock_datetime.utcnow.return_value = datetime(2015, 1, 1, 15, 15,
+                                                 tzinfo=timezone.utc)
+
+    namespace = 'AWS/Lambda'
+    metric_name = 'Invocations'
+    dimension_name = 'FunctionName'
+    dimension_value = 'MyFunction'
+    duration = 120
+    offset = 60
+    statistic = None
+    extended_statistic = 'p99'
+    client.get_metric_statistics.return_value = {
+        'Datapoints': [{'ExtendedStatistics': {extended_statistic: 4753.0}}]
+    }
+    unit = None
+
+    result = get_metric_statistics(namespace=namespace,
+                                   metric_name=metric_name,
+                                   dimension_name=dimension_name,
+                                   dimension_value=dimension_value,
+                                   duration=duration,
+                                   offset=offset,
+                                   statistic=statistic,
+                                   extended_statistic=extended_statistic,
+                                   unit=unit)
+
+    assert result == 4753.0
+    client.get_metric_statistics.assert_called_with(
+        Namespace=namespace,
+        MetricName=metric_name,
+        Dimensions=[{'Name': dimension_name, 'Value': dimension_value}],
+        Period=duration,
+        StartTime=datetime(2015, 1, 1, 15, 12, tzinfo=timezone.utc),
+        EndTime=datetime(2015, 1, 1, 15, 14, tzinfo=timezone.utc),
+        ExtendedStatistics=[extended_statistic],
+    )
+
+
+@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
+@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+def test_cloudwatch_get_metric_statistics_no_datapoints(
+        aws_client, mock_datetime):
+    client = MagicMock()
+    aws_client.return_value = client
+    mock_datetime.utcnow.return_value = datetime(2015, 1, 1, 15, 15,
+                                                 tzinfo=timezone.utc)
+
+    namespace = 'AWS/Lambda'
+    metric_name = 'Invocations'
+    dimension_name = 'FunctionName'
+    dimension_value = 'MyFunction'
+    duration = 120
+    offset = 60
+    statistic = 'Sum'
+    extended_statistic = None
+    unit = 'Count'
+    client.get_metric_statistics.return_value = {
+        'Datapoints': []
+    }
+
+    with pytest.raises(FailedActivity):
+        get_metric_statistics(namespace=namespace, metric_name=metric_name,
+                              dimension_name=dimension_name,
+                              dimension_value=dimension_value,
+                              duration=duration, offset=offset,
+                              statistic=statistic,
+                              extended_statistic=extended_statistic, unit=unit)
+
+    client.get_metric_statistics.assert_called_with(
+        Namespace=namespace,
+        MetricName=metric_name,
+        Dimensions=[{'Name': dimension_name, 'Value': dimension_value}],
+        Period=duration,
+        StartTime=datetime(2015, 1, 1, 15, 12, tzinfo=timezone.utc),
+        EndTime=datetime(2015, 1, 1, 15, 14, tzinfo=timezone.utc),
+        Statistics=[statistic],
+        Unit=unit
+    )
+
+
+@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
+@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+def test_cloudwatch_get_metric_statistics_bad_response(
+        aws_client, mock_datetime):
+    client = MagicMock()
+    aws_client.return_value = client
+    mock_datetime.utcnow.return_value = datetime(2015, 1, 1, 15, 15,
+                                                 tzinfo=timezone.utc)
+
+    namespace = 'AWS/Lambda'
+    metric_name = 'Invocations'
+    dimension_name = 'FunctionName'
+    dimension_value = 'MyFunction'
+    duration = 120
+    offset = 60
+    statistic = 'Sum'
+    extended_statistic = None
+    unit = 'Count'
+    client.get_metric_statistics.return_value = {
+        'Datapoints': [{'some': 'value'}]
+    }
+
+    with pytest.raises(FailedActivity):
+        get_metric_statistics(namespace=namespace, metric_name=metric_name,
+                              dimension_name=dimension_name,
+                              dimension_value=dimension_value,
+                              duration=duration, offset=offset,
+                              statistic=statistic,
+                              extended_statistic=extended_statistic, unit=unit)
+
+    client.get_metric_statistics.assert_called_with(
+        Namespace=namespace,
+        MetricName=metric_name,
+        Dimensions=[{'Name': dimension_name, 'Value': dimension_value}],
+        Period=duration,
+        StartTime=datetime(2015, 1, 1, 15, 12, tzinfo=timezone.utc),
+        EndTime=datetime(2015, 1, 1, 15, 14, tzinfo=timezone.utc),
+        Statistics=[statistic],
+        Unit=unit
+    )


### PR DESCRIPTION
This pull requests adds a probe to retrieve CloudWatch metric statistics.

An example probe definition:
```json
{
  "type": "probe",
  "name": "get_metric_statistics",
  "provider": {
    "type": "python",
    "module": "chaosaws.cloudwatch.probes",
    "func": "get_metric_statistics",
    "arguments": {
      "namespace": "AWS/Lambda",
      "metric_name": "Invocations",
      "dimension_name": "FunctionName",
      "dimension_value": "MyFunction",
      "statistic": "Sum",
      "extended_statistic": null,
      "unit": "Count",
      "duration": 60,
      "offset": 0
    }
  },
  "tolerance": [
    24,
    32
  ]
}
```