### PR TITLE
adding probes & actions for Route53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.15.1...HEAD
 
+### Added
+- adding route53 probes & actions
+
+### Changed
+
 ## [0.15.1][]
 [0.15.1]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.15.0...0.15.1
 

--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -242,4 +242,6 @@ def load_exported_activities() -> List[DiscoveredActivities]:
     activities.extend(discover_probes('chaosaws.elasticache.probes'))
     activities.extend(discover_actions("chaosaws.emr.actions"))
     activities.extend(discover_probes('chaosaws.emr.probes'))
+    activities.extend(discover_actions("chaosaws.route53.actions"))
+    activities.extend(discover_probes('chaosaws.route53.probes'))
     return activities

--- a/chaosaws/route53/actions.py
+++ b/chaosaws/route53/actions.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from botocore.exceptions import ClientError
+from chaoslib.exceptions import FailedActivity
+from chaoslib.types import Configuration, Secrets
+from logzero import logger
+
+from chaosaws import aws_client
+from chaosaws.types import AWSResponse
+
+__all__ = ['associate_vpc_with_zone', 'disassociate_vpc_from_zone']
+
+
+def associate_vpc_with_zone(zone_id: str,
+                            vpc_id: str,
+                            vpc_region: str,
+                            comment: str = None,
+                            configuration: Configuration = None,
+                            secrets: Secrets = None) -> AWSResponse:
+    """Associate a VPC with a private hosted zone
+
+    :param zone_id: The hosted zone id
+    :param vpc_id: The id of the vpc
+    :param vpc_region: The region of the vpc
+    :param configuration: access values used by actions/probes
+    :param comment: a comment regarding the request
+    :param secrets: values that need to be passed on to actions/probes
+    :returns: Dict[str, Any]
+    """
+    client = aws_client('route53', configuration, secrets)
+    params = {
+        'HostedZoneId': zone_id,
+        'VPC': {
+            'VPCId': vpc_id,
+            'VPCRegion': vpc_region
+        },
+        **({'Comment': comment} if comment else {})
+    }
+    try:
+        return client.associate_vpc_with_hosted_zone(**params)
+    except ClientError as e:
+        logger.exception(e.response['Error']['Message'])
+        raise FailedActivity(e.response['Error']['Message'])
+
+
+def disassociate_vpc_from_zone(zone_id: str,
+                               vpc_id: str,
+                               vpc_region: str,
+                               comment: str = None,
+                               configuration: Configuration = None,
+                               secrets: Secrets = None) -> AWSResponse:
+    """Remove an association between a VPC and a private hosted zone
+
+    :param zone_id: The hosted zone id
+    :param vpc_id: The id of the vpc
+    :param vpc_region: The region of the vpc
+    :param comment: A note regarding the disassociation request
+    :param configuration: access values used by actions/probes
+    :param secrets: values that need to be passed on to actions/probes
+    :returns: Dict[str, Any]
+    """
+    client = aws_client('route53', configuration, secrets)
+    params = {
+        'HostedZoneId': zone_id,
+        'VPC': {
+            'VPCId': vpc_id,
+            'VPCRegion': vpc_region
+        },
+        **({'Comment': comment} if comment else {})
+    }
+    try:
+        return client.disassociate_vpc_from_hosted_zone(**params)
+    except ClientError as e:
+        logger.exception(e.response['Error']['Message'])
+        raise FailedActivity(e.response['Error']['Message'])

