### PR TITLE
adds probe for counting the number of running nodes

### DIFF
--- a/tests/elasticache/test_elasticache_probes.py
+++ b/tests/elasticache/test_elasticache_probes.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch
 from chaosaws.elasticache.probes import (
-    describe_cache_cluster, get_cache_node_status, get_cache_node_count)
+    describe_cache_cluster, get_cache_node_status, get_cache_node_count, count_cache_clusters_from_replication_group)
 
 import pytest
 
@@ -42,6 +42,14 @@ def test_get_node_count_invalid():
         get_cache_node_count()
     assert "get_cache_node_count() missing 1 required positional " \
            "argument: 'cluster_id'" in str(x.value)
+
+
+def test_count_cache_clusters_from_replication_group():
+    with pytest.raises(TypeError) as x:
+        count_cache_clusters_from_replication_group()
+    assert "count_cache_clusters_from_replication_group() missing 1 " \
+           "required positional argument: 'replication_group_id'" \
+           in str(x.value)
 
 
 @patch('chaosaws.elasticache.probes.aws_client', autospec=True)


### PR DESCRIPTION
Found out that the current elasticache.probe does not include probes for Replication Groups, and counting Nodes is only relevant per cluster, as stated in the documentation:

```
NumCacheNodes (integer) --
The number of cache nodes in the cluster.
For clusters running Redis, this value must be 1. For clusters running Memcached, this value must be between 1 and 20.
```

Added new function that uses `boto3.client.describe_replication_groups()`, and then counts the number of MemberClusters, to get total count of EC clusters within the given ReplicationGroup (which can be set to None, and then all Replication groups are included).

The return value can be seen as a Node count, if multiple REDIS clusters are being used in the same AWS Account, as this will count up cluster (with nodes=1).