### PR TITLE
correcting type error on validation

### DIFF
--- a/chaosaws/ecs/actions.py
+++ b/chaosaws/ecs/actions.py
@@ -216,7 +216,7 @@ def update_desired_count(cluster: str,
 ###############################################################################
 def validate_cluster(cluster: str, client: boto3.client) -> Union[str, None]:
     """Validates the provided cluster exists"""
-    cluster = client.describe_clusters(clusters=cluster)['clusters']
+    cluster = client.describe_clusters(clusters=[cluster])['clusters']
     if not cluster:
         return
     return cluster[0]['clusterArn']

--- a/tests/ecs/test_ecs_actions.py
+++ b/tests/ecs/test_ecs_actions.py
@@ -330,5 +330,6 @@ def test_update_desired_service_count(aws_client):
     )
     update_desired_count(
         cluster=cluster, service=service, desired_count=1)
+    client.describe_clusters.assert_called_with(clusters=[cluster])
     client.update_service.assert_called_with(
         cluster=cluster, service=service, desiredCount=1)


### PR DESCRIPTION
#65

- describe_clusters `clusters` parameter must be a list, not a string

Signed-off-by: Joshua Root <joshua.root@capitalone.com>