### PR TITLE
[Enhancement] adding ecs action 'update_desired_count'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - correcting IndexError in ecs are desired tasks running probe
 - adding unit tests for are desired tasks running probe
 - updating probes ALL list to include describe functions
+- adding action to set the desired task count of an ecs service
 
 ## [0.12.0][]
 

--- a/chaosaws/ecs/actions.py
+++ b/chaosaws/ecs/actions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import random
 import re
-from typing import List, Dict, Any, Union
+from typing import List, Union
 
 import boto3
 from chaoslib.exceptions import FailedActivity
@@ -214,7 +214,7 @@ def update_desired_count(cluster: str,
 ###############################################################################
 # Private functions
 ###############################################################################
-def validate_cluster(cluster: str, client:boto3.client) -> Union[str, None]:
+def validate_cluster(cluster: str, client: boto3.client) -> Union[str, None]:
     """Validates the provided cluster exists"""
     cluster = client.describe_clusters(clusters=cluster)['clusters']
     if not cluster:


### PR DESCRIPTION
- adds new action `update_desired_count` action that will allow for setting desired task count without deleting the actual task.

Signed-off-by: Joshua Root <joshua.root@capitalone.com>