### PR TITLE
Remove Python2 specific UTF-8 statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Removed
 - Removed TravisCI related files
+- All `# -*- coding: utf-8 -*-` statements
 
 ### Changed
 - update return value of asg action detach_random_instances to include instance IDs

--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 from typing import Any, Dict, List
 

--- a/chaosaws/asg/actions.py
+++ b/chaosaws/asg/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Dict, List, Any
 
 import boto3

--- a/chaosaws/asg/probes.py
+++ b/chaosaws/asg/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import time
 from collections import Counter
 from sys import maxsize

--- a/chaosaws/awslambda/actions.py
+++ b/chaosaws/awslambda/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 from base64 import b64encode
 from json.decoder import JSONDecodeError

--- a/chaosaws/awslambda/probes.py
+++ b/chaosaws/awslambda/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import boto3
 from chaoslib.types import Configuration, Secrets
 

--- a/chaosaws/cloudwatch/actions.py
+++ b/chaosaws/cloudwatch/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Any, Dict, List, Union
 
 import boto3

--- a/chaosaws/cloudwatch/probes.py
+++ b/chaosaws/cloudwatch/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
 from statistics import mean
 

--- a/chaosaws/ec2/actions.py
+++ b/chaosaws/ec2/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import random
 from collections import defaultdict
 from copy import deepcopy

--- a/chaosaws/ec2/probes.py
+++ b/chaosaws/ec2/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Any, Dict, List
 
 from chaosaws import aws_client

--- a/chaosaws/ecs/actions.py
+++ b/chaosaws/ecs/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import random
 import re
 from typing import List, Union, Dict

--- a/chaosaws/ecs/probes.py
+++ b/chaosaws/ecs/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 

--- a/chaosaws/eks/actions.py
+++ b/chaosaws/eks/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Any, Dict
 
 from chaoslib.types import Configuration, Secrets

--- a/chaosaws/eks/probes.py
+++ b/chaosaws/eks/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from chaoslib.types import Configuration, Secrets
 from logzero import logger
 

--- a/chaosaws/elasticache/actions.py
+++ b/chaosaws/elasticache/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import List, Dict, Any
 
 import boto3

--- a/chaosaws/elasticache/probes.py
+++ b/chaosaws/elasticache/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from botocore.exceptions import ClientError
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets

--- a/chaosaws/elbv2/actions.py
+++ b/chaosaws/elbv2/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import random
 from typing import Dict, List
 

--- a/chaosaws/elbv2/probes.py
+++ b/chaosaws/elbv2/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from collections import Counter
 from typing import Any, Dict, List
 

--- a/chaosaws/emr/actions.py
+++ b/chaosaws/emr/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import List
 
 from botocore.exceptions import ClientError

--- a/chaosaws/emr/probes.py
+++ b/chaosaws/emr/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import List
 
 from chaoslib.types import Configuration, Secrets

--- a/chaosaws/emr/shared.py
+++ b/chaosaws/emr/shared.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import List
 
 import boto3

--- a/chaosaws/iam/actions.py
+++ b/chaosaws/iam/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 from typing import Any, Dict
 

--- a/chaosaws/iam/probes.py
+++ b/chaosaws/iam/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 

--- a/chaosaws/rds/actions.py
+++ b/chaosaws/rds/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import boto3
 
 from typing import Any, Dict, List

--- a/chaosaws/rds/probes.py
+++ b/chaosaws/rds/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Any, Dict, List, Union
 
 import boto3

--- a/chaosaws/route53/actions.py
+++ b/chaosaws/route53/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from botocore.exceptions import ClientError
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets

--- a/chaosaws/route53/probes.py
+++ b/chaosaws/route53/probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from botocore.exceptions import ClientError
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets

--- a/chaosaws/route53/shared.py
+++ b/chaosaws/route53/shared.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import boto3
 from chaosaws.types import AWSResponse
 from logzero import logger

--- a/chaosaws/ssm/actions.py
+++ b/chaosaws/ssm/actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import random
 import re
 from typing import Any, Dict, List, Union

--- a/chaosaws/types.py
+++ b/chaosaws/types.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Any, Dict, List
 
 __all__ = ["AWSResponse"]

