### PR TITLE
adding disruptions for elbv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - adding terminate_instance(s) actions to ec2/actions.py
 - asg actions to suspend/resume services
 - asg probe to detect if process is suspended
+- adding set_security_groups actions to elbv2
+- adding set_subnets action to elbv2
 
 ## [0.9.0][]
 

--- a/chaosaws/elbv2/actions.py
+++ b/chaosaws/elbv2/actions.py
@@ -33,8 +33,8 @@ def deregister_target(tg_name: str,
                                      Targets=[{'Id': random_target}])
 
 
-def set_security_groups(load_balancer_names: List[str] = None,
-                        security_group_ids: List[str] = None,
+def set_security_groups(load_balancer_names: List[str],
+                        security_group_ids: List[str],
                         configuration: Configuration = None,
                         secrets: Secrets = None) -> List[AWSResponse]:
     """
@@ -55,12 +55,6 @@ def set_security_groups(load_balancer_names: List[str] = None,
             ...
         ]
     """
-    if not load_balancer_names:
-        raise FailedActivity('You must specify at least 1 load balancer.')
-
-    if not security_group_ids:
-        raise FailedActivity('You must specify at least 1 security group id')
-
     security_group_ids = get_security_groups(
         security_group_ids, aws_client('ec2', configuration, secrets))
 
@@ -82,8 +76,8 @@ def set_security_groups(load_balancer_names: List[str] = None,
     return results
 
 
-def set_subnets(load_balancer_names: List[str] = None,
-                subnet_ids: List[str] = None,
+def set_subnets(load_balancer_names: List[str],
+                subnet_ids: List[str],
                 configuration: Configuration = None,
                 secrets: Secrets = None) -> List[AWSResponse]:
     """
@@ -113,12 +107,6 @@ def set_subnets(load_balancer_names: List[str] = None,
             ...
         ]
     """
-    if not load_balancer_names:
-        raise FailedActivity('You must specify at least 1 load balancer.')
-
-    if not subnet_ids:
-        raise FailedActivity('You must specify at least 1 subnet id')
-
     subnet_ids = get_subnets(
         subnet_ids, aws_client('ec2', configuration, secrets))
 

--- a/tests/elbv2/test_elbv2_actions.py
+++ b/tests/elbv2/test_elbv2_actions.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
-from unittest.mock import MagicMock, patch
+import pytest
 
-from chaosaws.elbv2.actions import deregister_target
+from unittest.mock import MagicMock, patch, call
+
+from chaoslib.exceptions import FailedActivity
+from chaosaws.elbv2.actions import (deregister_target,
+                                    set_subnets,
+                                    set_security_groups)
 
 
 @patch('chaosaws.elbv2.actions.aws_client', autospec=True)
@@ -24,6 +29,311 @@ def test_deregister_target(aws_client):
             'Target': {'Id': target_id}
         }]
     }
-    response = deregister_target(tg_name=tg_name)
+    deregister_target(tg_name=tg_name)
     client.deregister_targets.assert_called_with(
         TargetGroupArn=tg_arn, Targets=[{'Id': target_id}])
