### PR TITLE
adding ec2 actions for termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.9.0...HEAD
 
+### Added
+
+- adding terminate_instance(s) actions to ec2/actions.py
+
 ## [0.9.0][]
 
 [0.9.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.8.0...0.9.0

--- a/chaosaws/ec2/actions.py
+++ b/chaosaws/ec2/actions.py
@@ -34,12 +34,8 @@ def stop_instance(instance_id: str = None, az: str = None, force: bool = False,
             " an AZ to pick a random instance from, or a set of filters.")
 
     if az and not instance_id and not filters:
-        authorize = get_user_input(
-            'Based on the configuration provided, '
-            'this will stop a random instance in AZ %s. \n'
-            'Do you wish to proceed? [Y/N]:' % az)
-        if authorize.lower() != 'y':
-            raise FailedActivity("Experiment halted by user.")
+        logger.warning('Based on configuration provided I am going to '
+                       'stop a random instance in AZ %s!' % az)
 
     client = aws_client('ec2', configuration, secrets)
 
@@ -81,12 +77,8 @@ def stop_instances(instance_ids: List[str] = None, az: str = None,
             " an AZ to pick random instances from, or a set of filters.")
 
     if az and not instance_ids and not filters:
-        authorize = get_user_input(
-            'Based on the configuration provided, '
-            'this will stop all instance in AZ %s. \n'
-            'Do you wish to proceed? [Y/N]:' % az)
-        if authorize.lower() != 'y':
-            raise FailedActivity("Experiment halted by user.")
+        logger.warning('Based on configuration provided I am going to '
+                       'stop all instances in AZ %s!' % az)
 
     client = aws_client('ec2', configuration, secrets)
 
@@ -131,12 +123,8 @@ def terminate_instance(instance_id: str = None, az: str = None,
                              'set of filters')
 
     if az and not any([instance_id, filters]):
-        authorize = get_user_input(
-            'Based on the configuration provided, '
-            'this will terminate a random instance in AZ %s. \n'
-            'Do you wish to proceed? [Y/N]:' % az)
-        if authorize.lower() != 'y':
-            raise FailedActivity("Experiment halted by user.")
+        logger.warning('Based on configuration provided I am going to '
+                       'terminate a random instance in AZ %s!' % az)
 
     client = aws_client('ec2', configuration, secrets)
     if not instance_id:
@@ -181,12 +169,8 @@ def terminate_instances(instance_ids: List[str] = None, az: str = None,
                              'set of filters')
 
     if az and not any([instance_ids, filters]):
-        authorize = get_user_input(
-            'Based on the configuration provided, '
-            'this will terminate all instance in AZ %s. \n'
-            'Do you wish to proceed? [Y/N]:' % az)
-        if authorize.lower() != 'y':
-            raise FailedActivity("Experiment halted by user.")
+        logger.warning('Based on configuration provided I am going to '
+                       'terminate all instances in AZ %s!' % az)
 
     client = aws_client('ec2', configuration, secrets)
     if not instance_ids:
@@ -214,10 +198,6 @@ def terminate_instances(instance_ids: List[str] = None, az: str = None,
 ###############################################################################
 # Private functions
 ###############################################################################
-def get_user_input(message):
-    return input(message)
-
-
 def list_instances_by_type(filters: List[Dict[str, Any]],
                            client: boto3.client) -> List[str]:
     """

--- a/chaosaws/ec2/probes.py
+++ b/chaosaws/ec2/probes.py
@@ -14,7 +14,7 @@ def describe_instances(filters: List[Dict[str, Any]],
     """
     Describe instances following the specified filters.
 
-    Please refer to http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_instances
+    Please refer to https://bit.ly/2Sv9lmU
 
     for details on said filters.
     """  # noqa: E501
@@ -29,7 +29,7 @@ def count_instances(filters: List[Dict[str, Any]],
     """
     Return count of instances matching the specified filters.
 
-    Please refer to http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_instances
+    Please refer to https://bit.ly/2Sv9lmU
 
     for details on said filters.
     """  # noqa: E501

--- a/tests/ec2/test_ec2_actions.py
+++ b/tests/ec2/test_ec2_actions.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from chaosaws.ec2.actions import stop_instance, stop_instances
+from chaosaws.ec2.actions import (
+    stop_instance, stop_instances, terminate_instance, terminate_instances)
 from chaoslib.exceptions import FailedActivity
 
 
@@ -81,12 +82,18 @@ def test_stop_instances(aws_client):
 
 
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch('builtins.input', lambda *args: 'y')
 def test_stop_random_instance_in_az(aws_client):
     client = MagicMock()
     aws_client.return_value = client
+
     inst_id = "i-987654321fedcba"
-    client.describe_instances.return_value = {'Reservations':
-                                              [{'Instances': [{'InstanceId': inst_id, 'InstanceLifecycle': 'normal'}]}]}
+    client.describe_instances.return_value = {
+        'Reservations': [{
+            'Instances': [{
+                'InstanceId': inst_id,
+                'InstanceLifecycle': 'normal'}]
+        }]}
 
     stop_instance(az="us-west-1")
     client.stop_instances.assert_called_with(
@@ -101,16 +108,41 @@ def test_stop_random_needs_instance_id_or_az():
            str(x)
 
 
+@patch('builtins.input', lambda *args: 'n')
+def test_stop_random_instance_in_az_halt():
+    with pytest.raises(FailedActivity) as x:
+        stop_instance(az="us-west-1")
+    assert "Experiment halted by user." in str(x)
+
+
+@patch('builtins.input', lambda *args: 'n')
+def test_stop_instances_in_az_halt():
+    with pytest.raises(FailedActivity) as x:
+        stop_instances(az="us-west-1")
+    assert "Experiment halted by user." in str(x)
+
+
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch('builtins.input', lambda *args: 'y')
 def test_stop_all_instances_in_az(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_1_id = "i-987654321fedcba"
     inst_2_id = "i-123456789abcdef"
     spot_request_id = 'sir-abcdef01'
-    client.describe_instances.return_value = {'Reservations':
-                                              [{'Instances': [
-                                                  {'InstanceId': inst_1_id, 'InstanceLifecycle': 'normal'}, {'InstanceId': inst_2_id, 'InstanceLifecycle': 'spot', 'SpotInstanceRequestId': spot_request_id}]}]}
+    client.describe_instances.return_value = {
+        'Reservations': [{
+            'Instances': [
+                {
+                    'InstanceId': inst_1_id,
+                    'InstanceLifecycle': 'normal'
+                },
+                {
+                    'InstanceId': inst_2_id,
+                    'InstanceLifecycle': 'spot',
+                    'SpotInstanceRequestId': spot_request_id
+                }
+            ]}]}
 
     stop_instances(az="us-west-1")
     client.stop_instances.assert_called_with(
@@ -130,6 +162,7 @@ def test_stop_all_instances_needs_instance_id_or_az():
 
 
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch('builtins.input', lambda *args: 'y')
 def test_stop_all_instances_may_not_have_any_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -146,8 +179,12 @@ def test_stop_instance_by_specific_filters(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_1_id = "i-987654321fedcba"
-    client.describe_instances.return_value = {'Reservations':
-                                              [{'Instances': [{'InstanceId': inst_1_id, 'InstanceLifecycle': 'normal'}]}]}
+    client.describe_instances.return_value = {
+        'Reservations': [{
+            'Instances': [{
+                'InstanceId': inst_1_id,
+                'InstanceLifecycle': 'normal'}]
+        }]}
 
     filters = [
         {
@@ -211,3 +248,212 @@ def test_stop_normal_instance(aws_client):
     stop_instance(inst_id)
     client.stop_instances.assert_called_with(
         InstanceIds=[inst_id], Force=False)
+
+
+###
+# Terminate Instance
+###
+def test_terminate_instance_no_values():
+    with pytest.raises(FailedActivity) as x:
+        terminate_instance()
+    assert 'To terminate an EC2, you must specify the instance-id, ' \
+           'an Availability Zone, or provide a set of filters' in str(x)
+
+
+@patch('builtins.input', lambda *args: 'n')
+def test_terminate_random_instance_in_az_halt():
+    with pytest.raises(FailedActivity) as x:
+        terminate_instance(az="us-west-1")
+    assert "Experiment halted by user." in str(x)
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch('builtins.input', lambda *args: 'y')
+def test_terminate_instance_az_no_instances(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    az = 'us-west-2'
+    client.describe_instances.return_value = {
+        'Reservations': [{'Instances': []}]}
+
+    with pytest.raises(FailedActivity) as x:
+        terminate_instance(az=az)
+    assert 'No instances found matching filters: %s' % az
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+def test_terminate_normal_instance(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    inst_id = "i-1234567890abcdef0"
+    client.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{
+            'InstanceId': inst_id, 'InstanceLifecycle': 'normal'}]}]}
+    terminate_instance(inst_id)
+    client.terminate_instances.assert_called_with(InstanceIds=[inst_id])
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+def test_terminate_spot_instance(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    inst_id = "i-1234567890abcdef0"
+    spot_request_id = 'sir-abcdef01'
+    client.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{
+            'InstanceId': inst_id, 'InstanceLifecycle': 'spot',
+            'SpotInstanceRequestId': spot_request_id}]}]}
+    terminate_instance(inst_id)
+    client.cancel_spot_instance_requests.assert_called_with(
+        SpotInstanceRequestIds=[spot_request_id])
+    client.terminate_instances.assert_called_with(InstanceIds=[inst_id])
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch('builtins.input', lambda *args: 'y')
+def test_terminate_random_az_instance(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    inst_id = "i-987654321fedcba"
+    client.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{
+            'InstanceId': inst_id, 'InstanceLifecycle': 'normal'}]}]}
+
+    terminate_instance(az="us-west-1")
+    client.terminate_instances.assert_called_with(InstanceIds=[inst_id])
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+def test_terminate_instance_by_filters(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    inst_1_id = "i-987654321fedcba"
+    client.describe_instances.return_value = {
+        'Reservations': [{'Instances': [{
+            'InstanceId': inst_1_id, 'InstanceLifecycle': 'normal'}]}]}
+
+    filters = [
+        {'Name': 'instance-state-name', 'Values': ['running']},
+        {'Name': 'tag-value', 'Values': ['chaos-cluster']},
+        {'Name': 'tag-key', 'Values': ['kubernetes.io/cluster/chaos-cluster']},
+        {'Name': 'tag-value', 'Values': ['owned']},
+        {'Name': 'tag-key',
+         'Values': ['eksctl.cluster.k8s.io/v1alpha1/cluster-name']},
+    ]
+    terminate_instance(filters=filters, az='us-west-2')
+
+    called_filters = deepcopy(filters)
+    called_filters.append(
+        {'Name': 'availability-zone', 'Values': ['us-west-2']})
+    client.describe_instances.assert_called_with(Filters=called_filters)
+    client.terminate_instances.assert_called_with(InstanceIds=[inst_1_id])
+
+
+###
+# Terminate Instances
+###
+def test_terminate_instances_no_values():
+    with pytest.raises(FailedActivity) as x:
+        terminate_instances()
+    assert 'To terminate instances, you must specify the instance-id, an ' \
+           'Availability Zone, or provide a set of filters' in str(x)
+
+
+@patch('builtins.input', lambda *args: 'n')
+def test_terminate_instances_in_az_halt():
+    with pytest.raises(FailedActivity) as x:
+        terminate_instances(az="us-west-1")
+    assert "Experiment halted by user." in str(x)
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch('builtins.input', lambda *args: 'y')
+def test_terminate_instances_az_no_instances(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    az = 'us-west-2'
+    client.describe_instances.return_value = {
+        'Reservations': [{'Instances': []}]}
+
+    with pytest.raises(FailedActivity) as x:
+        terminate_instances(az=az)
+    assert 'No instances found matching filters: %s' % az
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+def test_terminate_normal_instances(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    client.describe_instances.return_value = {
+        'Reservations': [{'Instances': [
+            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
+            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
+        ]}]}
+    terminate_instances(instance_ids)
+    client.terminate_instances.assert_called_with(InstanceIds=instance_ids)
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+def test_terminate_spot_instances(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    spot_ids = ['sir-abcdef01', 'sir-fedcba10']
+    client.describe_instances.return_value = {
+        'Reservations': [{'Instances': [
+            {'InstanceId': instance_ids[0],
+             'InstanceLifecycle': 'spot',
+             'SpotInstanceRequestId': spot_ids[0]},
+            {'InstanceId': instance_ids[1],
+             'InstanceLifecycle': 'spot',
+             'SpotInstanceRequestId': spot_ids[1]},
+        ]}]}
+    terminate_instances(instance_ids)
+    client.cancel_spot_instance_requests.assert_called_with(
+        SpotInstanceRequestIds=spot_ids)
+    client.terminate_instances.assert_called_with(InstanceIds=instance_ids)
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch('builtins.input', lambda *args: 'y')
+def test_terminate_random_az_instances(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    client.describe_instances.return_value = {
+        'Reservations': [{'Instances': [
+            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
+            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
+        ]}]}
+
+    terminate_instances(az="us-west-1")
+    client.terminate_instances.assert_called_with(InstanceIds=instance_ids)
+
+
+@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+def test_terminate_instances_by_filters(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    client.describe_instances.return_value = {
+        'Reservations': [{'Instances': [
+            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
+            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
+        ]}]}
+
+    filters = [
+        {'Name': 'instance-state-name', 'Values': ['running']},
+        {'Name': 'tag-value', 'Values': ['chaos-cluster']},
+        {'Name': 'tag-key', 'Values': ['kubernetes.io/cluster/chaos-cluster']},
+        {'Name': 'tag-value', 'Values': ['owned']},
+        {'Name': 'tag-key',
+         'Values': ['eksctl.cluster.k8s.io/v1alpha1/cluster-name']},
+    ]
+    terminate_instances(filters=filters, az='us-west-2')
+
+    called_filters = deepcopy(filters)
+    called_filters.append(
+        {'Name': 'availability-zone', 'Values': ['us-west-2']})
+    client.describe_instances.assert_called_with(Filters=called_filters)
+    client.terminate_instances.assert_called_with(InstanceIds=instance_ids)

--- a/tests/ec2/test_ec2_actions.py
+++ b/tests/ec2/test_ec2_actions.py
@@ -82,7 +82,6 @@ def test_stop_instances(aws_client):
 
 
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
-@patch('builtins.input', lambda *args: 'y')
 def test_stop_random_instance_in_az(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -108,22 +107,7 @@ def test_stop_random_needs_instance_id_or_az():
            str(x)
 
 
-@patch('builtins.input', lambda *args: 'n')
-def test_stop_random_instance_in_az_halt():
-    with pytest.raises(FailedActivity) as x:
-        stop_instance(az="us-west-1")
-    assert "Experiment halted by user." in str(x)
-
-
-@patch('builtins.input', lambda *args: 'n')
-def test_stop_instances_in_az_halt():
-    with pytest.raises(FailedActivity) as x:
-        stop_instances(az="us-west-1")
-    assert "Experiment halted by user." in str(x)
-
-
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
-@patch('builtins.input', lambda *args: 'y')
 def test_stop_all_instances_in_az(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -162,7 +146,6 @@ def test_stop_all_instances_needs_instance_id_or_az():
 
 
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
-@patch('builtins.input', lambda *args: 'y')
 def test_stop_all_instances_may_not_have_any_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -260,15 +243,7 @@ def test_terminate_instance_no_values():
            'an Availability Zone, or provide a set of filters' in str(x)
 
 
-@patch('builtins.input', lambda *args: 'n')
-def test_terminate_random_instance_in_az_halt():
-    with pytest.raises(FailedActivity) as x:
-        terminate_instance(az="us-west-1")
-    assert "Experiment halted by user." in str(x)
-
-
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
-@patch('builtins.input', lambda *args: 'y')
 def test_terminate_instance_az_no_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -310,7 +285,6 @@ def test_terminate_spot_instance(aws_client):
 
 
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
-@patch('builtins.input', lambda *args: 'y')
 def test_terminate_random_az_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -359,15 +333,7 @@ def test_terminate_instances_no_values():
            'Availability Zone, or provide a set of filters' in str(x)
 
 
-@patch('builtins.input', lambda *args: 'n')
-def test_terminate_instances_in_az_halt():
-    with pytest.raises(FailedActivity) as x:
-        terminate_instances(az="us-west-1")
-    assert "Experiment halted by user." in str(x)
-
-
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
-@patch('builtins.input', lambda *args: 'y')
 def test_terminate_instances_az_no_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -416,7 +382,6 @@ def test_terminate_spot_instances(aws_client):
 
 
 @patch('chaosaws.ec2.actions.aws_client', autospec=True)
-@patch('builtins.input', lambda *args: 'y')
 def test_terminate_random_az_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client


### PR DESCRIPTION
- adding terminate_instance
- adding terminate_instances
- adding `Union` in annotation for `pick_random_instance` return type where no instances are discovered
- updating `log.warn` to `log.warning` to remove deprecated errors
- adding unittests

Signed-off-by: Joshua Root <joshua.root@capitalone.com>