### PR TITLE
adding action 'put_metric_data'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - adding list_event_source_mapping to awslambda probes
 - adding delete_event_source_mapping to awslambda actions
 - adding toggle_event_source_mapping_state to awslambda actions
+- adding put_metric_data to cloudwatch actions
 
 ### Changed
 

--- a/chaosaws/cloudwatch/actions.py
+++ b/chaosaws/cloudwatch/actions.py
@@ -128,7 +128,7 @@ def put_metric_data(namespace: str,
         ]
 
     For additional information, consult: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html#CloudWatch.Client.put_metric_data
-    """
+    """  # noqa: E501
     params = {
         'Namespace': namespace,
         'MetricData': metric_data

--- a/chaosaws/cloudwatch/actions.py
+++ b/chaosaws/cloudwatch/actions.py
@@ -115,21 +115,13 @@ def put_metric_data(namespace: str,
         namespace='MyCustomTestMetric',
         metric_data=[
             {
-                'MetricName': 'MyCustomInstanceMetric',
+                'MetricName': 'MemoryUsagePercent',
                 'Dimensions': [
                     {'Name': 'InstanceId', 'Value': 'i-000000000000'},
                     {'Name': 'Instance Name', 'Value': 'Test Instance'}
                 ],
-                'Timestamp': datetime(yyyy, mm, dd),
+                'Timestamp': datetime(yyyy, mm, dd, HH, MM, SS),
                 'Value': 55.55,
-                'StatisticValues': {
-                    'SampleCount': 0.0,
-                    'Sum': 0.0,
-                    'Minimum': 0.0,
-                    'Maximum': 0.0
-                },
-                'Values': [0.0, 1.0, 2.0],
-                'Counts': [1.0, 1.5, 2.6],
                 'Unit': 'Percent',
                 'StorageResolution': 60
             }


### PR DESCRIPTION
- adding new feature to cloudwatch actions `put_metric_data` which allows user to add metrics to a namespace to simulate a failure and activate any actions that may be associated to the matching condition.