--- a/chaosaws/route53/probes.py
+++ b/chaosaws/route53/probes.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from botocore.exceptions import ClientError
+from chaoslib.exceptions import FailedActivity
+from chaoslib.types import Configuration, Secrets
+from logzero import logger
+
+from chaosaws import aws_client
+from chaosaws.route53.shared import hosted_zone_by_id
+from chaosaws.types import AWSResponse
+
+_all__ = ['get_hosted_zone', 'get_health_check_status', 'get_dns_answer']
+
+
+def get_hosted_zone(zone_id: str,
+                    configuration: Configuration = None,
+                    secrets: Secrets = None) -> AWSResponse:
+    """Pull information regarding a specific zone id
+
+    :param zone_id: The route53 zone id
+    :param configuration: access values used by actions/probes
+    :param secrets: values that need to be passed on to actions/probes
+    :returns: Dict[str, Any]
+    """
+    client = aws_client('route53', configuration, secrets)
+    response = hosted_zone_by_id(client, zone_id)
+    if not response['HostedZone']:
+        raise FailedActivity('Hosted Zone %s not found.' % zone_id)
+    return response
+
+
+def get_health_check_status(check_id: str,
+                            configuration: Configuration = None,
+                            secrets: Secrets = None) -> AWSResponse:
+    """Get the status of the specified health check
+
+    :param check_id: The health check id
+    :param configuration: access values used by actions/probes
+    :param secrets: values that need to be passed on to actions/probes
+    :returns: Dict[str, Any]
+    """
+    client = aws_client('route53', configuration, secrets)
+    try:
+        response = client.get_health_check_status(HealthCheckId=check_id)
+        if not response.get('HealthCheckObservations'):
+            raise FailedActivity('No results found for %s' % check_id)
+        return response
+    except ClientError as e:
+        logger.exception(e.response['Error']['Message'])
+        raise FailedActivity(e.response['Error']['Message'])
+
+
+def get_dns_answer(zone_id: str,
+                   record_name: str,
+                   record_type: str,
+                   configuration: Configuration = None,
+                   secrets: Secrets = None) -> AWSResponse:
+    """Get the DNS response for the specified record name & type
+
+    :param zone_id: The route53 zone id
+    :param record_name: The name of the record to get a response for
+    :param record_type: The type of the record set
+    :param configuration: access values used by actions/probes
+    :param secrets: values that need to be passed on to actions/probes
+    :returns: Dict[str, Any]
+    """
+    client = aws_client('route53', configuration, secrets)
+    try:
+        return client.test_dns_answer(
+            HostedZoneId=zone_id,
+            RecordName=record_name,
+            RecordType=record_type)
+    except ClientError as e:
+        logger.exception(e.response['Error']['Message'])
+        raise FailedActivity(e.response['Error']['Message'])

--- a/chaosaws/route53/shared.py
+++ b/chaosaws/route53/shared.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import boto3
+from chaosaws.types import AWSResponse
+from logzero import logger
+from botocore.exceptions import ClientError
+
+
+def hosted_zone_by_id(client: boto3.client, zone_id: str) -> AWSResponse:
+    """Shared function for route53 actions/probes that will get a hosted zone
+
+    :param client: A boto3 session client for route53
+    :param zone_id: A route53 zone id
+    :returns: Dict[str, Any]
+    """
+    try:
+        return client.get_hosted_zone(Id=zone_id)
+    except ClientError as e:
+        logger.exception(e.response['Error']['Message'])
+        return {'HostedZone': []}

--- a/tests/route53/data/associate_vpc_1.json
+++ b/tests/route53/data/associate_vpc_1.json
@@ -1,0 +1,7 @@
+{
+  "ChangeInfo": {
+    "Id": "11111111-2222-3333-4444-555555555555",
+    "Status": "Pending",
+    "Comment": "CTK Disassociate"
+  }
+}

--- a/tests/route53/data/disassociate_vpc_1.json
+++ b/tests/route53/data/disassociate_vpc_1.json
@@ -1,0 +1,7 @@
+{
+  "ChangeInfo": {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "Status": "Pending",
+    "Comment": "CTK Disassociate"
+  }
+}

--- a/tests/route53/data/get_health_check_status_1.json
+++ b/tests/route53/data/get_health_check_status_1.json
@@ -1,0 +1,20 @@
+{
+  "HealthCheckObservations": [
+    {
+      "Region": "us-west-1",
+      "IPAddress": "0.0.0.0",
+      "StatusReport": {
+        "Status": "Success: 1 datapoint was not less than the threshold (0.0).",
+        "CheckedTime": "2020-08-31T14:23:08.060000+00:00"
+      }
+    },
+    {
+      "Region": "us-west-2",
+      "IPAddress": "0.0.0.0",
+      "StatusReport": {
+        "Status": "Success: 1 datapoint was not less than the threshold (0.0).",
+        "CheckedTime": "2020-08-31T14:23:13.566000+00:00"
+      }
+    }
+  ]
+}

--- a/tests/route53/data/get_hosted_zone_1.json
+++ b/tests/route53/data/get_hosted_zone_1.json
@@ -1,0 +1,20 @@
+{
+  "HostedZone": {
+    "Id": "/hostedzone/AAAAAAAAAAAAA",
+    "Name": "aws.testrecord.com.",
+    "CallerReference": "PublicInt-myExtern-AAAAAAAAAAAAA",
+    "Config": {
+      "Comment": "External sub-domain",
+      "PrivateZone": false
+    },
+    "ResourceRecordSetCount": 1
+  },
+  "DelegationSet": {
+    "NameServers": [
+      "ns-0000.awsdns-00.co.uk",
+      "ns-000.awsdns-00.net",
+      "ns-000.awsdns-00.com",
+      "ns-0000.awsdns-00.org"
+    ]
+  }
+}

