### PR TITLE
adding new ecs probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - correcting annotation for timeout parameter in asg actions
 - fix tests to match new pytest's API for accessing exceptions' values [#52][52]
 - adding action stop_random_tasks to ecs actions
+- adding describe_service, describe_tasks, & describe_cluster to ecs probes
 
 [52]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/issues/52
 

--- a/chaosaws/ecs/probes.py
+++ b/chaosaws/ecs/probes.py
@@ -3,8 +3,10 @@ from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 
 from chaosaws import aws_client
+from chaosaws.types import AWSResponse
 
-__all__ = ["service_is_deploying", "are_all_desired_tasks_running"]
+__all__ = ["service_is_deploying", "are_all_desired_tasks_running",
+           "describe_cluster", "describe_service", "describe_tasks"]
 
 
 def service_is_deploying(cluster: str,
@@ -36,3 +38,53 @@ def are_all_desired_tasks_running(cluster: str, service: str,
     response = client.describe_services(cluster=cluster, services=[service])
     service = response['services'][0]
     return service['desiredCount'] == service['runningCount']
+
+
+def describe_cluster(cluster: str,
+                     configuration: Configuration = None,
+                     secrets: Secrets = None) -> AWSResponse:
+    """
+    Returns AWS response describing the specified cluster
+    """
+    client = aws_client("ecs", configuration, secrets)
+    response = client.describe_clusters(clusters=[cluster])
+
+    if not response.get('clusters', []):
+        raise FailedActivity('Error retrieving information for cluster %s' % (
+            cluster))
+    return response
+
+
+def describe_service(cluster: str,
+                     service: str,
+                     configuration: Configuration = None,
+                     secrets: Secrets = None) -> AWSResponse:
+    """
+    Returns AWS response describing the specified cluster service
+    """
+    client = aws_client("ecs", configuration, secrets)
+    response = client.describe_services(cluster=cluster, services=[service])
+
+    if not response.get('services', []):
+        raise FailedActivity('Unable to collect service %s on cluster %s' % (
+            cluster, service))
+    return response
+
+
+def describe_tasks(cluster: str,
+                   configuration: Configuration = None,
+                   secrets: Secrets = None) -> AWSResponse:
+    client = aws_client("ecs", configuration, secrets)
+    paginator = client.get_paginator('list_tasks')
+    tasks = []
+
+    for p in paginator.paginate(cluster=cluster):
+        for t in p.get('taskArns', []):
+            tasks.append(t)
+
+    if not tasks:
+        raise FailedActivity('Unable to find any tasks for cluster %s' % (
+            cluster))
+
+    response = client.describe_tasks(cluster=cluster, tasks=tasks)
+    return response

--- a/chaosaws/ecs/probes.py
+++ b/chaosaws/ecs/probes.py
@@ -45,6 +45,31 @@ def describe_cluster(cluster: str,
                      secrets: Secrets = None) -> AWSResponse:
     """
     Returns AWS response describing the specified cluster
+
+    Probe example:
+        "steady-state-hypothesis": {
+            "title": "MyCluster has 3 running tasks",
+            "probes": [{
+                "type": "probe",
+                "name": "Cluster running task count",
+                "tolerance": {
+                    "type": "jsonpath",
+                    "path": $.clusters[0].runningTasksCount,
+                    "expect": 3
+                },
+                "provider": {
+                    "type": "python",
+                    "module": "chaosaws.ecs.probes",
+                    "func": "describe_cluster",
+                    "arguments": {
+                        "cluster": "MyCluster"
+                    }
+                }
+            }]
+        }
+
+    Full list of possible paths can be found:
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.describe_clusters
     """
     client = aws_client("ecs", configuration, secrets)
     response = client.describe_clusters(clusters=[cluster])
@@ -61,6 +86,32 @@ def describe_service(cluster: str,
                      secrets: Secrets = None) -> AWSResponse:
     """
     Returns AWS response describing the specified cluster service
+
+    Probe example:
+        "steady-state-hypothesis": {
+            "title": "MyService pending count is 1",
+            "probes": [{
+                "type": "probe",
+                "name": "Service pending count",
+                "tolerance": {
+                    "type": "jsonpath",
+                    "path": $.services[0].pendingCount,
+                    "expect": 1
+                },
+                "provider": {
+                    "type": "python",
+                    "module": "chaosaws.ecs.probes",
+                    "func": "describe_service",
+                    "arguments": {
+                        "cluster": "MyCluster",
+                        "service": "MyService"
+                    }
+                }
+            }]
+        }
+
+    Full list of possible paths can be found:
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.describe_services
     """
     client = aws_client("ecs", configuration, secrets)
     response = client.describe_services(cluster=cluster, services=[service])
@@ -74,6 +125,34 @@ def describe_service(cluster: str,
 def describe_tasks(cluster: str,
                    configuration: Configuration = None,
                    secrets: Secrets = None) -> AWSResponse:
+    """
+    Returns AWS response describing the tasks for a provided cluster
+
+    Probe example:
+        "steady-state-hypothesis": {
+            "title": "MyCluster tasks are healthy",
+            "probes": [{
+                "type": "probe",
+                "name": "first task is healthy",
+                "tolerance": {
+                    "type": "jsonpath",
+                    "path": $.tasks[0].healthStatus,
+                    "expect": "HEALTHY"
+                },
+                "provider": {
+                    "type": "python",
+                    "module": "chaosaws.ecs.probes",
+                    "func": "describe_tasks",
+                    "arguments": {
+                        "cluster": "MyCluster"
+                    }
+                }
+            }]
+        }
+
+    Full list of possible paths can be found:
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.describe_tasks
+    """
     client = aws_client("ecs", configuration, secrets)
     paginator = client.get_paginator('list_tasks')
     tasks = []

--- a/tests/ecs/test_ecs_probes.py
+++ b/tests/ecs/test_ecs_probes.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from chaoslib.exceptions import FailedActivity
 
-from chaosaws.ecs.probes import service_is_deploying
+from chaosaws.ecs.probes import (
+    service_is_deploying, describe_cluster, describe_service, describe_tasks)
 
 
 @patch('chaosaws.ecs.probes.aws_client', autospec=True)
@@ -21,7 +22,8 @@ def test_ecs_service_is_not_deploying(aws_client):
     cluster = "ecs-cluster"
     service = "ecs-service"
     response = service_is_deploying(cluster, service)
-    client.describe_services.assert_called_with(cluster=cluster, services=[service])
+    client.describe_services.assert_called_with(
+        cluster=cluster, services=[service])
     assert response is False
 
 
@@ -40,7 +42,8 @@ def test_ecs_service_is_deploying(aws_client):
     cluster = "ecs-cluster"
     service = "ecs-service"
     response = service_is_deploying(cluster, service)
-    client.describe_services.assert_called_with(cluster=cluster, services=[service])
+    client.describe_services.assert_called_with(
+        cluster=cluster, services=[service])
     assert response is True
 
 
@@ -60,5 +63,69 @@ def test_error_checking_ecs_service_is_not_deploying(aws_client):
     with pytest.raises(FailedActivity) as exceptionInfo:
         service_is_deploying(cluster, service)
 
-    client.describe_services.assert_called_with(cluster=cluster, services=[service])
+    client.describe_services.assert_called_with(
+        cluster=cluster, services=[service])
     assert 'Error retrieving service data from AWS' in str(exceptionInfo.value)
+
+
+@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+def test_describe_clusters(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    client.describe_clusters.return_value = {
+        'clusters': [{
+            'clusterArn': 'arn:aws:ecs:region:012345678910:cluster/MyCluster',
+            'clusterName': 'MyCluster',
+            'status': 'ACTIVE'
+        }]
+    }
+    response = describe_cluster(cluster='MyCluster')
+    client.describe_clusters.assert_called_with(clusters=['MyCluster'])
+    assert response['clusters'][0]['clusterName'] == 'MyCluster'
+
+
+@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+def test_describe_service(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    client.describe_services.return_value = {
+        'services': [{
+            'clusterArn': 'arn:aws:ecs:region:012345678910:cluster/MyCluster',
+            'serviceArn': 'arn:aws:ecs:region:012345678910:service/MyService',
+            'serviceName': 'MyService',
+            'status': 'ACTIVE'
+        }]
+    }
+    response = describe_service(cluster='MyCluster', service='MyService')
+    client.describe_services.assert_called_with(
+        cluster='MyCluster', services=['MyService'])
+    assert response['services'][0]['serviceName'] == 'MyService'
+
+
+@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+def test_describe_tasks(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    client.get_paginator.return_value.paginate.return_value = [{
+        'taskArns': [
+            'arn:aws:ecs:region:012345678910:task/MyCluster/123456789'
+        ]
+    }]
+    client.describe_tasks.return_value = {
+        'tasks': [
+            {
+                'clusterArn': 'arn:aws:ecs:region:012345678910:cluster/'
+                              'MyCluster',
+                'taskArn': 'arn:aws:ecs:region:012345678910:task/MyCluster/'
+                           '123456789',
+                'version': 22
+            }
+        ]
+    }
+    response = describe_tasks(cluster='MyCluster')
+    client.get_paginator.return_value.paginate.assert_called_with(
+        cluster='MyCluster')
+    client.describe_tasks.assert_called_with(
+        cluster='MyCluster',
+        tasks=['arn:aws:ecs:region:012345678910:task/MyCluster/123456789'])
+    assert response['tasks'][0]['version'] == 22


### PR DESCRIPTION
- adding probes: `describe_cluster`, `describe_service`, `describe_tasks` which will return an AWSResponse to allow for more granular tolerance criteria in steady-state.

Signed-off-by: Joshua Root <joshua.root@capitalone.com>