### PR TITLE
new: function to start a RDS DB instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.16.0...HEAD
 
+## [0.16.1][]
+[0.16.1]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.16.0...0.16.1
+
+### Added
+- new RDS action that starts a DB instance
+
 ## [0.16.0][]
 [0.16.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.15.1...0.16.0
 

--- a/tests/rds/test_rds_actions.py
+++ b/tests/rds/test_rds_actions.py
@@ -4,10 +4,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 from chaoslib.exceptions import FailedActivity
 
-from chaosaws.rds.actions import (failover_db_cluster, reboot_db_instance,
-                                  stop_db_instance, stop_db_cluster,
-                                  delete_db_instance, delete_db_cluster,
-                                  delete_db_cluster_endpoint)
+from chaosaws.rds.actions import (
+    failover_db_cluster,
+    reboot_db_instance,
+    stop_db_instance,
+    stop_db_cluster,
+    delete_db_instance,
+    delete_db_cluster,
+    delete_db_cluster_endpoint,
+    start_db_instance
+)
 
 
 @patch('chaosaws.rds.actions.aws_client', autospec=True)
@@ -237,3 +243,12 @@ def test_delete_db_cluster_endpoint(aws_client):
     delete_db_cluster_endpoint(db_cluster_identifier=cluster_id)
     client.delete_db_cluster_endpoint.assert_called_with(
         DBClusterEndpointIdentifier='%s.domain.endpoint' % cluster_id)
+
+
+@patch('chaosaws.rds.actions.aws_client', autospec=True)
+def test_start_db_instance(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    db_id = 'some-rds-instance-identifier'
+    start_db_instance(db_instance_identifier=db_id)
+    client.start_db_instance.assert_called_with(DBInstanceIdentifier=db_id)


### PR DESCRIPTION
chaostoolkit-aws does not have a function to start an AWS RDS DB Instance.

In my case, it is useful in the ```rollbacks``` phase, but it could be used in ```method``` for reasons.

I've already tested it with the following : 
```
rollbacks:
- name: start_db_instance
  provider:
    arguments:
      db_instance_identifier: rds-foo
    func: start_db_instance
    module: chaosaws.rds.actions
    type: python
  type: action
```

Hurry to have your feedback.