--- a/tests/route53/data/test_dns_answer_1.json
+++ b/tests/route53/data/test_dns_answer_1.json
@@ -1,0 +1,12 @@
+{
+  "Nameserver": "ns-0000.awsdns-00.co.uk",
+  "RecordName": "aws.testrecord.com",
+  "RecordType": "A",
+  "RecordData": [
+    "0.0.0.0",
+    "0.0.0.1",
+    "0.0.0.2"
+  ],
+  "ResponseCode": "NOERROR",
+  "Protocol": "UDP"
+}

--- a/tests/route53/test_route53_actions.py
+++ b/tests/route53/test_route53_actions.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from chaoslib.exceptions import FailedActivity
+
+from chaosaws.route53.actions import (
+    associate_vpc_with_zone, disassociate_vpc_from_zone)
+
+module_path = os.path.dirname(os.path.abspath(__file__))
+
+
+def read_in_data(filename):
+    with open(os.path.join(module_path, 'data', filename), 'r') as fh:
+        data = json.loads(fh.read())
+    return data
+
+
+def mocked_client_error(op: str):
+    return ClientError(
+        operation_name=op,
+        error_response={
+            'Error': {
+                'Message': 'Test Error',
+                'Code': 'Test Error'
+            }
+        }
+    )
+
+
+@patch('chaosaws.route53.actions.aws_client', autospec=True)
+def test_associate_vpc_with_zone(m_client):
+    mock_response = read_in_data('associate_vpc_1.json')
+    client = MagicMock()
+    m_client.return_value = client
+    client.associate_vpc_with_hosted_zone.return_value = mock_response
+
+    response = associate_vpc_with_zone(
+        zone_id='AAAAAAAAAAAAA',
+        vpc_id='vpc-00000000',
+        vpc_region='us-east-1',
+        comment='CTK Associate'
+    )
+
+    client.associate_vpc_with_hosted_zone.assert_called_with(
+        HostedZoneId='AAAAAAAAAAAAA',
+        VPC={
+            'VPCId': 'vpc-00000000',
+            'VPCRegion': 'us-east-1'
+        },
+        Comment='CTK Associate'
+    )
+
+    assert response['ChangeInfo']['Status'] == 'Pending'
+
+
+@patch('chaosaws.route53.actions.aws_client', autospec=True)
+def test_associate_vpc_with_zone_exception(m_client):
+    client = MagicMock()
+    m_client.return_value = client
+    client.associate_vpc_with_hosted_zone.side_effect = mocked_client_error(
+        'associate_vpc_with_hosted_zone')
+
+    with pytest.raises(FailedActivity) as e:
+        associate_vpc_with_zone(
+            zone_id='1234567890123',
+            vpc_id='vpc-00000000',
+            vpc_region='us-east-1'
+        )
+    assert 'Test Error' in str(e)
+
+
+@patch('chaosaws.route53.actions.aws_client', autospec=True)
+def test_disassociate_vpc_from_zone(m_client):
+    mock_response = read_in_data('disassociate_vpc_1.json')
+    client = MagicMock()
+    m_client.return_value = client
+    client.disassociate_vpc_from_hosted_zone.return_value = mock_response
+
+    response = disassociate_vpc_from_zone(
+        zone_id='AAAAAAAAAAAAA',
+        vpc_id='vpc-00000000',
+        vpc_region='us-east-1',
+        comment='CTK Disassociate'
+    )
+
+    client.disassociate_vpc_from_hosted_zone.assert_called_with(
+        HostedZoneId='AAAAAAAAAAAAA',
+        VPC={
+            'VPCId': 'vpc-00000000',
+            'VPCRegion': 'us-east-1'
+        },
+        Comment='CTK Disassociate'
+    )
+
+    assert response['ChangeInfo']['Status'] == 'Pending'
+
+
+@patch('chaosaws.route53.actions.aws_client', autospec=True)
+def test_disassociate_vpc_with_zone_exception(m_client):
+    client = MagicMock()
+    m_client.return_value = client
+    client.disassociate_vpc_from_hosted_zone.side_effect = mocked_client_error(
+        'disassociate_vpc_from_hosted_zone')
+
+    with pytest.raises(FailedActivity) as e:
+        disassociate_vpc_from_zone(
+            zone_id='1234567890123',
+            vpc_id='vpc-00000000',
+            vpc_region='us-east-1'
+        )
+    assert 'Test Error' in str(e)

