### PR TITLE
adding probes monitor

### DIFF
--- a/chaosaws/asg/probes.py
+++ b/chaosaws/asg/probes.py
@@ -5,18 +5,37 @@ from sys import maxsize
 from typing import Any, Dict, List, Union
 
 import boto3
-from chaosaws import aws_client
-from chaosaws.types import AWSResponse
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 from logzero import logger
-from chaosaws.utils import breakup_iterable
+
+from chaosaws import aws_client
+from chaosaws.types import AWSResponse
+from chaosaws.utils import breakup_iterable, probe_monitor
 
 __all__ = ["desired_equals_healthy", "desired_equals_healthy_tags",
            "wait_desired_equals_healthy", "wait_desired_equals_healthy_tags",
            "is_scaling_in_progress", "process_is_suspended", "has_subnets",
            "describe_auto_scaling_groups", "instance_count_by_health",
-           "wait_desired_not_equals_healthy_tags"]
+           "wait_desired_not_equals_healthy_tags", "monitor"]
+
+
+def monitor(probe_name: str,
+            probe_args: Dict[str, Any],
+            disrupted: Any,
+            recovered: Any,
+            json_path: str = None,
+            timeout: int = 300,
+            delay: int = 5,
+            configuration: Configuration = None,
+            secrets: Secrets = None) -> AWSResponse:
+    """Monitors an existing ASG probe for specific values
+    """
+    logger.info('Starting monitor of probe "%s"' % probe_name)
+    results = probe_monitor('asg', probe_name, probe_args, disrupted,
+                            recovered, json_path, timeout, delay,
+                            configuration, secrets)
+    return results
 
 
 def describe_auto_scaling_groups(asg_names: List[str] = None,

--- a/chaosaws/ec2/probes.py
+++ b/chaosaws/ec2/probes.py
@@ -1,12 +1,34 @@
 # -*- coding: utf-8 -*-
 from typing import Any, Dict, List
 
+from chaoslib.exceptions import FailedActivity
+from chaoslib.types import Configuration, Secrets
+from logzero import logger
+
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
-from chaoslib.types import Configuration, Secrets
-from chaoslib.exceptions import FailedActivity
+from chaosaws.utils import probe_monitor
 
-__all__ = ["describe_instances", "count_instances", "instance_state"]
+__all__ = ["describe_instances", "count_instances", "instance_state",
+           "monitor"]
+
+
+def monitor(probe_name: str,
+            probe_args: Dict[str, Any],
+            disrupted: Any,
+            recovered: Any,
+            json_path: str = None,
+            timeout: int = 300,
+            delay: int = 5,
+            configuration: Configuration = None,
+            secrets: Secrets = None) -> AWSResponse:
+    """Monitors an existing ASG probe for specific values
+    """
+    logger.info('Starting monitor of probe "%s"' % probe_name)
+    results = probe_monitor('ec2', probe_name, probe_args, disrupted,
+                            recovered, json_path, timeout, delay,
+                            configuration, secrets)
+    return results
 
 
 def describe_instances(filters: List[Dict[str, Any]],

--- a/chaosaws/ecs/probes.py
+++ b/chaosaws/ecs/probes.py
@@ -1,12 +1,35 @@
 # -*- coding: utf-8 -*-
+from typing import Any, Dict
+
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
+from logzero import logger
 
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
+from chaosaws.utils import probe_monitor
 
 __all__ = ["service_is_deploying", "are_all_desired_tasks_running",
-           "describe_cluster", "describe_service", "describe_tasks"]
+           "monitor", "describe_cluster", "describe_service",
+           "describe_tasks"]
+
+
+def monitor(probe_name: str,
+            probe_args: Dict[str, Any],
+            disrupted: Any,
+            recovered: Any,
+            json_path: str = None,
+            timeout: int = 300,
+            delay: int = 5,
+            configuration: Configuration = None,
+            secrets: Secrets = None) -> AWSResponse:
+    """Monitors for changes to the tasks in an ECS service.
+    """
+    logger.info('Starting monitor of probe "%s"' % probe_name)
+    results = probe_monitor('ecs', probe_name, probe_args, disrupted,
+                            recovered, json_path, timeout, delay,
+                            configuration, secrets)
+    return results
 
 
 def service_is_deploying(cluster: str,

--- a/chaosaws/utils.py
+++ b/chaosaws/utils.py
@@ -1,4 +1,88 @@
 #
+import time
+from importlib import import_module
+from typing import Union, Dict, Any
+
+import jmespath
+from chaoslib.exceptions import FailedActivity
+from chaoslib.types import Configuration, Secrets
+from logzero import logger
+
+
 def breakup_iterable(values: list, limit: int = 50) -> list:
     for i in range(0, len(values), limit):
         yield values[i:min(i + limit, len(values))]
+
+
+def jmes_search(json_path: str,
+                data: dict,
+                value: Union[list, int, bool, str]) -> bool:
+    results = jmespath.search(json_path, data)
+    if isinstance(value, int) and not isinstance(results, int):
+        results = jmespath.search('%s | length(@)' % json_path, data)
+    return results == value
+
+
+def probe_monitor(resource_type: str,
+                  probe_name: str,
+                  probe_args: Dict[str, Any],
+                  disrupted: Any,
+                  recovered: Any,
+                  json_path: str = None,
+                  timeout: int = 300,
+                  delay: int = 5,
+                  configuration: Configuration = None,
+                  secrets: Secrets = None) -> Dict[str, Any]:
+    def _check_status(_data, _value, _jpath=None):
+        if json_path:
+            return jmes_search(_jpath, _data, _value)
+        return _data == _value
+
+    probes = import_module('chaosaws.%s.probes' % resource_type)
+    probe = getattr(probes, probe_name)
+
+    results = {}
+    is_disrupted = False
+    start_time = time.time()
+    results['ctk:monitor_start'] = start_time
+
+    probe_args.update({'configuration': configuration, 'secrets': secrets})
+    logger.info('waiting for disruption to occur')
+    while not is_disrupted:
+        if int(time.time() - start_time) > timeout:
+            raise FailedActivity(
+                'Timeout reached on disruption (%s seconds).' % timeout)
+
+        response = probe(**probe_args)
+        if _check_status(response, disrupted, json_path):
+            is_disrupted = True
+            results['ctk:disruption_time'] = time.time()
+            logger.info('resource disruption detected at %s' % (
+                time.ctime(results['ctk:disruption_time'])))
+            continue
+        time.sleep(delay)
+
+    is_recovered = False
+    logger.info('waiting for recovery to occur')
+    while not is_recovered:
+        if int(time.time() - start_time) > timeout:
+            raise FailedActivity(
+                'Timeout reached on disruption (%s seconds).' % timeout)
+
+        response = probe(**probe_args)
+        if _check_status(response, recovered, json_path):
+            is_recovered = True
+            results['ctk:recovery_time'] = time.time()
+            logger.info('resource recovery detected at %s' % (
+                time.ctime(results['ctk:recovery_time'])))
+            continue
+        time.sleep(delay)
+
+    results['ctk:monitor_start'] = time.ctime(results['ctk:monitor_start'])
+    results['ctk:monitor_results'] = 'success'
+    results['ctk:time_to_recovery'] = int(
+        results['ctk:recovery_time'] - results['ctk:disruption_time'])
+    results['ctk:recovery_time'] = time.ctime(results['ctk:recovery_time'])
+    results['ctk:disruption_time'] = time.ctime(results['ctk:disruption_time'])
+    results['ctk:monitor_elapsed'] = int(time.time() - start_time)
+    return results

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest>=2.8
 pytest-cov
 pytest-sugar
 requests_mock
+placebo

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ aws-requests-auth
 boto3
 chaostoolkit-lib>=0.13.0
 requests
+botocore
+jmespath

--- a/tests/elbv2/test_elbv2_probes.py
+++ b/tests/elbv2/test_elbv2_probes.py
@@ -2,8 +2,10 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from chaosaws.elbv2.probes import all_targets_healthy, targets_health_count
+from tests.zpharmacy import Pharmacy
+from chaosaws.elbv2.probes import (
+    monitor, all_targets_healthy, targets_health_count)
+from chaosaws.ec2.actions import terminate_instance, stop_instance
 from chaoslib.exceptions import FailedActivity
 
 
@@ -123,3 +125,58 @@ def test_all_targets_healthy_needs_tg_names():
     with pytest.raises(FailedActivity) as x:
         all_targets_healthy([])
     assert "Non-empty list of target groups is required" in str(x.value)
+
+
+class TestMonitorELB(Pharmacy):
+    def test_monitor_targets_health_count(self):
+        session = self.replay('test_monitor_elbv2_targets_health_count')
+        tg_name = 'generic-tg'
+        params = {
+            'probe_name': 'targets_health_count',
+            'probe_args': {'tg_names': [tg_name]},
+            'json_path': '"%s".healthy' % tg_name,
+            'disrupted': 2,
+            'recovered': 3,
+            'delay': 1,
+            'configuration': {
+                'aws_session': session,
+                'aws_region': 'us-east-1'
+            }
+        }
+
+        targs = {
+            'instance_id': 'i-00000000000000000',
+            'configuration': {
+                'aws_session': session,
+                'aws_region': 'us-east-1'
+            }
+        }
+        terminate_instance(**targs)
+        results = monitor(**params)
+        self.assertEqual(results['ctk:monitor_results'], 'success')
+
+    def test_monitor_all_targets_healthy(self):
+        session = self.replay('test_monitor_elbv2_all_targets_healthy')
+        tg_name = 'generic_target_group'
+        params = {
+            'probe_name': 'all_targets_healthy',
+            'probe_args': {'tg_names': [tg_name]},
+            'disrupted': False,
+            'recovered': True,
+            'delay': 1,
+            'configuration': {
+                'aws_session': session,
+                'aws_region': 'us-east-1'
+            }
+        }
+
+        targs = {
+            'instance_id': 'i-00000000000000001',
+            'configuration': {
+                'aws_session': session,
+                'aws_region': 'us-east-1'
+            }
+        }
+        stop_instance(**targs)
+        results = monitor(**params)
+        self.assertEqual(results['ctk:monitor_results'], 'success')

--- a/tests/test_data/test_asg_monitor_desired_equals_healthy_names/autoscaling.DescribeAutoScalingGroups_1.json
+++ b/tests/test_data/test_asg_monitor_desired_equals_healthy_names/autoscaling.DescribeAutoScalingGroups_1.json
@@ -1,0 +1,92 @@
+{
+    "status_code": 200,
+    "data": {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "generic_asg",
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:000000000000:autoScalingGroup:00000000-0000-0000-0000-000000000000:autoScalingGroupName/generic_asg",
+                "LaunchConfigurationName": "generic_asg_lc",
+                "MinSize": 3,
+                "MaxSize": 3,
+                "DesiredCapacity": 3,
+                "DefaultCooldown": 300,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LoadBalancerNames": [],
+                "TargetGroupARNs": [],
+                "HealthCheckType": "EC2",
+                "HealthCheckGracePeriod": 600,
+                "Instances": [
+                    {
+                        "InstanceId": "i-00a8aa540bc737e54",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1a",
+                        "LifecycleState": "InService",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    },
+                    {
+                        "InstanceId": "i-00000000000000000",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1b",
+                        "LifecycleState": "InService",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    },
+                    {
+                        "InstanceId": "i-00000000000000001",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1c",
+                        "LifecycleState": "InService",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    }
+                ],
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 59,
+                    "second": 0,
+                    "microsecond": 528000
+                },
+                "SuspendedProcesses": [],
+                "VPCZoneIdentifier": "subnet-0000000a,subnet-0000000b,subnet-0000000c",
+                "Tags": [
+                    {
+                        "ResourceId": "generic_asg",
+                        "ResourceType": "auto-scaling-group",
+                        "Key": "Name",
+                        "Value": "generic_asg",
+                        "PropagateAtLaunch": true
+                    }
+                ],
+                "TerminationPolicies": [
+                    "Default"
+                ],
+                "NewInstancesProtectedFromScaleIn": false,
+                "ServiceLinkedRoleARN": "arn:aws:iam::000000000000:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "d4d361ca-2ff7-4ee1-85de-07e16c30d7a7",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "d4d361ca-2ff7-4ee1-85de-07e16c30d7a7",
+                "content-type": "text/xml",
+                "content-length": "9425",
+                "vary": "accept-encoding",
+                "date": "Tue, 02 Jun 2020 13:58:51 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_asg_monitor_desired_equals_healthy_names/autoscaling.DescribeAutoScalingGroups_2.json
+++ b/tests/test_data/test_asg_monitor_desired_equals_healthy_names/autoscaling.DescribeAutoScalingGroups_2.json
@@ -1,0 +1,92 @@
+{
+    "status_code": 200,
+    "data": {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "generic_asg",
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:000000000000:autoScalingGroup:00000000-0000-0000-0000-000000000000:autoScalingGroupName/generic_asg",
+                "LaunchConfigurationName": "generic_asg_lc",
+                "MinSize": 3,
+                "MaxSize": 3,
+                "DesiredCapacity": 3,
+                "DefaultCooldown": 300,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LoadBalancerNames": [],
+                "TargetGroupARNs": [],
+                "HealthCheckType": "EC2",
+                "HealthCheckGracePeriod": 600,
+                "Instances": [
+                    {
+                        "InstanceId": "i-00a8aa540bc737e54",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1a",
+                        "LifecycleState": "Terminating",
+                        "HealthStatus": "Unhealthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    },
+                    {
+                        "InstanceId": "i-00000000000000000",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1b",
+                        "LifecycleState": "InService",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    },
+                    {
+                        "InstanceId": "i-00000000000000001",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1c",
+                        "LifecycleState": "InService",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    }
+                ],
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 59,
+                    "second": 0,
+                    "microsecond": 528000
+                },
+                "SuspendedProcesses": [],
+                "VPCZoneIdentifier": "subnet-0000000a,subnet-0000000b,subnet-0000000c",
+                "Tags": [
+                    {
+                        "ResourceId": "generic_asg",
+                        "ResourceType": "auto-scaling-group",
+                        "Key": "Name",
+                        "Value": "generic_asg",
+                        "PropagateAtLaunch": true
+                    }
+                ],
+                "TerminationPolicies": [
+                    "Default"
+                ],
+                "NewInstancesProtectedFromScaleIn": false,
+                "ServiceLinkedRoleARN": "arn:aws:iam::000000000000:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "8add1bc7-2b84-4d2a-aded-a9c053e03672",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "8add1bc7-2b84-4d2a-aded-a9c053e03672",
+                "content-type": "text/xml",
+                "content-length": "9429",
+                "vary": "accept-encoding",
+                "date": "Tue, 02 Jun 2020 13:59:43 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_asg_monitor_desired_equals_healthy_names/autoscaling.DescribeAutoScalingGroups_3.json
+++ b/tests/test_data/test_asg_monitor_desired_equals_healthy_names/autoscaling.DescribeAutoScalingGroups_3.json
@@ -1,0 +1,92 @@
+{
+    "status_code": 200,
+    "data": {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "generic_asg",
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:000000000000:autoScalingGroup:00000000-0000-0000-0000-000000000000:autoScalingGroupName/generic_asg",
+                "LaunchConfigurationName": "generic_asg_lc",
+                "MinSize": 3,
+                "MaxSize": 3,
+                "DesiredCapacity": 3,
+                "DefaultCooldown": 300,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LoadBalancerNames": [],
+                "TargetGroupARNs": [],
+                "HealthCheckType": "EC2",
+                "HealthCheckGracePeriod": 600,
+                "Instances": [
+                    {
+                        "InstanceId": "i-00000000000000000",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1b",
+                        "LifecycleState": "InService",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    },
+                    {
+                        "InstanceId": "i-00000000000000001",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1c",
+                        "LifecycleState": "InService",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    },
+                    {
+                        "InstanceId": "i-00000000000000002",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1a",
+                        "LifecycleState": "Pending",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    }
+                ],
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 59,
+                    "second": 0,
+                    "microsecond": 528000
+                },
+                "SuspendedProcesses": [],
+                "VPCZoneIdentifier": "subnet-0000000a,subnet-0000000b,subnet-0000000c",
+                "Tags": [
+                    {
+                        "ResourceId": "generic_asg",
+                        "ResourceType": "auto-scaling-group",
+                        "Key": "Name",
+                        "Value": "generic_asg",
+                        "PropagateAtLaunch": true
+                    }
+                ],
+                "TerminationPolicies": [
+                    "Default"
+                ],
+                "NewInstancesProtectedFromScaleIn": false,
+                "ServiceLinkedRoleARN": "arn:aws:iam::000000000000:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "cbd71d6c-812c-47ad-bf16-06c4bfb019ee",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cbd71d6c-812c-47ad-bf16-06c4bfb019ee",
+                "content-type": "text/xml",
+                "content-length": "9423",
+                "vary": "accept-encoding",
+                "date": "Tue, 02 Jun 2020 14:00:44 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_asg_monitor_desired_equals_healthy_names/autoscaling.DescribeAutoScalingGroups_4.json
+++ b/tests/test_data/test_asg_monitor_desired_equals_healthy_names/autoscaling.DescribeAutoScalingGroups_4.json
@@ -1,0 +1,92 @@
+{
+    "status_code": 200,
+    "data": {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "generic_asg",
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:000000000000:autoScalingGroup:00000000-0000-0000-0000-000000000000:autoScalingGroupName/generic_asg",
+                "LaunchConfigurationName": "generic_asg_lc",
+                "MinSize": 3,
+                "MaxSize": 3,
+                "DesiredCapacity": 3,
+                "DefaultCooldown": 300,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LoadBalancerNames": [],
+                "TargetGroupARNs": [],
+                "HealthCheckType": "EC2",
+                "HealthCheckGracePeriod": 600,
+                "Instances": [
+                    {
+                        "InstanceId": "i-00000000000000000",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1b",
+                        "LifecycleState": "InService",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    },
+                    {
+                        "InstanceId": "i-00000000000000001",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1c",
+                        "LifecycleState": "InService",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    },
+                    {
+                        "InstanceId": "i-00000000000000002",
+                        "InstanceType": "t3a.large",
+                        "AvailabilityZone": "us-east-1a",
+                        "LifecycleState": "InService",
+                        "HealthStatus": "Healthy",
+                        "LaunchConfigurationName": "generic_asg_lc",
+                        "ProtectedFromScaleIn": false
+                    }
+                ],
+                "CreatedTime": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 59,
+                    "second": 0,
+                    "microsecond": 528000
+                },
+                "SuspendedProcesses": [],
+                "VPCZoneIdentifier": "subnet-0000000a,subnet-0000000b,subnet-0000000c",
+                "Tags": [
+                    {
+                        "ResourceId": "generic_asg",
+                        "ResourceType": "auto-scaling-group",
+                        "Key": "Name",
+                        "Value": "generic_asg",
+                        "PropagateAtLaunch": true
+                    }
+                ],
+                "TerminationPolicies": [
+                    "Default"
+                ],
+                "NewInstancesProtectedFromScaleIn": false,
+                "ServiceLinkedRoleARN": "arn:aws:iam::000000000000:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "8745fa73-4a67-42b1-bd70-165b29dfcb0a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "8745fa73-4a67-42b1-bd70-165b29dfcb0a",
+                "content-type": "text/xml",
+                "content-length": "9425",
+                "vary": "accept-encoding",
+                "date": "Tue, 02 Jun 2020 14:00:50 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_asg_monitor_desired_equals_healthy_names/ec2.TerminateInstances_1.json
+++ b/tests/test_data/test_asg_monitor_desired_equals_healthy_names/ec2.TerminateInstances_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "TerminatingInstances": [
+            {
+                "CurrentState": {
+                    "Code": 32,
+                    "Name": "shutting-down"
+                },
+                "InstanceId": "i-00000000000000000",
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "529ba7b2-e1ed-4b78-b501-e76667621b20",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "529ba7b2-e1ed-4b78-b501-e76667621b20",
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "accept-encoding",
+                "date": "Tue, 02 Jun 2020 13:58:52 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_ecs_monitor_describe_tasks/ecs.DescribeTasks_1.json
+++ b/tests/test_data/test_ecs_monitor_describe_tasks/ecs.DescribeTasks_1.json
@@ -1,0 +1,495 @@
+{
+    "status_code": 200,
+    "data": {
+        "tasks": [
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1a",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 22,
+                    "microsecond": 896000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000010",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000003",
+                        "name": "service_2",
+                        "image": "generic_image",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [
+                            {
+                                "bindIP": "0.0.0.0",
+                                "containerPort": 80,
+                                "hostPort": 20001,
+                                "protocol": "tcp"
+                            }
+                        ],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 22,
+                    "microsecond": 896000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_2",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_2"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 23,
+                    "microsecond": 455000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 58,
+                    "microsecond": 455000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 20,
+                    "second": 2,
+                    "microsecond": 455000
+                },
+                "startedBy": "ecs-svc/0000000000000000003",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000003",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_2:1",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1b",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 227000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000000",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000000",
+                        "name": "service_name",
+                        "image": "image_name",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 227000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_1",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_name"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 139000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 26,
+                    "second": 14,
+                    "microsecond": 139000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 26,
+                    "second": 15,
+                    "microsecond": 139000
+                },
+                "startedBy": "ecs-svc/0000000000000000002",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000000",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_name:136",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1c",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 11,
+                    "microsecond": 853000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000000",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000001",
+                        "name": "service_name",
+                        "image": "image_name",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 11,
+                    "microsecond": 853000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_1",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_name"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 13,
+                    "microsecond": 517000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 13,
+                    "microsecond": 517000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 13,
+                    "microsecond": 517000
+                },
+                "startedBy": "ecs-svc/0000000000000000002",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000001",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_name:136",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1a",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 11,
+                    "microsecond": 864000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-1000-0000-0000-000000000000",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000004",
+                        "name": "service_3",
+                        "image": "generic_image:latest",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [
+                            {
+                                "bindIP": "0.0.0.0",
+                                "containerPort": 8080,
+                                "hostPort": 20000,
+                                "protocol": "tcp"
+                            }
+                        ],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 11,
+                    "microsecond": 864000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_3",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_3"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 13,
+                    "microsecond": 30000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 14,
+                    "microsecond": 30000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 14,
+                    "microsecond": 30000
+                },
+                "startedBy": "ecs-svc/0000000000000000001",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000004",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_3:1",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1a",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 28,
+                    "microsecond": 952000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000020",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000005",
+                        "name": "service_3",
+                        "image": "generic_image_3",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [
+                            {
+                                "bindIP": "0.0.0.0",
+                                "containerPort": 80,
+                                "hostPort": 20002,
+                                "protocol": "tcp"
+                            }
+                        ],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 28,
+                    "microsecond": 952000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:service_4",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_4"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 29,
+                    "microsecond": 565000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 20,
+                    "second": 0,
+                    "microsecond": 565000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 20,
+                    "second": 2,
+                    "microsecond": 565000
+                },
+                "startedBy": "ecs-svc/0000000000000000000",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000005",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_4:555",
+                "version": 2
+            }
+        ],
+        "failures": [],
+        "ResponseMetadata": {
+            "RequestId": "0877a1af-c2cb-4bc2-ad52-b65b3e9225c7",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "0877a1af-c2cb-4bc2-ad52-b65b3e9225c7",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "7290",
+                "date": "Mon, 01 Jun 2020 17:31:23 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_ecs_monitor_describe_tasks/ecs.DescribeTasks_2.json
+++ b/tests/test_data/test_ecs_monitor_describe_tasks/ecs.DescribeTasks_2.json
@@ -1,0 +1,495 @@
+{
+    "status_code": 200,
+    "data": {
+        "tasks": [
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1a",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 22,
+                    "microsecond": 896000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000010",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000003",
+                        "name": "service_2",
+                        "image": "generic_image",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [
+                            {
+                                "bindIP": "0.0.0.0",
+                                "containerPort": 80,
+                                "hostPort": 20001,
+                                "protocol": "tcp"
+                            }
+                        ],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 22,
+                    "microsecond": 896000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_2",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_2"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 23,
+                    "microsecond": 455000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 58,
+                    "microsecond": 455000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 20,
+                    "second": 2,
+                    "microsecond": 455000
+                },
+                "startedBy": "ecs-svc/0000000000000000003",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000003",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_2:1",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1b",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 227000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000000",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000000",
+                        "name": "service_name",
+                        "image": "image_name",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 227000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_1",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_name"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 139000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 26,
+                    "second": 14,
+                    "microsecond": 139000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 26,
+                    "second": 15,
+                    "microsecond": 139000
+                },
+                "startedBy": "ecs-svc/0000000000000000002",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000000",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_name:136",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1c",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 11,
+                    "microsecond": 853000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000000",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000001",
+                        "name": "service_name",
+                        "image": "image_name",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 11,
+                    "microsecond": 853000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_1",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_name"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 13,
+                    "microsecond": 517000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 13,
+                    "microsecond": 517000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 13,
+                    "microsecond": 517000
+                },
+                "startedBy": "ecs-svc/0000000000000000002",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000001",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_name:136",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1a",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 11,
+                    "microsecond": 864000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-1000-0000-0000-000000000000",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000004",
+                        "name": "service_3",
+                        "image": "generic_image:latest",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [
+                            {
+                                "bindIP": "0.0.0.0",
+                                "containerPort": 8080,
+                                "hostPort": 20000,
+                                "protocol": "tcp"
+                            }
+                        ],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 11,
+                    "microsecond": 864000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_3",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_3"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 13,
+                    "microsecond": 30000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 14,
+                    "microsecond": 30000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 14,
+                    "microsecond": 30000
+                },
+                "startedBy": "ecs-svc/0000000000000000001",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000004",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_3:106",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1a",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 28,
+                    "microsecond": 952000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000020",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000005",
+                        "name": "service_4",
+                        "image": "generic_image_3",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [
+                            {
+                                "bindIP": "0.0.0.0",
+                                "containerPort": 80,
+                                "hostPort": 20002,
+                                "protocol": "tcp"
+                            }
+                        ],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 28,
+                    "microsecond": 952000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:service_4",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_4"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 29,
+                    "microsecond": 565000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 20,
+                    "second": 0,
+                    "microsecond": 565000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 20,
+                    "second": 2,
+                    "microsecond": 565000
+                },
+                "startedBy": "ecs-svc/0000000000000000000",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000005",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_4:555",
+                "version": 2
+            }
+        ],
+        "failures": [],
+        "ResponseMetadata": {
+            "RequestId": "d8ae3ba3-3520-47fc-a2d2-4d6ce7e53fea",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "d8ae3ba3-3520-47fc-a2d2-4d6ce7e53fea",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "7290",
+                "date": "Mon, 01 Jun 2020 17:31:24 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_ecs_monitor_describe_tasks/ecs.DescribeTasks_3.json
+++ b/tests/test_data/test_ecs_monitor_describe_tasks/ecs.DescribeTasks_3.json
@@ -1,0 +1,586 @@
+{
+    "status_code": 200,
+    "data": {
+        "tasks": [
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1a",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 31,
+                    "second": 55,
+                    "microsecond": 928000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/30b7988c-5338-417f-a76b-dd5ac66d4b14",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000006",
+                        "name": "service_name",
+                        "image": "image_name",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 31,
+                    "second": 55,
+                    "microsecond": 928000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_1",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_name"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 31,
+                    "second": 56,
+                    "microsecond": 269000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 31,
+                    "second": 56,
+                    "microsecond": 269000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 31,
+                    "second": 57,
+                    "microsecond": 269000
+                },
+                "startedBy": "ecs-svc/0000000000000000002",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000006",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_name:136",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1a",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 22,
+                    "microsecond": 896000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000010",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000003",
+                        "name": "service_2",
+                        "image": "generic_image",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [
+                            {
+                                "bindIP": "0.0.0.0",
+                                "containerPort": 80,
+                                "hostPort": 20001,
+                                "protocol": "tcp"
+                            }
+                        ],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 22,
+                    "microsecond": 896000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_2",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_2"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 23,
+                    "microsecond": 455000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 58,
+                    "microsecond": 455000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 20,
+                    "second": 2,
+                    "microsecond": 455000
+                },
+                "startedBy": "ecs-svc/0000000000000000003",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000003",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_2:1",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1b",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 227000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000000",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000000",
+                        "name": "service_name",
+                        "image": "image_name",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 227000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_1",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_name"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 25,
+                    "second": 34,
+                    "microsecond": 139000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 26,
+                    "second": 14,
+                    "microsecond": 139000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 7,
+                    "minute": 26,
+                    "second": 15,
+                    "microsecond": 139000
+                },
+                "startedBy": "ecs-svc/0000000000000000002",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000000",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_name:136",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1c",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 11,
+                    "microsecond": 853000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000000",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000001",
+                        "name": "service_name",
+                        "image": "image_name",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 11,
+                    "microsecond": 853000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_1",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_name"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 13,
+                    "microsecond": 517000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 13,
+                    "microsecond": 517000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 6,
+                    "day": 1,
+                    "hour": 13,
+                    "minute": 23,
+                    "second": 13,
+                    "microsecond": 517000
+                },
+                "startedBy": "ecs-svc/0000000000000000002",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000001",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_name:136",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1a",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 11,
+                    "microsecond": 864000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-1000-0000-0000-000000000000",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000004",
+                        "name": "service_3",
+                        "image": "generic_image:latest",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [
+                            {
+                                "bindIP": "0.0.0.0",
+                                "containerPort": 8080,
+                                "hostPort": 20000,
+                                "protocol": "tcp"
+                            }
+                        ],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 11,
+                    "microsecond": 864000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:generic_service_3",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_3"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 13,
+                    "microsecond": 30000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 14,
+                    "microsecond": 30000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 14,
+                    "microsecond": 30000
+                },
+                "startedBy": "ecs-svc/0000000000000000001",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000004",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_3:106",
+                "version": 2
+            },
+            {
+                "attachments": [],
+                "availabilityZone": "us-east-1a",
+                "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+                "connectivity": "CONNECTED",
+                "connectivityAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 28,
+                    "microsecond": 952000
+                },
+                "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+                "containers": [
+                    {
+                        "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/00000000-0000-0000-0000-000000000020",
+                        "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000005",
+                        "name": "service_4",
+                        "image": "generic_image_3",
+                        "lastStatus": "RUNNING",
+                        "networkBindings": [
+                            {
+                                "bindIP": "0.0.0.0",
+                                "containerPort": 80,
+                                "hostPort": 20002,
+                                "protocol": "tcp"
+                            }
+                        ],
+                        "networkInterfaces": [],
+                        "healthStatus": "UNKNOWN",
+                        "cpu": "128",
+                        "memory": "1024"
+                    }
+                ],
+                "cpu": "128",
+                "createdAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 28,
+                    "microsecond": 952000
+                },
+                "desiredStatus": "RUNNING",
+                "group": "service:service_4",
+                "healthStatus": "UNKNOWN",
+                "lastStatus": "RUNNING",
+                "launchType": "EC2",
+                "memory": "1024",
+                "overrides": {
+                    "containerOverrides": [
+                        {
+                            "name": "service_4"
+                        }
+                    ],
+                    "inferenceAcceleratorOverrides": []
+                },
+                "pullStartedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 19,
+                    "second": 29,
+                    "microsecond": 565000
+                },
+                "pullStoppedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 20,
+                    "second": 0,
+                    "microsecond": 565000
+                },
+                "startedAt": {
+                    "__class__": "datetime",
+                    "year": 2020,
+                    "month": 5,
+                    "day": 29,
+                    "hour": 22,
+                    "minute": 20,
+                    "second": 2,
+                    "microsecond": 565000
+                },
+                "startedBy": "ecs-svc/0000000000000000000",
+                "tags": [],
+                "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000005",
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_4:555",
+                "version": 2
+            }
+        ],
+        "failures": [],
+        "ResponseMetadata": {
+            "RequestId": "f8c0b828-0bd5-4272-8544-255a0ce30400",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f8c0b828-0bd5-4272-8544-255a0ce30400",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "8701",
+                "date": "Mon, 01 Jun 2020 17:31:57 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_ecs_monitor_describe_tasks/ecs.ListTasks_1.json
+++ b/tests/test_data/test_ecs_monitor_describe_tasks/ecs.ListTasks_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200,
+    "data": {
+        "taskArns": [
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000000",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000001",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000002"
+        ],
+        "ResponseMetadata": {
+            "RequestId": "aaf6875b-a276-438d-bc22-d508e8778369",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "aaf6875b-a276-438d-bc22-d508e8778369",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "290",
+                "date": "Mon, 01 Jun 2020 17:31:23 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_ecs_monitor_describe_tasks/ecs.ListTasks_2.json
+++ b/tests/test_data/test_ecs_monitor_describe_tasks/ecs.ListTasks_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "taskArns": [
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000003",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000000",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000001",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000004",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000005"
+        ],
+        "ResponseMetadata": {
+            "RequestId": "bb2848e6-9332-4b17-a144-8d1a2347b98d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "bb2848e6-9332-4b17-a144-8d1a2347b98d",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "474",
+                "date": "Mon, 01 Jun 2020 17:31:23 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_ecs_monitor_describe_tasks/ecs.ListTasks_3.json
+++ b/tests/test_data/test_ecs_monitor_describe_tasks/ecs.ListTasks_3.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 200,
+    "data": {
+        "taskArns": [
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000006",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000003",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000000",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000001",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000004",
+            "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000005"
+        ],
+        "ResponseMetadata": {
+            "RequestId": "b90d1ad7-b7d3-41bc-b693-cba31fa24f4d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b90d1ad7-b7d3-41bc-b693-cba31fa24f4d",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "566",
+                "date": "Mon, 01 Jun 2020 17:31:57 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_ecs_monitor_describe_tasks/ecs.StopTask_1.json
+++ b/tests/test_data/test_ecs_monitor_describe_tasks/ecs.StopTask_1.json
@@ -1,0 +1,117 @@
+{
+    "status_code": 200,
+    "data": {
+        "task": {
+            "attachments": [],
+            "availabilityZone": "us-east-1a",
+            "clusterArn": "arn:aws:ecs:us-east-1:000000000000:cluster/generic_cluster",
+            "connectivity": "CONNECTED",
+            "connectivityAt": {
+                "__class__": "datetime",
+                "year": 2020,
+                "month": 6,
+                "day": 1,
+                "hour": 13,
+                "minute": 26,
+                "second": 55,
+                "microsecond": 410000
+            },
+            "containerInstanceArn": "arn:aws:ecs:us-east-1:000000000000:container-instance/generic_cluster/00000000000000000000000000000000a",
+            "containers": [
+                {
+                    "containerArn": "arn:aws:ecs:us-east-1:000000000000:container/000000000-0000-0000-0000-00000000000f",
+                    "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000002",
+                    "name": "service_name",
+                    "image": "image_name",
+                    "lastStatus": "RUNNING",
+                    "networkBindings": [],
+                    "networkInterfaces": [],
+                    "cpu": "128",
+                    "memory": "1024"
+                }
+            ],
+            "cpu": "128",
+            "createdAt": {
+                "__class__": "datetime",
+                "year": 2020,
+                "month": 6,
+                "day": 1,
+                "hour": 13,
+                "minute": 26,
+                "second": 55,
+                "microsecond": 410000
+            },
+            "desiredStatus": "STOPPED",
+            "group": "service:generic_service_1",
+            "lastStatus": "RUNNING",
+            "launchType": "EC2",
+            "memory": "1024",
+            "overrides": {
+                "containerOverrides": [
+                    {
+                        "name": "service_name"
+                    }
+                ],
+                "inferenceAcceleratorOverrides": []
+            },
+            "pullStartedAt": {
+                "__class__": "datetime",
+                "year": 2020,
+                "month": 6,
+                "day": 1,
+                "hour": 13,
+                "minute": 26,
+                "second": 56,
+                "microsecond": 809000
+            },
+            "pullStoppedAt": {
+                "__class__": "datetime",
+                "year": 2020,
+                "month": 6,
+                "day": 1,
+                "hour": 13,
+                "minute": 26,
+                "second": 56,
+                "microsecond": 809000
+            },
+            "startedAt": {
+                "__class__": "datetime",
+                "year": 2020,
+                "month": 6,
+                "day": 1,
+                "hour": 13,
+                "minute": 26,
+                "second": 56,
+                "microsecond": 809000
+            },
+            "startedBy": "ecs-svc/0000000000000000002",
+            "stopCode": "UserInitiated",
+            "stoppedReason": "Chaos Testing",
+            "stoppingAt": {
+                "__class__": "datetime",
+                "year": 2020,
+                "month": 6,
+                "day": 1,
+                "hour": 13,
+                "minute": 31,
+                "second": 24,
+                "microsecond": 48000
+            },
+            "tags": [],
+            "taskArn": "arn:aws:ecs:us-east-1:000000000000:task/generic_cluster/000000000000000000000000000000002",
+            "taskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/service_name:136",
+            "version": 3
+        },
+        "ResponseMetadata": {
+            "RequestId": "d81b081b-47bc-4469-b5d4-eff9af4c619f",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "d81b081b-47bc-4469-b5d4-eff9af4c619f",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "1456",
+                "date": "Mon, 01 Jun 2020 17:31:23 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_ec2_describe/ec2.DescribeInstances_1.json
+++ b/tests/test_data/test_monitor_ec2_describe/ec2.DescribeInstances_1.json
@@ -1,0 +1,164 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-00000000000000000",
+                        "InstanceId": "i-00000000000000000",
+                        "InstanceType": "t3.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2020,
+                            "month": 6,
+                            "day": 10,
+                            "hour": 14,
+                            "minute": 55,
+                            "second": 18,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "enabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                        "PrivateIpAddress": "0.0.0.0",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-00000000",
+                        "VpcId": "vpc-00000000",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/sda1",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2020,
+                                        "month": 6,
+                                        "day": 10,
+                                        "hour": 14,
+                                        "minute": 55,
+                                        "second": 18,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-00000000000000000"
+                                }
+                            }
+                        ],
+                        "ClientToken": "00000000-0000-0000-0000-000000000000",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "IamInstanceProfile": {
+                            "Arn": "arn:aws:iam::000000000000:instance-profile/TestRole",
+                            "Id": "AAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2020,
+                                        "month": 6,
+                                        "day": 10,
+                                        "hour": 14,
+                                        "minute": 55,
+                                        "second": 18,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-00000000000000000",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached"
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "TestSG",
+                                        "GroupId": "sg-00000000000000000"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "00:00:00:00:00:00",
+                                "NetworkInterfaceId": "eni-00000000000000000",
+                                "OwnerId": "000000000000",
+                                "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                                "PrivateIpAddress": "0.0.0.0",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                                        "PrivateIpAddress": "0.0.0.0"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-00000000",
+                                "VpcId": "vpc-00000000",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/sda1",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "TestSG",
+                                "GroupId": "sg-00000000000000000"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Tags": [],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 2
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled"
+                        }
+                    }
+                ],
+                "OwnerId": "000000000000",
+                "RequesterId": "000000000000",
+                "ReservationId": "r-00000000000000000"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "468e94fe-c601-491f-a2a4-f050221d3094",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "468e94fe-c601-491f-a2a4-f050221d3094",
+                "content-type": "text/xml;charset=UTF-8",
+                "content-length": "8145",
+                "vary": "accept-encoding",
+                "date": "Wed, 10 Jun 2020 15:13:17 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_ec2_describe/ec2.DescribeInstances_2.json
+++ b/tests/test_data/test_monitor_ec2_describe/ec2.DescribeInstances_2.json
@@ -1,0 +1,168 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-00000000000000000",
+                        "InstanceId": "i-00000000000000000",
+                        "InstanceType": "t3.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2020,
+                            "month": 6,
+                            "day": 10,
+                            "hour": 14,
+                            "minute": 55,
+                            "second": 18,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "enabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                        "PrivateIpAddress": "0.0.0.0",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 32,
+                            "Name": "shutting-down"
+                        },
+                        "StateTransitionReason": "User initiated (2020-06-10 15:13:17 GMT)",
+                        "SubnetId": "subnet-00000000",
+                        "VpcId": "vpc-00000000",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/sda1",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2020,
+                                        "month": 6,
+                                        "day": 10,
+                                        "hour": 14,
+                                        "minute": 55,
+                                        "second": 18,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-00000000000000000"
+                                }
+                            }
+                        ],
+                        "ClientToken": "00000000-0000-0000-0000-000000000000",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "IamInstanceProfile": {
+                            "Arn": "arn:aws:iam::000000000000:instance-profile/TestRole",
+                            "Id": "AAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2020,
+                                        "month": 6,
+                                        "day": 10,
+                                        "hour": 14,
+                                        "minute": 55,
+                                        "second": 18,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-00000000000000000",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached"
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "TestSG",
+                                        "GroupId": "sg-00000000000000000"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "00:00:00:00:00:00",
+                                "NetworkInterfaceId": "eni-00000000000000000",
+                                "OwnerId": "000000000000",
+                                "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                                "PrivateIpAddress": "0.0.0.0",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                                        "PrivateIpAddress": "0.0.0.0"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-00000000",
+                                "VpcId": "vpc-00000000",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/sda1",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "TestSG",
+                                "GroupId": "sg-00000000000000000"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 2
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled"
+                        }
+                    }
+                ],
+                "OwnerId": "000000000000",
+                "RequesterId": "000000000000",
+                "ReservationId": "r-00000000000000000"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "5ab09f3f-536a-4c65-a966-808aed786faf",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "5ab09f3f-536a-4c65-a966-808aed786faf",
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "accept-encoding",
+                "date": "Wed, 10 Jun 2020 15:13:17 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_ec2_describe/ec2.DescribeInstances_3.json
+++ b/tests/test_data/test_monitor_ec2_describe/ec2.DescribeInstances_3.json
@@ -1,0 +1,92 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-00000000000000000",
+                        "InstanceId": "i-00000000000000000",
+                        "InstanceType": "t3.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2020,
+                            "month": 6,
+                            "day": 10,
+                            "hour": 14,
+                            "minute": 55,
+                            "second": 18,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "enabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2020-06-10 15:13:17 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "00000000-0000-0000-0000-000000000000",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/sda1",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 2
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled"
+                        }
+                    }
+                ],
+                "OwnerId": "000000000000",
+                "RequesterId": "000000000000",
+                "ReservationId": "r-00000000000000000"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "b3af4700-3e52-4910-be53-58a10f503615",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b3af4700-3e52-4910-be53-58a10f503615",
+                "content-type": "text/xml;charset=UTF-8",
+                "content-length": "4105",
+                "vary": "accept-encoding",
+                "date": "Wed, 10 Jun 2020 15:14:39 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_ec2_describe/ec2.TerminateInstances_1.json
+++ b/tests/test_data/test_monitor_ec2_describe/ec2.TerminateInstances_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "TerminatingInstances": [
+            {
+                "CurrentState": {
+                    "Code": 32,
+                    "Name": "shutting-down"
+                },
+                "InstanceId": "i-00000000000000000",
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "ee87d483-f178-4add-98bc-35d9c319a25a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ee87d483-f178-4add-98bc-35d9c319a25a",
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "accept-encoding",
+                "date": "Wed, 10 Jun 2020 15:13:17 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_ec2_state/ec2.DescribeInstances_1.json
+++ b/tests/test_data/test_monitor_ec2_state/ec2.DescribeInstances_1.json
@@ -1,0 +1,164 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-00000000000000000",
+                        "InstanceId": "i-00000000000000000",
+                        "InstanceType": "t3.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2020,
+                            "month": 6,
+                            "day": 10,
+                            "hour": 14,
+                            "minute": 42,
+                            "second": 26,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "enabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                        "PrivateIpAddress": "0.0.0.0",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-00000000",
+                        "VpcId": "vpc-00000000",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/sda1",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2020,
+                                        "month": 6,
+                                        "day": 10,
+                                        "hour": 14,
+                                        "minute": 42,
+                                        "second": 27,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-00000000000000000"
+                                }
+                            }
+                        ],
+                        "ClientToken": "00000000-0000-0000-0000-000000000000",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "IamInstanceProfile": {
+                            "Arn": "arn:aws:iam::000000000000:instance-profile/TestRole",
+                            "Id": "AAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2020,
+                                        "month": 6,
+                                        "day": 10,
+                                        "hour": 14,
+                                        "minute": 42,
+                                        "second": 26,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-00000000000000000",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached"
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "TestSG",
+                                        "GroupId": "sg-00000000000000000"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "00:00:00:00:00:00",
+                                "NetworkInterfaceId": "eni-00000000000000000",
+                                "OwnerId": "000000000000",
+                                "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                                "PrivateIpAddress": "0.0.0.0",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                                        "PrivateIpAddress": "0.0.0.0"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-00000000",
+                                "VpcId": "vpc-00000000",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/sda1",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "TestSG",
+                                "GroupId": "sg-00000000000000000"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Tags": [],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 2
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled"
+                        }
+                    }
+                ],
+                "OwnerId": "000000000000",
+                "RequesterId": "000000000000",
+                "ReservationId": "r-00000000000000000"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "fbbb0883-7f89-4efd-bac1-ea1204d60fb7",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "fbbb0883-7f89-4efd-bac1-ea1204d60fb7",
+                "content-type": "text/xml;charset=UTF-8",
+                "content-length": "8139",
+                "vary": "accept-encoding",
+                "date": "Wed, 10 Jun 2020 14:53:44 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_ec2_state/ec2.DescribeInstances_2.json
+++ b/tests/test_data/test_monitor_ec2_state/ec2.DescribeInstances_2.json
@@ -1,0 +1,92 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-00000000000000000",
+                        "InstanceId": "i-00000000000000000",
+                        "InstanceType": "t3.micro",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2020,
+                            "month": 6,
+                            "day": 10,
+                            "hour": 14,
+                            "minute": 42,
+                            "second": 26,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "enabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 48,
+                            "Name": "terminated"
+                        },
+                        "StateTransitionReason": "User initiated (2020-06-10 14:53:45 GMT)",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [],
+                        "ClientToken": "00000000-0000-0000-0000-000000000000",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "NetworkInterfaces": [],
+                        "RootDeviceName": "/dev/sda1",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [],
+                        "StateReason": {
+                            "Code": "Client.UserInitiatedShutdown",
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown"
+                        },
+                        "Tags": [],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 2
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "pending",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled"
+                        }
+                    }
+                ],
+                "OwnerId": "000000000000",
+                "RequesterId": "000000000000",
+                "ReservationId": "r-00000000000000000"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "0ffee018-978b-4cf0-9e88-afcc684c558f",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "0ffee018-978b-4cf0-9e88-afcc684c558f",
+                "content-type": "text/xml;charset=UTF-8",
+                "content-length": "4105",
+                "vary": "accept-encoding",
+                "date": "Wed, 10 Jun 2020 14:54:16 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_ec2_state/ec2.TerminateInstances_1.json
+++ b/tests/test_data/test_monitor_ec2_state/ec2.TerminateInstances_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "TerminatingInstances": [
+            {
+                "CurrentState": {
+                    "Code": 32,
+                    "Name": "shutting-down"
+                },
+                "InstanceId": "i-00000000000000000",
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "f7aae6e4-9340-44b3-b730-3db622e61320",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f7aae6e4-9340-44b3-b730-3db622e61320",
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "accept-encoding",
+                "date": "Wed, 10 Jun 2020 14:53:44 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_all_targets_healthy/ec2.DescribeInstances_1.json
+++ b/tests/test_data/test_monitor_elbv2_all_targets_healthy/ec2.DescribeInstances_1.json
@@ -1,0 +1,169 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-00000000000000000",
+                        "InstanceId": "i-00000000000000001",
+                        "InstanceType": "t3a.large",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2020,
+                            "month": 6,
+                            "day": 2,
+                            "hour": 14,
+                            "minute": 53,
+                            "second": 49,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "enabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1c",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                        "PrivateIpAddress": "0.0.0.0",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-00000000",
+                        "VpcId": "vpc-00000000",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/sda1",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2020,
+                                        "month": 6,
+                                        "day": 2,
+                                        "hour": 14,
+                                        "minute": 53,
+                                        "second": 50,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-00000000000000000"
+                                }
+                            }
+                        ],
+                        "ClientToken": "00000000-0000-0000-0000-000000000000",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "IamInstanceProfile": {
+                            "Arn": "arn:aws:iam::000000000000:instance-profile/Generic-Instance-Role",
+                            "Id": "AAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2020,
+                                        "month": 6,
+                                        "day": 2,
+                                        "hour": 14,
+                                        "minute": 53,
+                                        "second": 49,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-00000000000000000",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached"
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "Generic-Security-Group",
+                                        "GroupId": "sg-00000000000000000"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "00:00:00:00:00:00",
+                                "NetworkInterfaceId": "eni-00000000000000000",
+                                "OwnerId": "000000000000",
+                                "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                                "PrivateIpAddress": "0.0.0.0",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                                        "PrivateIpAddress": "0.0.0.0"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-00000000",
+                                "VpcId": "vpc-00000000",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/sda1",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "Generic-Security-Group",
+                                "GroupId": "sg-00000000000000000"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "Tags": [
+                            {
+                                "Key": "Name",
+                                "Value": "Generic_Instance"
+                            }
+                        ],
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 2
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled"
+                        }
+                    }
+                ],
+                "OwnerId": "000000000000",
+                "RequesterId": "000000000000",
+                "ReservationId": "r-00000000000000000"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "1cc08c92-4c32-4b56-bfd3-dd0b1d9fd109",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "1cc08c92-4c32-4b56-bfd3-dd0b1d9fd109",
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "accept-encoding",
+                "date": "Tue, 02 Jun 2020 16:30:14 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_all_targets_healthy/ec2.StopInstances_1.json
+++ b/tests/test_data/test_monitor_elbv2_all_targets_healthy/ec2.StopInstances_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200,
+    "data": {
+        "StoppingInstances": [
+            {
+                "CurrentState": {
+                    "Code": 64,
+                    "Name": "stopping"
+                },
+                "InstanceId": "i-00000000000000001",
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "7b13dfff-cca1-4425-beb5-e68b25a96a5f",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "7b13dfff-cca1-4425-beb5-e68b25a96a5f",
+                "content-type": "text/xml;charset=UTF-8",
+                "content-length": "579",
+                "date": "Tue, 02 Jun 2020 16:30:15 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetGroups_1.json
+++ b/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetGroups_1.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200,
+    "data": {
+        "TargetGroups": [
+            {
+                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/generic_target_group/0000000000000000",
+                "TargetGroupName": "generic_target_group",
+                "Protocol": "HTTP",
+                "Port": 443,
+                "VpcId": "vpc-00000000",
+                "HealthCheckProtocol": "HTTP",
+                "HealthCheckPort": "traffic-port",
+                "HealthCheckEnabled": true,
+                "HealthCheckIntervalSeconds": 30,
+                "HealthCheckTimeoutSeconds": 5,
+                "HealthyThresholdCount": 2,
+                "UnhealthyThresholdCount": 4,
+                "HealthCheckPath": "/health",
+                "Matcher": {
+                    "HttpCode": "200-299"
+                },
+                "LoadBalancerArns": [
+                    "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/generic_alb/0000000000000000"
+                ],
+                "TargetType": "instance"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "f2310609-7564-499e-80a7-da5ff0da6f5f",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f2310609-7564-499e-80a7-da5ff0da6f5f",
+                "content-type": "text/xml",
+                "content-length": "1441",
+                "date": "Tue, 02 Jun 2020 16:30:16 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetGroups_2.json
+++ b/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetGroups_2.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200,
+    "data": {
+        "TargetGroups": [
+            {
+                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/generic_target_group/0000000000000000",
+                "TargetGroupName": "generic_target_group",
+                "Protocol": "HTTP",
+                "Port": 443,
+                "VpcId": "vpc-00000000",
+                "HealthCheckProtocol": "HTTP",
+                "HealthCheckPort": "traffic-port",
+                "HealthCheckEnabled": true,
+                "HealthCheckIntervalSeconds": 30,
+                "HealthCheckTimeoutSeconds": 5,
+                "HealthyThresholdCount": 2,
+                "UnhealthyThresholdCount": 4,
+                "HealthCheckPath": "/health",
+                "Matcher": {
+                    "HttpCode": "200-299"
+                },
+                "LoadBalancerArns": [
+                    "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/generic_alb/0000000000000000"
+                ],
+                "TargetType": "instance"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "39e53989-780f-4891-81be-05a9c690c262",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "39e53989-780f-4891-81be-05a9c690c262",
+                "content-type": "text/xml",
+                "content-length": "1441",
+                "date": "Tue, 02 Jun 2020 16:30:37 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetGroups_3.json
+++ b/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetGroups_3.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200,
+    "data": {
+        "TargetGroups": [
+            {
+                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/generic_target_group/0000000000000000",
+                "TargetGroupName": "generic_target_group",
+                "Protocol": "HTTP",
+                "Port": 443,
+                "VpcId": "vpc-00000000",
+                "HealthCheckProtocol": "HTTP",
+                "HealthCheckPort": "traffic-port",
+                "HealthCheckEnabled": true,
+                "HealthCheckIntervalSeconds": 30,
+                "HealthCheckTimeoutSeconds": 5,
+                "HealthyThresholdCount": 2,
+                "UnhealthyThresholdCount": 4,
+                "HealthCheckPath": "/health",
+                "Matcher": {
+                    "HttpCode": "200-299"
+                },
+                "LoadBalancerArns": [
+                    "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/generic_alb/0000000000000000"
+                ],
+                "TargetType": "instance"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "ff20286f-dc76-489f-bbce-f3099f55452a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ff20286f-dc76-489f-bbce-f3099f55452a",
+                "content-type": "text/xml",
+                "content-length": "1441",
+                "date": "Tue, 02 Jun 2020 16:30:48 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetHealth_1.json
+++ b/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetHealth_1.json
@@ -1,0 +1,50 @@
+{
+    "status_code": 200,
+    "data": {
+        "TargetHealthDescriptions": [
+            {
+                "Target": {
+                    "Id": "i-00000000000000000",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            },
+            {
+                "Target": {
+                    "Id": "i-00000000000000001",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "unused",
+                    "Reason": "Target.InvalidState",
+                    "Description": "Target is in the stopped state"
+                }
+            },
+            {
+                "Target": {
+                    "Id": "i-00000000000000002",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "37a4a9dd-bc29-4405-b2b9-8b834ed2068d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "37a4a9dd-bc29-4405-b2b9-8b834ed2068d",
+                "content-type": "text/xml",
+                "content-length": "1259",
+                "date": "Tue, 02 Jun 2020 16:30:16 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetHealth_2.json
+++ b/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetHealth_2.json
@@ -1,0 +1,50 @@
+{
+    "status_code": 200,
+    "data": {
+        "TargetHealthDescriptions": [
+            {
+                "Target": {
+                    "Id": "i-00000000000000000",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            },
+            {
+                "Target": {
+                    "Id": "i-00000000000000001",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "draining",
+                    "Reason": "Target.DeregistrationInProgress",
+                    "Description": "Target deregistration is in progress"
+                }
+            },
+            {
+                "Target": {
+                    "Id": "i-00000000000000002",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "02aef754-477f-4eff-ae20-b561cc8bd3e3",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "02aef754-477f-4eff-ae20-b561cc8bd3e3",
+                "content-type": "text/xml",
+                "content-length": "1279",
+                "date": "Tue, 02 Jun 2020 16:30:37 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetHealth_3.json
+++ b/tests/test_data/test_monitor_elbv2_all_targets_healthy/elasticloadbalancing.DescribeTargetHealth_3.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200,
+    "data": {
+        "TargetHealthDescriptions": [
+            {
+                "Target": {
+                    "Id": "i-00000000000000000",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            },
+            {
+                "Target": {
+                    "Id": "i-00000000000000002",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "c189578c-a21d-42a7-b3e9-498b88f2359e",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c189578c-a21d-42a7-b3e9-498b88f2359e",
+                "content-type": "text/xml",
+                "content-length": "884",
+                "date": "Tue, 02 Jun 2020 16:30:48 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_targets_health_count/ec2.DescribeInstances_1.json
+++ b/tests/test_data/test_monitor_elbv2_targets_health_count/ec2.DescribeInstances_1.json
@@ -1,0 +1,163 @@
+{
+    "status_code": 200,
+    "data": {
+        "Reservations": [
+            {
+                "Groups": [],
+                "Instances": [
+                    {
+                        "AmiLaunchIndex": 0,
+                        "ImageId": "ami-00000000000000000",
+                        "InstanceId": "i-00000000000000000",
+                        "InstanceType": "t3a.large",
+                        "LaunchTime": {
+                            "__class__": "datetime",
+                            "year": 2020,
+                            "month": 6,
+                            "day": 2,
+                            "hour": 14,
+                            "minute": 0,
+                            "second": 15,
+                            "microsecond": 0
+                        },
+                        "Monitoring": {
+                            "State": "enabled"
+                        },
+                        "Placement": {
+                            "AvailabilityZone": "us-east-1a",
+                            "GroupName": "",
+                            "Tenancy": "default"
+                        },
+                        "PrivateDnsName": "ip-0-0-0-0.ec2.internal",
+                        "PrivateIpAddress": "0.0.0.0",
+                        "ProductCodes": [],
+                        "PublicDnsName": "",
+                        "State": {
+                            "Code": 16,
+                            "Name": "running"
+                        },
+                        "StateTransitionReason": "",
+                        "SubnetId": "subnet-00000000",
+                        "VpcId": "vpc-00000000",
+                        "Architecture": "x86_64",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/sda1",
+                                "Ebs": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2020,
+                                        "month": 6,
+                                        "day": 2,
+                                        "hour": 14,
+                                        "minute": 0,
+                                        "second": 15,
+                                        "microsecond": 0
+                                    },
+                                    "DeleteOnTermination": true,
+                                    "Status": "attached",
+                                    "VolumeId": "vol-00000000000000000"
+                                }
+                            }
+                        ],
+                        "ClientToken": "00000000-0000-0000-0000-000000000000",
+                        "EbsOptimized": false,
+                        "EnaSupport": true,
+                        "Hypervisor": "xen",
+                        "IamInstanceProfile": {
+                            "Arn": "arn:aws:iam::000000000000:instance-profile/InstanceRole",
+                            "Id": "AAAAAAAAAAAAAAAAAAAAA"
+                        },
+                        "NetworkInterfaces": [
+                            {
+                                "Attachment": {
+                                    "AttachTime": {
+                                        "__class__": "datetime",
+                                        "year": 2020,
+                                        "month": 6,
+                                        "day": 2,
+                                        "hour": 14,
+                                        "minute": 0,
+                                        "second": 15,
+                                        "microsecond": 0
+                                    },
+                                    "AttachmentId": "eni-attach-00000000000000000",
+                                    "DeleteOnTermination": true,
+                                    "DeviceIndex": 0,
+                                    "Status": "attached"
+                                },
+                                "Description": "",
+                                "Groups": [
+                                    {
+                                        "GroupName": "SecurityGroup",
+                                        "GroupId": "sg-00000000000000000"
+                                    }
+                                ],
+                                "Ipv6Addresses": [],
+                                "MacAddress": "0a:8b:48:80:96:7d",
+                                "NetworkInterfaceId": "eni-00000000000000000",
+                                "OwnerId": "000000000000",
+                                "PrivateDnsName": "ip-0-0-0-0.ecs.internal",
+                                "PrivateIpAddress": "0.0.0.0",
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true,
+                                        "PrivateDnsName": "ip-0-0-0-0.ecs.internal",
+                                        "PrivateIpAddress": "0.0.0.0"
+                                    }
+                                ],
+                                "SourceDestCheck": true,
+                                "Status": "in-use",
+                                "SubnetId": "subnet-00000000",
+                                "VpcId": "vpc-00000000",
+                                "InterfaceType": "interface"
+                            }
+                        ],
+                        "RootDeviceName": "/dev/sda1",
+                        "RootDeviceType": "ebs",
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "SecurityGroup",
+                                "GroupId": "sg-00000000000000000"
+                            }
+                        ],
+                        "SourceDestCheck": true,
+                        "VirtualizationType": "hvm",
+                        "CpuOptions": {
+                            "CoreCount": 1,
+                            "ThreadsPerCore": 2
+                        },
+                        "CapacityReservationSpecification": {
+                            "CapacityReservationPreference": "open"
+                        },
+                        "HibernationOptions": {
+                            "Configured": false
+                        },
+                        "MetadataOptions": {
+                            "State": "applied",
+                            "HttpTokens": "optional",
+                            "HttpPutResponseHopLimit": 1,
+                            "HttpEndpoint": "enabled"
+                        }
+                    }
+                ],
+                "OwnerId": "000000000000",
+                "RequesterId": "000000000000",
+                "ReservationId": "r-00000000000000000"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "1f05e670-e83a-4158-a1f1-165b27c3834a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "1f05e670-e83a-4158-a1f1-165b27c3834a",
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "accept-encoding",
+                "date": "Tue, 02 Jun 2020 15:07:52 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_targets_health_count/ec2.TerminateInstances_1.json
+++ b/tests/test_data/test_monitor_elbv2_targets_health_count/ec2.TerminateInstances_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "TerminatingInstances": [
+            {
+                "CurrentState": {
+                    "Code": 32,
+                    "Name": "shutting-down"
+                },
+                "InstanceId": "i-00000000000000000",
+                "PreviousState": {
+                    "Code": 16,
+                    "Name": "running"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "c8891200-23f2-44ad-9e57-3842775a0312",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c8891200-23f2-44ad-9e57-3842775a0312",
+                "content-type": "text/xml;charset=UTF-8",
+                "transfer-encoding": "chunked",
+                "vary": "accept-encoding",
+                "date": "Tue, 02 Jun 2020 15:07:52 GMT",
+                "server": "AmazonEC2"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_targets_health_count/elasticloadbalancing.DescribeTargetGroups_1.json
+++ b/tests/test_data/test_monitor_elbv2_targets_health_count/elasticloadbalancing.DescribeTargetGroups_1.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200,
+    "data": {
+        "TargetGroups": [
+            {
+                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/generic-tg/0000000000000000",
+                "TargetGroupName": "generic-tg",
+                "Protocol": "HTTP",
+                "Port": 443,
+                "VpcId": "vpc-00000000",
+                "HealthCheckProtocol": "HTTP",
+                "HealthCheckPort": "traffic-port",
+                "HealthCheckEnabled": true,
+                "HealthCheckIntervalSeconds": 30,
+                "HealthCheckTimeoutSeconds": 5,
+                "HealthyThresholdCount": 2,
+                "UnhealthyThresholdCount": 4,
+                "HealthCheckPath": "/health",
+                "Matcher": {
+                    "HttpCode": "200-299"
+                },
+                "LoadBalancerArns": [
+                    "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/generic-alb/0000000000000000"
+                ],
+                "TargetType": "instance"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "efd907c3-bb93-4529-bdbd-0c9ffe485031",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "efd907c3-bb93-4529-bdbd-0c9ffe485031",
+                "content-type": "text/xml",
+                "content-length": "1441",
+                "date": "Tue, 02 Jun 2020 15:07:52 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_targets_health_count/elasticloadbalancing.DescribeTargetGroups_2.json
+++ b/tests/test_data/test_monitor_elbv2_targets_health_count/elasticloadbalancing.DescribeTargetGroups_2.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200,
+    "data": {
+        "TargetGroups": [
+            {
+                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/generic-tg/0000000000000000",
+                "TargetGroupName": "generic-tg",
+                "Protocol": "HTTP",
+                "Port": 443,
+                "VpcId": "vpc-00000000",
+                "HealthCheckProtocol": "HTTP",
+                "HealthCheckPort": "traffic-port",
+                "HealthCheckEnabled": true,
+                "HealthCheckIntervalSeconds": 30,
+                "HealthCheckTimeoutSeconds": 5,
+                "HealthyThresholdCount": 2,
+                "UnhealthyThresholdCount": 4,
+                "HealthCheckPath": "/health",
+                "Matcher": {
+                    "HttpCode": "200-299"
+                },
+                "LoadBalancerArns": [
+                    "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/generic-alb/0000000000000000"
+                ],
+                "TargetType": "instance"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "16d594c3-0593-43b7-a53a-a72e184b112c",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "16d594c3-0593-43b7-a53a-a72e184b112c",
+                "content-type": "text/xml",
+                "content-length": "1441",
+                "date": "Tue, 02 Jun 2020 15:22:38 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_targets_health_count/elasticloadbalancing.DescribeTargetHealth_1.json
+++ b/tests/test_data/test_monitor_elbv2_targets_health_count/elasticloadbalancing.DescribeTargetHealth_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200,
+    "data": {
+        "TargetHealthDescriptions": [
+            {
+                "Target": {
+                    "Id": "i-00000000000000001",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            },
+            {
+                "Target": {
+                    "Id": "i-00000000000000002",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "10f7d3b7-ec24-404f-acba-cd17c19b2f48",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "10f7d3b7-ec24-404f-acba-cd17c19b2f48",
+                "content-type": "text/xml",
+                "content-length": "884",
+                "date": "Tue, 02 Jun 2020 15:07:52 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_data/test_monitor_elbv2_targets_health_count/elasticloadbalancing.DescribeTargetHealth_2.json
+++ b/tests/test_data/test_monitor_elbv2_targets_health_count/elasticloadbalancing.DescribeTargetHealth_2.json
@@ -1,0 +1,48 @@
+{
+    "status_code": 200,
+    "data": {
+        "TargetHealthDescriptions": [
+            {
+                "Target": {
+                    "Id": "i-00000000000000003",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            },
+            {
+                "Target": {
+                    "Id": "i-00000000000000001",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            },
+            {
+                "Target": {
+                    "Id": "i-00000000000000002",
+                    "Port": 8080
+                },
+                "HealthCheckPort": "8080",
+                "TargetHealth": {
+                    "State": "healthy"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "25033593-0f25-471d-a5a3-16942df84acc",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "25033593-0f25-471d-a5a3-16942df84acc",
+                "content-type": "text/xml",
+                "content-length": "1145",
+                "date": "Tue, 02 Jun 2020 15:22:38 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/zpharmacy.py
+++ b/tests/zpharmacy.py
@@ -1,0 +1,139 @@
+#
+import os
+import shutil
+import unittest
+from datetime import datetime, timedelta, tzinfo
+
+import boto3
+import placebo
+from botocore.response import StreamingBody
+from six import StringIO
+
+
+###########################################################################
+# BEGIN PLACEBO MONKEY PATCH
+#
+# Placebo is effectively abandoned upstream, since mitch went back to work at
+# AWS, irony...
+# These monkeypatch patches represent fixes on trunk of that repo that have
+# not been released into an extant version, we carry them here. We can drop
+# this when this issue is resolved
+#
+# https://github.com/garnaat/placebo/issues/63
+#
+# License - Apache 2.0
+# Copyright (c) 2015 Mitch Garnaat
+
+
+class UTC(tzinfo):
+    """UTC"""
+
+    def utcoffset(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return timedelta(0)
+
+
+utc = UTC()
+
+
+def deserialize(obj):
+    """Convert JSON dicts back into objects."""
+    # Be careful of shallow copy here
+    target = dict(obj)
+    class_name = None
+    if "__class__" in target:
+        class_name = target.pop("__class__")
+    if "__module__" in obj:
+        obj.pop("__module__")
+    # Use getattr(module, class_name) for custom types if needed
+    if class_name == "datetime":
+        return datetime(tzinfo=utc, **target)
+    if class_name == "StreamingBody":
+        return StringIO(target["body"])
+    # Return unrecognized structures as-is
+    return obj
+
+
+def serialize(obj):
+    """Convert objects into JSON structures."""
+    # Record class and module information for deserialization
+    result = {"__class__": obj.__class__.__name__}
+    try:
+        result["__module__"] = obj.__module__
+    except AttributeError:
+        pass
+    # Convert objects to dictionary representation based on type
+    if isinstance(obj, datetime):
+        result["year"] = obj.year
+        result["month"] = obj.month
+        result["day"] = obj.day
+        result["hour"] = obj.hour
+        result["minute"] = obj.minute
+        result["second"] = obj.second
+        result["microsecond"] = obj.microsecond
+        return result
+    if isinstance(obj, StreamingBody):
+        result["body"] = obj.read()
+        obj._raw_stream = StringIO(result["body"])
+        obj._amount_read = 0
+        return result
+    # Raise a TypeError if the object isn't recognized
+    raise TypeError("Type not serializable")
+
+
+placebo.pill.serialize = serialize
+placebo.pill.deserialize = deserialize
+
+# END PLACEBO MONKEY
+##########################################################################
+
+
+class Pharmacy(unittest.TestCase):
+    placebo_dir = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "test_data")
+    recording = False
+
+    def default_session(self):
+        if os.environ.get('AWS_PROFILE'):
+            boto3.setup_default_session(
+                profile_name=os.environ.get('AWS_PROFILE'),
+                region_name=os.environ.get('AWS_DEFAULT_REGION'))
+        else:
+            boto3.setup_default_session(
+                aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID') or 'foo',
+                aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY') or 'bar',
+                region_name=os.environ.get('AWS_DEFAULT_REGION'))
+        session = boto3.DEFAULT_SESSION
+        return session
+
+    def cleanUp(self):
+        pass
+
+    def record(self, test_case, region='us-east-1'):
+        self.recording = True
+        test_dir = os.path.join(self.placebo_dir, test_case)
+        if os.path.exists(test_dir):
+            shutil.rmtree(test_dir)
+        os.makedirs(test_dir)
+
+        session = boto3.Session(region_name=region)
+        pill = placebo.attach(session, data_path=test_dir, debug=True)
+        pill.record()
+        self.addCleanup(self.cleanUp)
+        return session
+
+    def replay(self, test_case, region='us-east-1'):
+        test_dir = os.path.join(self.placebo_dir, test_case)
+        if not os.path.exists(test_dir):
+            raise RuntimeError('Invalid test directory: %s' % test_dir)
+
+        session = boto3.Session(region_name=region)
+        pill = placebo.attach(session, data_path=test_dir)
+        pill.playback()
+        self.addCleanup(self.cleanUp)
+        return session


### PR DESCRIPTION
- adding `monitor` as probe to ecs, elbv2, & ecs
- monitor will extend a probes usage to run and detect when a disruption has occurred based on given parameters, mark the time, and when a given "recovery" objective has been reached, and mark the time.
- when defining a monitor, it should be marked to run in the background to allow for other actions to run.

Signed-off-by: Joshua Root <joshua.root@capitalone.com>