+
+
+@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+def test_set_security_groups(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    security_group_ids = ['sg-0123456789abcdef0', 'sg-0fedcba9876543210']
+
+    client.describe_security_groups.return_value = {
+        'SecurityGroups': [
+            {'GroupId': 'sg-0123456789abcdef0'},
+            {'GroupId': 'sg-0fedcba9876543210'}
+        ]
+    }
+    client.describe_load_balancers.return_value = {
+        'LoadBalancers': [
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
+                                   '000000000000:loadbalancer/app/'
+                                   'test-loadbalancer-01/0f158eab895ab000',
+                'State': {'Code': 'active'},
+                'Type': 'application',
+                'LoadBalancerName': alb_names[0]
+            },
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
+                                   '000000000000:loadbalancer/app/'
+                                   'test-loadbalancer-02/010aec0000fae123',
+                'State': {'Code': 'active'},
+                'Type': 'application',
+                'LoadBalancerName': alb_names[1]
+            }
+        ]
+
+    }
+    set_security_groups(alb_names, security_group_ids)
+
+    calls = [
+        call(
+            LoadBalancerArn='arn:aws:elasticloadbalancing:us-east-1:'
+                            '000000000000:loadbalancer/app/'
+                            'test-loadbalancer-01/0f158eab895ab000',
+            SecurityGroups=security_group_ids),
+        call(
+            LoadBalancerArn='arn:aws:elasticloadbalancing:us-east-1:'
+                            '000000000000:loadbalancer/app/'
+                            'test-loadbalancer-02/010aec0000fae123',
+            SecurityGroups=security_group_ids)]
+    client.set_security_groups.assert_has_calls(calls, any_order=True)
+
+
+@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+def test_set_security_groups_invalid_alb_type(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    security_group_ids = ['sg-0123456789abcdef0', 'sg-0fedcba9876543210']
+
+    client.describe_security_groups.return_value = {
+        'SecurityGroups': [
+            {'GroupId': 'sg-0123456789abcdef0'},
+            {'GroupId': 'sg-0fedcba9876543210'}
+        ]
+    }
+    client.describe_load_balancers.return_value = {
+        'LoadBalancers': [
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
+                                   '000000000000:loadbalancer/app/'
+                                   'test-loadbalancer-01/0f158eab895ab000',
+                'State': {'Code': 'active'},
+                'Type': 'application',
+                'LoadBalancerName': alb_names[0]
+            },
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
+                                   '000000000000:loadbalancer/app/'
+                                   'test-loadbalancer-02/010aec0000fae123',
+                'State': {'Code': 'active'},
+                'Type': 'network',
+                'LoadBalancerName': alb_names[1]
+            }
+        ]
+
+    }
+    with pytest.raises(FailedActivity) as x:
+        set_security_groups(alb_names, security_group_ids)
+    assert 'Cannot change security groups of network load balancers.' in str(x)
+
+
+@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+def test_set_security_group_invalid_alb_name(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    security_group_ids = ['sg-0123456789abcdef0', 'sg-0fedcba9876543210']
+
+    client.describe_security_groups.return_value = {
+        'SecurityGroups': [
+            {'GroupId': 'sg-0123456789abcdef0'},
+            {'GroupId': 'sg-0fedcba9876543210'}
+        ]
+    }
+    client.describe_load_balancers.return_value = {
+        'LoadBalancers': [
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
+                                   '000000000000:loadbalancer/app/'
+                                   'test-loadbalancer-01/0f158eab895ab000',
+                'State': {'Code': 'active'},
+                'Type': 'application',
+                'LoadBalancerName': alb_names[0]
+            }
+        ]
+
+    }
+    with pytest.raises(FailedActivity) as x:
+        set_security_groups(alb_names, security_group_ids)
+    assert 'Unable to locate load balancer(s): {}'.format(
+        [alb_names[1]]) in str(x)
+
+
+@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+def test_set_security_groups_invalid_group(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    security_group_ids = ['sg-0123456789abcdef0', 'sg-0fedcba9876543210']
+
+    client.describe_security_groups.return_value = {
+        'SecurityGroups': [
+            {'GroupId': 'sg-0123456789abcdef0'}
+        ]
+    }
+
+    with pytest.raises(FailedActivity) as x:
+        set_security_groups(alb_names, security_group_ids)
+    assert 'Invalid security group id(s): {}'.format(
+        [security_group_ids[1]]) in str(x)
+
+
+def test_set_security_group_no_subnets():
+    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    with pytest.raises(FailedActivity) as x:
+        set_security_groups(alb_names)
+    assert 'You must specify at least 1 security group id' in str(x)
+
+
+def test_set_security_group_no_args():
+    with pytest.raises(FailedActivity) as x:
+        set_security_groups()
+    assert 'You must specify at least 1 load balancer.' in str(x)
+
+
+@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+def test_set_subnets(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    subnet_ids = ['subnet-012345678', 'subnet-abcdefg0']
+
+    client.describe_subnets.return_value = {
+        'Subnets': [
+            {'SubnetId': 'subnet-012345678'},
+            {'SubnetId': 'subnet-abcdefg0'}
+        ]
+    }
+    client.describe_load_balancers.return_value = {
+        'LoadBalancers': [
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
+                                   '000000000000:loadbalancer/app/'
+                                   'test-loadbalancer-01/0f158eab895ab000',
+                'State': {'Code': 'active'},
+                'Type': 'application',
+                'LoadBalancerName': alb_names[0]
+            },
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
+                                   '000000000000:loadbalancer/app/'
+                                   'test-loadbalancer-02/010aec0000fae123',
+                'State': {'Code': 'active'},
+                'Type': 'application',
+                'LoadBalancerName': alb_names[1]
+            }
+        ]
+
+    }
+    set_subnets(alb_names, subnet_ids)
+
+    calls = [
+        call(
+            LoadBalancerArn='arn:aws:elasticloadbalancing:us-east-1:'
+                            '000000000000:loadbalancer/app/'
+                            'test-loadbalancer-01/0f158eab895ab000',
+            Subnets=subnet_ids),
+        call(
+            LoadBalancerArn='arn:aws:elasticloadbalancing:us-east-1:'
+                            '000000000000:loadbalancer/app/'
+                            'test-loadbalancer-02/010aec0000fae123',
+            Subnets=subnet_ids)]
+    client.set_subnets.assert_has_calls(calls, any_order=True)
+
+
+@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+def test_set_subnets_invalid_alb_type(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    subnet_ids = ['subnet-012345678', 'subnet-abcdefg0']
+
+    client.describe_subnets.return_value = {
+        'Subnets': [
+            {'SubnetId': 'subnet-012345678'},
+            {'SubnetId': 'subnet-abcdefg0'}
+        ]
+    }
+    client.describe_load_balancers.return_value = {
+        'LoadBalancers': [
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
+                                   '000000000000:loadbalancer/app/'
+                                   'test-loadbalancer-01/0f158eab895ab000',
+                'State': {'Code': 'active'},
+                'Type': 'application',
+                'LoadBalancerName': alb_names[0]
+            },
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
+                                   '000000000000:loadbalancer/app/'
+                                   'test-loadbalancer-02/010aec0000fae123',
+                'State': {'Code': 'active'},
+                'Type': 'network',
+                'LoadBalancerName': alb_names[1]
+            }
+        ]
+
+    }
+    with pytest.raises(FailedActivity) as x:
+        set_subnets(alb_names, subnet_ids)
+    assert 'Cannot change subnets of network load balancers.' in str(x)
+
+
+@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+def test_set_subnets_invalid_alb_name(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    subnet_ids = ['subnet-012345678', 'subnet-abcdefg0']
+
+    client.describe_subnets.return_value = {
+        'Subnets': [
+            {'SubnetId': 'subnet-012345678'},
+            {'SubnetId': 'subnet-abcdefg0'}
+        ]
+    }
+    client.describe_load_balancers.return_value = {
+        'LoadBalancers': [
+            {
+                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
+                                   '000000000000:loadbalancer/app/'
+                                   'test-loadbalancer-01/0f158eab895ab000',
+                'State': {'Code': 'active'},
+                'Type': 'application',
+                'LoadBalancerName': alb_names[0]
+            }
+        ]
+
+    }
+    with pytest.raises(FailedActivity) as x:
+        set_subnets(alb_names, subnet_ids)
+    assert 'Unable to locate load balancer(s): {}'.format(
+        [alb_names[1]]) in str(x)
+
+
+@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+def test_set_subnets_invalid_subnet(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    subnet_ids = ['subnet-012345678', 'subnet-abcdefg0']
+
+    client.describe_subnets.return_value = {
+        'Subnets': [
+            {'SubnetId': 'subnet-012345678'}
+        ]
+    }
+
+    with pytest.raises(FailedActivity) as x:
+        set_subnets(alb_names, subnet_ids)
+    assert 'Invalid subnet id(s): {}'.format([subnet_ids[1]]) in str(x)
+
+
+def test_set_subnet_no_subnets():
+    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    with pytest.raises(FailedActivity) as x:
+        set_subnets(alb_names)
+    assert 'You must specify at least 1 subnet id' in str(x)
+
+
+def test_set_subnet_no_args():
+    with pytest.raises(FailedActivity) as x:
+        set_subnets()
+    assert 'You must specify at least 1 load balancer.' in str(x)

--- a/tests/elbv2/test_elbv2_actions.py
+++ b/tests/elbv2/test_elbv2_actions.py
@@ -176,15 +176,17 @@ def test_set_security_groups_invalid_group(aws_client):
 
 def test_set_security_group_no_subnets():
     alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
-    with pytest.raises(FailedActivity) as x:
+    with pytest.raises(TypeError) as x:
         set_security_groups(alb_names)
-    assert 'You must specify at least 1 security group id' in str(x)
+    assert "set_security_groups() missing 1 required positional " \
+           "argument: 'security_group_ids'" in str(x)
 
 
 def test_set_security_group_no_args():
-    with pytest.raises(FailedActivity) as x:
+    with pytest.raises(TypeError) as x:
         set_security_groups()
-    assert 'You must specify at least 1 load balancer.' in str(x)
+    assert "set_security_groups() missing 2 required positional arguments: " \
+           "'load_balancer_names' and 'security_group_ids" in str(x)
 
 
 @patch('chaosaws.elbv2.actions.aws_client', autospec=True)
@@ -328,12 +330,15 @@ def test_set_subnets_invalid_subnet(aws_client):
 
 def test_set_subnet_no_subnets():
     alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
-    with pytest.raises(FailedActivity) as x:
+    with pytest.raises(TypeError) as x:
         set_subnets(alb_names)
-    assert 'You must specify at least 1 subnet id' in str(x)
+
+    assert "set_subnets() missing 1 required " \
+           "positional argument: 'subnet_ids'" in str(x)
 
 
 def test_set_subnet_no_args():
-    with pytest.raises(FailedActivity) as x:
+    with pytest.raises(TypeError) as x:
         set_subnets()
-    assert 'You must specify at least 1 load balancer.' in str(x)
+    assert "set_subnets() missing 2 required positional " \
+           "arguments: 'load_balancer_names' and 'subnet_ids'" in str(x)


### PR DESCRIPTION
- adding disruption `set_subnets` to elbv2.actions
  - allows for changing subnets on an ALB
- adding disruption `set_security_groups` to elbv2.actions
  - allows for changing security groups on an ALB
- adding unittests
- updating changelog

Signed-off-by: Joshua Root <joshua.root@capitalone.com>