### PR TITLE
Include elasticache module in pip package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ packages = [
     'chaosaws.ecs',
     'chaosaws.ec2',
     'chaosaws.eks',
+    'chaosaws.elasticache',
     'chaosaws.iam',
     'chaosaws.elbv2',
     'chaosaws.asg',


### PR DESCRIPTION
The elasticache module is missing from the 0.12.0 pip package which causes discovery to fail.  Adding the elasticache module to setup.py to correct this issue.  #64 
