### PR TITLE
Feature/ecs stop tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - correcting annotation for ec2 probe count_instances
 - correcting annotation for timeout parameter in asg actions
 - fix tests to match new pytest's API for accessing exceptions' values [#52][52]
+- adding action stop_random_tasks to ecs actions
 
 [52]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/issues/52
 
@@ -67,14 +68,6 @@
   experiment, after assuming the initial aws profile
 - adding action to terminate random asg instance(s)
 - adding action to detach random instances from autoscaling groups
-
-### Added
-
-- adding terminate_instance(s) actions to ec2/actions.py
-- asg actions to suspend/resume services
-- asg probe to detect if process is suspended
-- adding set_security_groups actions to elbv2
-- adding set_subnets action to elbv2
 
 ## [0.9.0][]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,14 @@
 - adding action to terminate random asg instance(s)
 - adding action to detach random instances from autoscaling groups
 
+### Added
+
+- adding terminate_instance(s) actions to ec2/actions.py
+- asg actions to suspend/resume services
+- asg probe to detect if process is suspended
+- adding set_security_groups actions to elbv2
+- adding set_subnets action to elbv2
+
 ## [0.9.0][]
 
 [0.9.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.8.0...0.9.0

--- a/chaosaws/ecs/actions.py
+++ b/chaosaws/ecs/actions.py
@@ -11,8 +11,69 @@ from logzero import logger
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ["stop_task", "delete_service", "delete_cluster",
-           "deregister_container_instance"]
+__all__ = ["stop_random_tasks", "stop_task", "delete_service",
+           "delete_cluster", "deregister_container_instance"]
+
+
+def stop_random_tasks(cluster: str = None,
+                      task_count: int = None,
+                      task_percent: int = None,
+                      service: str = None,
+                      reason: str = 'Chaos Testing',
+                      configuration: Configuration = None,
+                      secrets: Secrets = None) -> AWSResponse:
+    """
+    Stop a random number of tasks based on given task_count or task_percent
+
+    You can specify a cluster by its ARN identifier or, if not provided, the
+    default cluster will be picked up.
+
+    Parameters:
+                Required:
+                    - cluster: name of the cluster to stop tasks in
+
+                Optional:
+                    - service: name of the service to stop tasks in
+
+                One Of:
+                    - task_count: the number of tasks to stop
+                    - task_percent: the percentage of tasks to stop
+    """
+    client = aws_client("ecs", configuration, secrets)
+
+    if not cluster:
+        raise FailedActivity(
+            "A cluster name is required")
+
+    if not any([task_count, task_percent]) or all([task_count, task_percent]):
+        raise FailedActivity(
+            'Must specify one of "task_count", "task_percent"')
+
+    tasks = list_running_tasks_in_cluster(cluster=cluster, client=client,
+                                          service=service)
+
+    if task_percent:
+        task_count = int(float(
+            len(tasks) * float(task_percent)) / 100)
+
+    if len(tasks) < task_count:
+        raise FailedActivity(
+            'Not enough running tasks in {} to satisfy '
+            'stop count {} ({})'.format(
+                cluster, task_count,
+                len(tasks)))
+
+    tasks = random.sample(tasks, task_count)
+
+    results = []
+    for task in tasks:
+        logger.debug("Stopping ECS task: {}".format(task))
+        response = client.stop_task(cluster=cluster, task=task, reason=reason)
+        results.append({
+            'Task_Id': response['task']['taskArn'],
+            'Desired_Status': response['task']['desiredStatus']
+        })
+    return results
 
 
 def stop_task(cluster: str = None, task_id: str = None, service: str = None,
@@ -153,5 +214,35 @@ def list_tasks(cluster: str, service: str, client: boto3.client) -> List[str]:
 
         res = client.list_tasks(cluster=cluster, serviceName=service,
                                 nextToken=next_token, maxResults=100)
+        tasks.extend(res["taskArns"])
+    return tasks
+
+
+def list_running_tasks_in_cluster(cluster: str, client: boto3.client,
+                                  service: str = None):
+    if service:
+        res = client.list_tasks(cluster=cluster, serviceName=service,
+                                maxResults=100,
+                                desiredStatus='RUNNING')
+    else:
+        res = client.list_tasks(cluster=cluster,
+                                maxResults=100,
+                                desiredStatus='RUNNING')
+    tasks = res['taskArns'][:]
+    while True:
+        next_token = res.get("nextToken")
+        if not next_token:
+            break
+
+        if service:
+            res = client.list_tasks(cluster=cluster, serviceName=service,
+                                    nextToken=next_token,
+                                    maxResults=100,
+                                    desiredStatus='RUNNING')
+        else:
+            res = client.list_tasks(cluster=cluster,
+                                    nextToken=next_token,
+                                    maxResults=100,
+                                    desiredStatus='RUNNING')
         tasks.extend(res["taskArns"])
     return tasks

--- a/tests/ecs/test_ecs_actions.py
+++ b/tests/ecs/test_ecs_actions.py
@@ -1,8 +1,196 @@
 # -*- coding: utf-8 -*-
 from unittest.mock import ANY, MagicMock, patch
-
+from chaoslib.exceptions import FailedActivity
+import pytest
 from chaosaws.ecs.actions import (delete_cluster, delete_service,
-                                  deregister_container_instance, stop_task)
+                                  deregister_container_instance, stop_task,
+                                  stop_random_tasks)
+
+
+def test_stop_random_tasks_no_cluster():
+    with pytest.raises(FailedActivity) as x:
+        stop_random_tasks(service='ecs-service')
+    assert 'A cluster name is required' in str(x.value)
+
+
+def test_stop_random_tasks_no_count_or_percent():
+    with pytest.raises(FailedActivity) as x:
+        stop_random_tasks(cluster='ecs-cluster')
+    assert 'Must specify one of "task_count", "task_percent"' in str(x.value)
+
+
+def test_stop_random_tasks_both_count_and_percent():
+    with pytest.raises(FailedActivity) as x:
+        stop_random_tasks(cluster='ecs-cluster', task_count=1, task_percent=1)
+    assert 'Must specify one of "task_count", "task_percent"' in str(x.value)
+
+
+@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+def test_stop_random_tasks_count_too_high(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    cluster = "ecs-cluster"
+    task_count = 3
+    reason = "unit-test"
+    client.list_tasks.side_effect = [
+        {'taskArns': [
+            ("arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb"
+             "-8c7fada847da")],
+            'nextToken': 'token0'},
+        {'taskArns': [
+            ("arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki"
+             "-4o9amby245lk")],
+            'nextToken': None}
+    ]
+
+    with pytest.raises(FailedActivity) as x:
+        stop_random_tasks(cluster=cluster, task_count=task_count,
+                          reason=reason)
+
+    assert ('Not enough running tasks in ecs-cluster to satisfy stop count '
+            '3 (2)') in str(x.value)
+
+
+@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+def test_stop_random_tasks_count_no_service(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    cluster = "ecs-cluster"
+    task_count = 2
+    reason = "unit-test"
+    client.list_tasks.side_effect = [
+        {'taskArns': [
+            ("arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb"
+             "-8c7fada847da")],
+            'nextToken': 'token0'},
+        {'taskArns': [
+            ("arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki"
+             "-4o9amby245lk")],
+            'nextToken': None}
+    ]
+    stop_random_tasks(cluster=cluster, task_count=task_count, reason=reason)
+
+    assert client.stop_task.call_count == 2
+    client.stop_task.assert_any_call(cluster=cluster,
+                                     task=("arn:aws:ecs:us-east-1:012345678910"
+                                           ":task/16fd2706-8baf-433b-82eb"
+                                           "-8c7fada847da"),
+                                     reason=reason)
+    client.stop_task.assert_any_call(cluster=cluster,
+                                     task=("arn:aws:ecs:us-east-1:012345678910"
+                                           ":task/84th9568-3tth-55g1-35ki"
+                                           "-4o9amby245lk"),
+                                     reason=reason)
+
+
+@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+def test_stop_random_tasks_percent_no_service(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    cluster = "ecs-cluster"
+    task_percent = 50
+    reason = "unit-test"
+    client.list_tasks.side_effect = [
+        {'taskArns': [
+            ("arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb"
+             "-8c7fada847da")],
+            'nextToken': 'token0'},
+        {'taskArns': [
+            ("arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki"
+             "-4o9amby245lk")],
+            'nextToken': None}
+    ]
+    stop_random_tasks(cluster=cluster, task_percent=task_percent,
+                      reason=reason)
+
+    assert client.stop_task.call_count == 1
+    task_calls = [("arn:aws:ecs:us-east-1:012345678910:task/16fd2706-"
+                   "8baf-433b-82eb-8c7fada847da"),
+                  ("arn:aws:ecs:us-east-1:012345678910:task/84th9568-"
+                   "3tth-55g1-35ki-4o9amby245lk")]
+
+    ex = None
+    for i in task_calls:
+        try:
+            client.stop_task.assert_called_with(
+                cluster=cluster, reason=reason, task=i)
+            return True
+        except AssertionError as e:
+            ex = e.args
+    raise AssertionError(ex)
+
+
+@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+def test_stop_random_tasks_percent_yes_service(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    cluster = "ecs-cluster"
+    task_percent = 50
+    reason = "unit-test"
+    service = "ecs-service"
+    client.list_tasks.side_effect = [
+        {'taskArns': [
+            ("arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb"
+             "-8c7fada847da")],
+            'nextToken': 'token0'},
+        {'taskArns': [
+            ("arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki"
+             "-4o9amby245lk")],
+            'nextToken': None}
+    ]
+    stop_random_tasks(cluster=cluster, service=service,
+                      task_percent=task_percent, reason=reason)
+
+    assert client.stop_task.call_count == 1
+    task_calls = [("arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf"
+                   "-433b-82eb-8c7fada847da"),
+                  ("arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth"
+                   "-55g1-35ki-4o9amby245lk")]
+
+    ex = None
+    for i in task_calls:
+        try:
+            client.stop_task.assert_called_with(
+                cluster=cluster, reason=reason, task=i)
+            return True
+        except AssertionError as e:
+            ex = e.args
+    raise AssertionError(ex)
+
+
+@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+def test_stop_random_tasks_count_yes_service(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    cluster = "ecs-cluster"
+    task_count = 2
+    reason = "unit-test"
+    service = "ecs-service"
+    client.list_tasks.side_effect = [
+        {'taskArns': [
+            ("arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb"
+             "-8c7fada847da")],
+            'nextToken': 'token0'},
+        {'taskArns': [
+            ("arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki"
+             "-4o9amby245lk")],
+            'nextToken': None}
+    ]
+    stop_random_tasks(cluster=cluster, service=service, task_count=task_count,
+                      reason=reason)
+
+    assert client.stop_task.call_count == 2
+    client.stop_task.assert_any_call(cluster=cluster,
+                                     task=("arn:aws:ecs:us-east-1:"
+                                           "012345678910:task/16fd2706-8baf"
+                                           "-433b-82eb-8c7fada847da"),
+                                     reason=reason)
+
+    client.stop_task.assert_any_call(cluster=cluster,
+                                     task=("arn:aws:ecs:us-east-1:"
+                                           "012345678910:task/84th9568-3tth"
+                                           "-55g1-35ki-4o9amby245lk"),
+                                     reason=reason)
 
 
 @patch('chaosaws.ecs.actions.aws_client', autospec=True)
@@ -26,9 +214,13 @@ def test_stop_tasks(aws_client):
     reason = "unit test"
     client.list_tasks.side_effect = [
         {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"], 'nextToken': 'token0'},
+            ("arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb"
+             "-8c7fada847da")],
+            'nextToken': 'token0'},
         {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"], 'nextToken': None}
+            ("arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki"
+             "-4o9amby245lk")],
+            'nextToken': None}
     ]
     stop_task(cluster=cluster, service=service, reason=reason)
 


### PR DESCRIPTION
- Added ecs stop_random_tasks to stop a given number of tasks in an ecs cluster/service
- Added helper function list_running_tasks_in_cluster to aid in above

Signed-off-by: Neil Advani <neil.advani@capitalone.com>