### PR TITLE
Switch from pycodestyle to black, flake8, and isort

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=88

--- a/.github/workflows/build-and-discover.yaml
+++ b/.github/workflows/build-and-discover.yaml
@@ -23,9 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install chaostoolkit
-          python setup.py develop
+          pip install chaostoolkit .
       - name: Discover
         run: |
           if chaos discover chaostoolkit-aws 2>&1 | grep "WARNING"; then

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build, Test, and Lint
 
 on:
   pull_request:
@@ -9,6 +9,21 @@ on:
       - master
 
 jobs:
+  build-and-lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install-dev
+      - name: Run tests
+        run: |
+          make lint
   build-and-test:
     runs-on: ubuntu-20.04
     strategy:
@@ -23,8 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt
-          python setup.py develop
+          make install-dev
       - name: Run tests
         run: |
-          pytest
+          make tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - adding toggle_event_source_mapping_state to awslambda actions
 - adding put_metric_data to cloudwatch actions
 - added GitHub Actions Workflows for Build and Test, Build and Discover, and Releasing
+- added `Makefile` to abstract away common commands: `install`, `install-dev`, `lint`, `format`, `tests`
 
 ### Removed
 - Removed TravisCI related files
@@ -17,6 +18,7 @@
 
 ### Changed
 - update return value of asg action detach_random_instances to include instance IDs
+- switch from `pycodestyle` to `black`, `flake8`, and `isort` for linting/formatting
 
 ### Fixed
 - `chaosaws.route53.probes` now correctly exposes the `__all__` attribute

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: install
+install:
+	pip install -r requirements.txt
+
+.PHONY: install-dev
+install-dev: install
+	pip install -r requirements-dev.txt
+	python setup.py develop
+
+.PHONY: lint
+lint:
+	flake8 chaosaws/ tests/
+	isort --check-only --profile black chaosaws/ tests/
+	black --check --diff chaosaws/ tests/
+
+.PHONY: format
+format:
+	isort --profile black chaosaws/ tests/
+	black chaosaws/ tests/
+
+.PHONY: tests
+tests:
+	pytest

--- a/README.md
+++ b/README.md
@@ -255,11 +255,12 @@ If none of these are set, your experiment will likely fail.
 ## Contribute
 
 If you wish to contribute more functions to this package, you are more than
-welcome to do so. Please, fork this project, make your changes following the
-usual [PEP 8][pep8] code style, sprinkling with tests and submit a PR for
-review.
+welcome to do so. Please, fork this project, write unit tests to cover the proposed changes,
+implement the changes, ensure they meet the formatting standards set out by `black`,
+`flake8`, and `isort`, and then raise a PR to the repository for review.
 
-[pep8]: https://pycodestyle.readthedocs.io/en/latest/
+Please refer to the [formatting][#formatting-and-linting] section for more information
+on the formatting standards.
 
 The Chaos Toolkit projects require all contributors must sign a
 [Developer Certificate of Origin][dco] on each commit they would like to merge
@@ -277,25 +278,44 @@ those dependencies.
 [venv]: http://chaostoolkit.org/reference/usage/install/#create-a-virtual-environment
 
 ```console
-$ pip install -r requirements-dev.txt -r requirements.txt 
-```
-
-Then, point your environment to this directory:
-
-```console
-$ python setup.py develop
+$ make install-dev
 ```
 
 Now, you can edit the files and they will be automatically be seen by your
 environment, even when running from the `chaos` command locally.
 
-### Test
+### Tests
 
 To run the tests for the project execute the following:
 
+```console
+$ make tests
 ```
-$ pytest
+
+### Formatting and Linting
+
+We use a combination of [`black`][black], [`flake8`][flake8], and [`isort`][isort] to both
+lint and format this repositories code.
+
+[black]: https://github.com/psf/black
+[flake8]: https://github.com/PyCQA/flake8
+[isort]: https://github.com/PyCQA/isort
+
+Before raising a Pull Request, we recommend you run formatting against your code with:
+
+```console
+$ make format
 ```
+
+This will automatically format any code that doesn't adhere to the formatting standards.
+
+As some things are not picked up by the formatting, we also recommend you run:
+
+```console
+$ make lint
+```
+
+To ensure that any unused import statements/strings that are too long, etc. are also picked up.
 
 ### Add new AWS API Support
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,10 @@
+black
 coverage
+cryptography
+flake8
+isort
 moto
 pytest>=6.0
 pytest-cov
 pytest-sugar
 requests_mock
-cryptography

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 coverage
 moto
-pycodestyle
 pytest>=6.0
 pytest-cov
 pytest-sugar

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,3 @@ test = pytest
 
 [wheel]
 universal = 0
-
-[pycodestyle]
-ignore = E741


### PR DESCRIPTION
This PR does the following:

- Remove pycodestyle
- Add Black, Flake8, and Isort
- Add Makefile with install, install-dev, lint, format, and tests
- Switches the GitHub Actions Workflows to use the Makefile when able
- Update CHANGELOG.md
- Update README

This is mainly because we're touching this repository a fair bit in the
near future. The plan is to consolidate these standards across all repos
and likely include pre-commit config to do this also.

**NOTE:**

The build: `Build, Test, and Lint / build-and-lint` will fail as I have not gone and formatted the codebase yet. I wanted these changes in so that when I do the big formatting PR, that the changes will be validated by the CI pipeline, making reviewing a bit easier.