### PR TITLE
Allow deleting entire SSM document

### DIFF
--- a/chaosaws/ssm/actions.py
+++ b/chaosaws/ssm/actions.py
@@ -107,9 +107,10 @@ def delete_document(name: str,
 
     try:
         client = aws_client('ssm', configuration, secrets)
-        return client.delete_document(Name=name,
-                                      VersionName=version_name,
-                                      Force=force)
+        kwargs = {'Name': name, 'Force': force}
+        if version_name:
+            kwargs['VersionName'] = version_name
+        return client.delete_document(**kwargs)
     except ClientError as e:
         raise ActivityFailed(
             "Failed to delete  document '{}': '{}'".format(


### PR DESCRIPTION
I just got started with Chaos Toolkit and the AWS driver. I immediately
ran into issue with automatically creating and deleting documents with
every run.

When not specifying version_name, I get the following error:

```
[2021-01-13 16:14:03 ERROR]   => failed: botocore.exceptions.ParamValidationError: Parameter validation failed:
    Invalid type for parameter VersionName, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
```

When I do specify the version_name, I get the following error, because it's the only version that exists:

```
[2021-01-13 16:14:59 ERROR]   => failed: chaoslib.exceptions.ActivityFailed: Failed to delete  document 'chaos-latency': 'Default version of the document can't be deleted.'
```

So this PR allows for version_name to be empty, so the entire SSM document is deleted.