--- a/tests/asg/test_asg_actions.py
+++ b/tests/asg/test_asg_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch
 from chaoslib.exceptions import FailedActivity
 from chaosaws.asg.actions import (

--- a/tests/asg/test_asg_probes.py
+++ b/tests/asg/test_asg_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from sys import maxsize
 from unittest.mock import MagicMock, patch
 

--- a/tests/awslambda/test_awslambda_actions.py
+++ b/tests/awslambda/test_awslambda_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 from base64 import b64encode
 from unittest.mock import MagicMock, patch

--- a/tests/awslambda/test_awslambda_probes.py
+++ b/tests/awslambda/test_awslambda_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 from unittest.mock import MagicMock, patch

--- a/tests/cloudwatch/test_cloudwatch_actions.py
+++ b/tests/cloudwatch/test_cloudwatch_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 

--- a/tests/cloudwatch/test_cloudwatch_probes.py
+++ b/tests/cloudwatch/test_cloudwatch_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 from datetime import datetime, timezone

--- a/tests/ec2/test_ec2_actions.py
+++ b/tests/ec2/test_ec2_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from copy import deepcopy
 from unittest.mock import MagicMock, patch
 

--- a/tests/ec2/test_ec2_probes.py
+++ b/tests/ec2/test_ec2_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 from unittest.mock import MagicMock, patch

--- a/tests/ecs/test_ecs_actions.py
+++ b/tests/ecs/test_ecs_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 from json import loads
 from unittest.mock import ANY, MagicMock, patch

--- a/tests/ecs/test_ecs_probes.py
+++ b/tests/ecs/test_ecs_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/eks/test_eks_actions.py
+++ b/tests/eks/test_eks_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch
 
 from chaosaws.eks.actions import create_cluster, delete_cluster

--- a/tests/eks/test_eks_probes.py
+++ b/tests/eks/test_eks_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch
 
 from chaosaws.eks.probes import describe_cluster, list_clusters

--- a/tests/elasticache/test_elasticache_actions.py
+++ b/tests/elasticache/test_elasticache_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch
 from chaosaws.elasticache.actions import (
     reboot_cache_clusters, delete_replication_groups, delete_cache_clusters)

--- a/tests/elasticache/test_elasticache_probes.py
+++ b/tests/elasticache/test_elasticache_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch
 from chaosaws.elasticache.probes import (
     describe_cache_cluster, get_cache_node_status, get_cache_node_count, count_cache_clusters_from_replication_group)

--- a/tests/elbv2/test_elbv2_actions.py
+++ b/tests/elbv2/test_elbv2_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch, call
 
 import pytest

--- a/tests/elbv2/test_elbv2_probes.py
+++ b/tests/elbv2/test_elbv2_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/emr/test_emr_actions.py
+++ b/tests/emr/test_emr_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 from json import loads
 from unittest.mock import MagicMock, patch

--- a/tests/emr/test_emr_probes.py
+++ b/tests/emr/test_emr_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 from json import loads
 from unittest.mock import MagicMock, patch

--- a/tests/iam/test_iam_actions.py
+++ b/tests/iam/test_iam_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 from unittest.mock import MagicMock, patch
 

--- a/tests/iam/test_iam_probes.py
+++ b/tests/iam/test_iam_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch
 
 from chaosaws.iam.probes import get_policy

--- a/tests/rds/test_rds_actions.py
+++ b/tests/rds/test_rds_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/rds/test_rds_probes.py
+++ b/tests/rds/test_rds_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 from unittest import TestCase

--- a/tests/route53/test_route53_actions.py
+++ b/tests/route53/test_route53_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 from unittest.mock import MagicMock, patch

--- a/tests/route53/test_route53_probes.py
+++ b/tests/route53/test_route53_probes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 from unittest.mock import MagicMock, patch

--- a/tests/ssm/test_ssm_actions.py
+++ b/tests/ssm/test_ssm_actions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import MagicMock, patch,mock_open
 import os
 import pytest

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import logging
 import os


### PR DESCRIPTION
The statement:

```
# -*- coding: utf-8 -*-
```

Is no longer needed as this is for Python2 - Python3 uses UTF-8 strings as default

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