--- a/tests/route53/test_route53_probes.py
+++ b/tests/route53/test_route53_probes.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from chaoslib.exceptions import FailedActivity
+
+from chaosaws.route53.probes import (
+    get_hosted_zone, get_dns_answer, get_health_check_status)
+
+module_path = os.path.dirname(os.path.abspath(__file__))
+
+
+def read_in_data(filename):
+    with open(os.path.join(module_path, 'data', filename), 'r') as fh:
+        data = json.loads(fh.read())
+    return data
+
+
+@patch('chaosaws.route53.probes.aws_client', autospec=True)
+def test_get_hosted_zone(m_client):
+    mock_response = read_in_data('get_hosted_zone_1.json')
+    client = MagicMock()
+    m_client.return_value = client
+    client.get_hosted_zone.return_value = mock_response
+
+    response = get_hosted_zone(zone_id='AAAAAAAAAAAAA')
+    client.get_hosted_zone.assert_called_with(Id='AAAAAAAAAAAAA')
+    assert response['HostedZone']['Name'] == 'aws.testrecord.com.'
+
+
+@patch('chaosaws.route53.probes.aws_client', autospec=True)
+def test_get_hosted_zone_not_found(m_client):
+    mock_response = ClientError(
+        operation_name='get_hosted_zone',
+        error_response={'Error': {'Message': 'Test Error',
+                                  'Code': 'NoSuchHostedZone'}})
+    client = MagicMock()
+    m_client.return_value = client
+    client.get_hosted_zone.side_effect = mock_response
+
+    with pytest.raises(FailedActivity) as e:
+        get_hosted_zone(zone_id='BBBBBBBBBBBBB')
+    assert 'Hosted Zone BBBBBBBBBBBBB not found.' in str(e)
+
+
+@patch('chaosaws.route53.probes.aws_client', autospec=True)
+def test_get_health_check_status(m_client):
+    mock_response = read_in_data('get_health_check_status_1.json')
+    client = MagicMock()
+    m_client.return_value = client
+    client.get_health_check_status.return_value = mock_response
+
+    response = get_health_check_status(
+        check_id='00000000-0000-0000-0000-000000000000')
+
+    client.get_health_check_status.assert_called_with(
+        HealthCheckId='00000000-0000-0000-0000-000000000000')
+    assert len(response['HealthCheckObservations']) == 2
+
+
+@patch('chaosaws.route53.probes.aws_client', autospec=True)
+def test_get_health_check_status_not_found(m_client):
+    mock_response = ClientError(
+        operation_name='get_hosted_zone',
+        error_response={'Error': {'Message': 'Test Error',
+                                  'Code': 'NoSuchHealthCheck'}})
+    client = MagicMock()
+    m_client.return_value = client
+    client.get_health_check_status.side_effect = mock_response
+
+    with pytest.raises(FailedActivity) as e:
+        get_health_check_status(
+            check_id='00000000-1111-1111-1111-000000000000')
+    assert 'Test Error' in str(e)
+
+
+@patch('chaosaws.route53.probes.aws_client', autospec=True)
+def test_get_health_check_status_no_results(m_client):
+    mock_response = {'HealthCheckObservations': []}
+    client = MagicMock()
+    m_client.return_value = client
+    client.get_health_check_status.return_value = mock_response
+
+    with pytest.raises(FailedActivity) as e:
+        get_health_check_status(
+            check_id='00000000-2222-2222-2222-000000000000')
+    assert 'No results found for' in str(e)
+
+
+@patch('chaosaws.route53.probes.aws_client', autospec=True)
+def test_get_dns_answer(m_client):
+    mock_response = read_in_data('test_dns_answer_1.json')
+    client = MagicMock()
+    m_client.return_value = client
+    client.test_dns_answer.return_value = mock_response
+
+    response = get_dns_answer(
+        zone_id='AAAAAAAAAAAAA',
+        record_name='aws.testrecord.com',
+        record_type='A')
+
+    client.test_dns_answer.assert_called_with(
+        HostedZoneId='AAAAAAAAAAAAA',
+        RecordName='aws.testrecord.com',
+        RecordType='A')
+
+    assert response['ResponseCode'] == 'NOERROR'
+
+
+@patch('chaosaws.route53.probes.aws_client', autospec=True)
+def test_get_dns_answer_not_found(m_client):
+    mock_response = ClientError(
+        operation_name='get_hosted_zone',
+        error_response={'Error': {'Message': 'Test Error',
+                                  'Code': 'NoSuchHealthCheck'}})
+    client = MagicMock()
+    m_client.return_value = client
+    client.test_dns_answer.side_effect = mock_response
+
+    with pytest.raises(FailedActivity) as e:
+        get_dns_answer(
+            zone_id='BBBBBBBBBBBBB',
+            record_name='aws.testrecord.com',
+            record_type='A')
+    assert 'Test Error' in str(e)


### PR DESCRIPTION
- adding actions `associate_vpc_with_zone` and `disassociate_vpc_from_zone` actions
- adding probes `get_hosted_zone`, `get_health_check_status`, & `get_dns_answer`
- using reST docstring format... not sure if it's the standard you'd like @Lawouach 

Signed-off-by: Joshua Root <joshua.root@capitalone.com>