### PR TITLE
Apply black, flake8, and isort across codebase

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 88
-ignore = E203
+ignore = E203, W503

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
-max-line-length=88
+max-line-length = 88
+ignore = E203

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Changed
 - update return value of asg action detach_random_instances to include instance IDs
 - switch from `pycodestyle` to `black`, `flake8`, and `isort` for linting/formatting
+- applied `black`, `flake8`, and `isort` across the codebase
 
 ### Fixed
 - `chaosaws.route53.probes` now correctly exposes the `__all__` attribute

--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -11,12 +11,7 @@ from chaoslib.discovery.discover import (
     initialize_discovery_result,
 )
 from chaoslib.exceptions import InterruptExecution
-from chaoslib.types import (
-    Configuration,
-    DiscoveredActivities,
-    Discovery,
-    Secrets,
-)
+from chaoslib.types import Configuration, DiscoveredActivities, Discovery, Secrets
 from logzero import logger
 
 __version__ = "0.16.0"

--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -5,23 +5,19 @@ import boto3
 import requests
 from aws_requests_auth.aws_auth import AWSRequestsAuth
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
-from botocore import parsers
 from chaoslib.discovery.discover import (
     discover_actions,
     discover_probes,
     initialize_discovery_result,
 )
-from chaoslib.exceptions import DiscoveryFailed, InterruptExecution
+from chaoslib.exceptions import InterruptExecution
 from chaoslib.types import (
     Configuration,
     DiscoveredActivities,
-    DiscoveredSystemInfo,
     Discovery,
     Secrets,
 )
 from logzero import logger
-
-from chaosaws.types import AWSResponse
 
 __version__ = "0.16.0"
 __all__ = ["__version__", "discover", "aws_client", "signed_api_call"]

--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -6,15 +6,24 @@ import requests
 from aws_requests_auth.aws_auth import AWSRequestsAuth
 from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from botocore import parsers
-from chaosaws.types import AWSResponse
-from chaoslib.discovery.discover import (discover_actions, discover_probes,
-                                         initialize_discovery_result)
+from chaoslib.discovery.discover import (
+    discover_actions,
+    discover_probes,
+    initialize_discovery_result,
+)
 from chaoslib.exceptions import DiscoveryFailed, InterruptExecution
-from chaoslib.types import (Configuration, DiscoveredActivities,
-                            DiscoveredSystemInfo, Discovery, Secrets)
+from chaoslib.types import (
+    Configuration,
+    DiscoveredActivities,
+    DiscoveredSystemInfo,
+    Discovery,
+    Secrets,
+)
 from logzero import logger
 
-__version__ = '0.16.0'
+from chaosaws.types import AWSResponse
+
+__version__ = "0.16.0"
 __all__ = ["__version__", "discover", "aws_client", "signed_api_call"]
 
 
@@ -27,8 +36,8 @@ def get_credentials(secrets: Secrets = None) -> Dict[str, str]:
     See: https://boto3.readthedocs.io/en/latest/guide/configuration.html#guide-configuration
     """  # noqa: E501
     creds = dict(
-        aws_access_key_id=None, aws_secret_access_key=None,
-        aws_session_token=None)
+        aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None
+    )
 
     if secrets:
         creds["aws_access_key_id"] = secrets.get("aws_access_key_id")
@@ -38,8 +47,9 @@ def get_credentials(secrets: Secrets = None) -> Dict[str, str]:
     return creds
 
 
-def aws_client(resource_name: str, configuration: Configuration = None,
-               secrets: Secrets = None):
+def aws_client(
+    resource_name: str, configuration: Configuration = None, secrets: Secrets = None
+):
     """
     Create a boto3 client for the given resource.
 
@@ -64,7 +74,8 @@ def aws_client(resource_name: str, configuration: Configuration = None,
     if not region:
         logger.debug(
             "The configuration key `aws_region` is not set, looking in the "
-            "environment instead for `AWS_REGION` or `AWS_DEFAULT_REGION`")
+            "environment instead for `AWS_REGION` or `AWS_DEFAULT_REGION`"
+        )
         region = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION"))
         if not region:
             raise InterruptExecution("AWS requires a region to be set!")
@@ -81,37 +92,44 @@ def aws_client(resource_name: str, configuration: Configuration = None,
     if not aws_assume_role_arn:
         logger.debug(
             "Client will be using profile '{}' from boto3 session".format(
-                aws_profile_name or "default"))
+                aws_profile_name or "default"
+            )
+        )
         return boto3.client(resource_name, **params)
     else:
         logger.debug(
             "Fetching credentials dynamically assuming role '{}'".format(
-                aws_assume_role_arn))
+                aws_assume_role_arn
+            )
+        )
 
-        aws_assume_role_session_name = configuration.get(
-            "aws_assume_role_session_name")
+        aws_assume_role_session_name = configuration.get("aws_assume_role_session_name")
         if not aws_assume_role_session_name:
             aws_assume_role_session_name = "ChaosToolkit"
             logger.debug(
                 "You are missing the `aws_assume_role_session_name` "
                 "configuration key. A unique one was generated: '{}'".format(
-                    aws_assume_role_session_name))
+                    aws_assume_role_session_name
+                )
+            )
 
-        client = boto3.client('sts', **params)
+        client = boto3.client("sts", **params)
         params = {
             "RoleArn": aws_assume_role_arn,
-            "RoleSessionName": aws_assume_role_session_name
+            "RoleSessionName": aws_assume_role_session_name,
         }
         response = client.assume_role(**params)
-        creds = response['Credentials']
+        creds = response["Credentials"]
         logger.debug(
             "Temporary credentials will expire on {}".format(
-                creds["Expiration"].isoformat()))
+                creds["Expiration"].isoformat()
+            )
+        )
 
         params = {
-            "aws_access_key_id": creds['AccessKeyId'],
-            "aws_secret_access_key": creds['SecretAccessKey'],
-            "aws_session_token": creds['SessionToken']
+            "aws_access_key_id": creds["AccessKeyId"],
+            "aws_secret_access_key": creds["SecretAccessKey"],
+            "aws_session_token": creds["SessionToken"],
         }
         if region:
             params["region_name"] = region
@@ -119,10 +137,14 @@ def aws_client(resource_name: str, configuration: Configuration = None,
         return boto3.client(resource_name, **params)
 
 
-def signed_api_call(service: str, path: str = "/", method: str = 'GET',
-                    configuration: Configuration = None,
-                    secrets: Secrets = None,
-                    params: Dict[str, Any] = None) -> requests.Response:
+def signed_api_call(
+    service: str,
+    path: str = "/",
+    method: str = "GET",
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+    params: Dict[str, Any] = None,
+) -> requests.Response:
     """
     Perform an API call against an AWS service.
 
@@ -164,8 +186,8 @@ def signed_api_call(service: str, path: str = "/", method: str = 'GET',
     scheme = configuration.get("aws_endpoint_scheme", "https")
     host = "{s}.{r}.{h}".format(s=service, r=region, h=host)
     endpoint = configuration.get(
-        "aws_endpoint", '{scheme}://{h}'.format(
-            scheme=scheme, h=host)).replace('..', '.')
+        "aws_endpoint", "{scheme}://{h}".format(scheme=scheme, h=host)
+    ).replace("..", ".")
     endpoint = "{e}{p}".format(e=endpoint, p=path)
     creds = get_credentials(secrets)
 
@@ -178,23 +200,21 @@ def signed_api_call(service: str, path: str = "/", method: str = 'GET',
             aws_secret_access_key=creds["aws_secret_access_key"],
             aws_host=host,
             aws_region=region,
-            aws_service=service)
+            aws_service=service,
+        )
     else:
         auth = BotoAWSRequestsAuth(
-            aws_host=host,
-            aws_region=region,
-            aws_service=service)
+            aws_host=host, aws_region=region, aws_service=service
+        )
 
-    headers = {
-        "Accept": "application/json"
-    }
+    headers = {"Accept": "application/json"}
 
-    if method in ('DELETE', 'GET'):
+    if method in ("DELETE", "GET"):
         return requests.request(
-            method, endpoint, headers=headers, auth=auth, params=params)
+            method, endpoint, headers=headers, auth=auth, params=params
+        )
 
-    return requests.request(
-        method, endpoint, headers=headers, auth=auth, json=params)
+    return requests.request(method, endpoint, headers=headers, auth=auth, json=params)
 
 
 def discover(discover_system: bool = True) -> Discovery:
@@ -204,8 +224,7 @@ def discover(discover_system: bool = True) -> Discovery:
     """
     logger.info("Discovering capabilities from chaostoolkit-aws")
 
-    discovery = initialize_discovery_result(
-        "chaostoolkit-aws", __version__, "aws")
+    discovery = initialize_discovery_result("chaostoolkit-aws", __version__, "aws")
     discovery["activities"].extend(load_exported_activities())
 
     return discovery
@@ -238,10 +257,10 @@ def load_exported_activities() -> List[DiscoveredActivities]:
     activities.extend(discover_actions("chaosaws.rds.actions"))
     activities.extend(discover_probes("chaosaws.rds.probes"))
     activities.extend(discover_actions("chaosaws.elasticache.actions"))
-    activities.extend(discover_probes('chaosaws.elasticache.probes'))
+    activities.extend(discover_probes("chaosaws.elasticache.probes"))
     activities.extend(discover_actions("chaosaws.emr.actions"))
-    activities.extend(discover_probes('chaosaws.emr.probes'))
+    activities.extend(discover_probes("chaosaws.emr.probes"))
     activities.extend(discover_actions("chaosaws.route53.actions"))
-    activities.extend(discover_probes('chaosaws.route53.probes'))
-    activities.extend(discover_probes('chaosaws.ssm.actions'))
+    activities.extend(discover_probes("chaosaws.route53.probes"))
+    activities.extend(discover_probes("chaosaws.ssm.actions"))
     return activities

--- a/chaosaws/asg/actions.py
+++ b/chaosaws/asg/actions.py
@@ -1,28 +1,36 @@
-from typing import Dict, List, Any
+import random
+from typing import Any, Dict, List
 
 import boto3
-import random
-
 from botocore.exceptions import ClientError
-from chaosaws import aws_client
-from chaosaws.types import AWSResponse
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
-
 from logzero import logger
 
-__all__ = ["suspend_processes", "resume_processes", "stop_random_instances",
-           "terminate_random_instances", "detach_random_instances",
-           "change_subnets", "detach_random_volume", "attach_volume"]
+from chaosaws import aws_client
+from chaosaws.types import AWSResponse
+
+__all__ = [
+    "suspend_processes",
+    "resume_processes",
+    "stop_random_instances",
+    "terminate_random_instances",
+    "detach_random_instances",
+    "change_subnets",
+    "detach_random_volume",
+    "attach_volume",
+]
 
 
-def terminate_random_instances(asg_names: List[str] = None,
-                               tags: List[Dict[str, str]] = None,
-                               instance_count: int = None,
-                               instance_percent: int = None,
-                               az: str = None,
-                               configuration: Configuration = None,
-                               secrets: Secrets = None) -> List[AWSResponse]:
+def terminate_random_instances(
+    asg_names: List[str] = None,
+    tags: List[Dict[str, str]] = None,
+    instance_count: int = None,
+    instance_percent: int = None,
+    az: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Terminates one or more random healthy instances associated to an ALB
 
@@ -48,11 +56,13 @@ def terminate_random_instances(asg_names: List[str] = None,
     validate_asgs(asg_names, tags)
 
     if not any([instance_count, instance_percent, az]) or all(
-            [instance_percent, instance_count, az]):
+        [instance_percent, instance_count, az]
+    ):
         raise FailedActivity(
-            'Must specify one of "instance_count", "instance_percent", "az"')
+            'Must specify one of "instance_count", "instance_percent", "az"'
+        )
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     if asg_names:
         asgs = get_asg_by_name(asg_names, client)
@@ -60,51 +70,59 @@ def terminate_random_instances(asg_names: List[str] = None,
         asgs = get_asg_by_tags(tags, client)
 
     results = []
-    for a in asgs['AutoScalingGroups']:
+    for a in asgs["AutoScalingGroups"]:
         # Filter out all instances not currently 'InService'
-        instances = [e for e in a['Instances'] if e[
-            'LifecycleState'] == 'InService']
+        instances = [e for e in a["Instances"] if e["LifecycleState"] == "InService"]
 
         if az:
-            instances = [e for e in instances if e['AvailabilityZone'] == az]
+            instances = [e for e in instances if e["AvailabilityZone"] == az]
 
             if not instances:
                 raise FailedActivity(
-                    'No instances found in Availability Zone: {}'.format(az))
+                    "No instances found in Availability Zone: {}".format(az)
+                )
         else:
             if instance_percent:
-                instance_count = int(float(
-                    len(instances) * float(instance_percent)) / 100)
+                instance_count = int(
+                    float(len(instances) * float(instance_percent)) / 100
+                )
 
             if len(instances) < instance_count:
                 raise FailedActivity(
-                    'Not enough healthy instances in {} to satisfy '
-                    'termination count {} ({})'.format(
-                        a['AutoScalingGroupName'], instance_count,
-                        len(instances)))
+                    "Not enough healthy instances in {} to satisfy "
+                    "termination count {} ({})".format(
+                        a["AutoScalingGroupName"], instance_count, len(instances)
+                    )
+                )
 
             instances = random.sample(instances, instance_count)
 
-        client = aws_client('ec2', configuration, secrets)
+        client = aws_client("ec2", configuration, secrets)
         try:
             response = client.terminate_instances(
-                InstanceIds=sorted([e['InstanceId'] for e in instances]))
-            results.append({
-                'AutoScalingGroupName': a['AutoScalingGroupName'],
-                'TerminatingInstances': response['TerminatingInstances']})
+                InstanceIds=sorted([e["InstanceId"] for e in instances])
+            )
+            results.append(
+                {
+                    "AutoScalingGroupName": a["AutoScalingGroupName"],
+                    "TerminatingInstances": response["TerminatingInstances"],
+                }
+            )
         except ClientError as e:
-            raise FailedActivity(e.response['Error']['Message'])
+            raise FailedActivity(e.response["Error"]["Message"])
     return results
 
 
-def stop_random_instances(asg_names: List[str] = None,
-                          tags: List[Dict[str, str]] = None,
-                          instance_count: int = None,
-                          instance_percent: int = None,
-                          az: str = None,
-                          force: bool = False,
-                          configuration: Configuration = None,
-                          secrets: Secrets = None) -> List[AWSResponse]:
+def stop_random_instances(
+    asg_names: List[str] = None,
+    tags: List[Dict[str, str]] = None,
+    instance_count: int = None,
+    instance_percent: int = None,
+    az: str = None,
+    force: bool = False,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Terminates one or more random healthy instances associated to an ALB
 
@@ -132,11 +150,13 @@ def stop_random_instances(asg_names: List[str] = None,
     validate_asgs(asg_names, tags)
 
     if not any([instance_count, instance_percent, az]) or all(
-            [instance_percent, instance_count, az]):
+        [instance_percent, instance_count, az]
+    ):
         raise FailedActivity(
-            'Must specify one of "instance_count", "instance_percent", "az"')
+            'Must specify one of "instance_count", "instance_percent", "az"'
+        )
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     if asg_names:
         asgs = get_asg_by_name(asg_names, client)
@@ -144,49 +164,55 @@ def stop_random_instances(asg_names: List[str] = None,
         asgs = get_asg_by_tags(tags, client)
 
     results = []
-    for a in asgs['AutoScalingGroups']:
+    for a in asgs["AutoScalingGroups"]:
         # Filter out all instances not currently 'InService'
-        instances = [e for e in a['Instances'] if e[
-            'LifecycleState'] == 'InService']
+        instances = [e for e in a["Instances"] if e["LifecycleState"] == "InService"]
 
         if az:
-            instances = [e for e in instances if e['AvailabilityZone'] == az]
+            instances = [e for e in instances if e["AvailabilityZone"] == az]
 
             if not instances:
                 raise FailedActivity(
-                    'No instances found in Availability Zone: {}'.format(az))
+                    "No instances found in Availability Zone: {}".format(az)
+                )
         else:
             if instance_percent:
-                instance_count = int(float(
-                    len(instances) * float(instance_percent)) / 100)
+                instance_count = int(
+                    float(len(instances) * float(instance_percent)) / 100
+                )
 
             if len(instances) < instance_count:
                 raise FailedActivity(
-                    'Not enough healthy instances in %s to satisfy '
-                    'stop count %s (%s)' % (a['AutoScalingGroupName'],
-                                            instance_count,
-                                            len(instances)))
+                    "Not enough healthy instances in %s to satisfy "
+                    "stop count %s (%s)"
+                    % (a["AutoScalingGroupName"], instance_count, len(instances))
+                )
 
             instances = random.sample(instances, instance_count)
 
-        client = aws_client('ec2', configuration, secrets)
+        client = aws_client("ec2", configuration, secrets)
         try:
             response = client.stop_instances(
-                InstanceIds=sorted([e['InstanceId'] for e in instances]),
-                Force=force)
-            results.append({
-                'AutoScalingGroupName': a['AutoScalingGroupName'],
-                'StoppingInstances': response['StoppingInstances']})
+                InstanceIds=sorted([e["InstanceId"] for e in instances]), Force=force
+            )
+            results.append(
+                {
+                    "AutoScalingGroupName": a["AutoScalingGroupName"],
+                    "StoppingInstances": response["StoppingInstances"],
+                }
+            )
         except ClientError as e:
-            raise FailedActivity(e.response['Error']['Message'])
+            raise FailedActivity(e.response["Error"]["Message"])
     return results
 
 
-def suspend_processes(asg_names: List[str] = None,
-                      tags: List[Dict[str, str]] = None,
-                      process_names: List[str] = None,
-                      configuration: Configuration = None,
-                      secrets: Secrets = None) -> AWSResponse:
+def suspend_processes(
+    asg_names: List[str] = None,
+    tags: List[Dict[str, str]] = None,
+    process_names: List[str] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Suspends 1 or more processes on a list of auto scaling groups.
 
@@ -213,31 +239,33 @@ def suspend_processes(asg_names: List[str] = None,
     if process_names:
         validate_processes(process_names)
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     if asg_names:
         asgs = get_asg_by_name(asg_names, client)
     else:
         asgs = get_asg_by_tags(tags, client)
 
-    for a in asgs['AutoScalingGroups']:
-        params = dict(AutoScalingGroupName=a['AutoScalingGroupName'])
+    for a in asgs["AutoScalingGroups"]:
+        params = dict(AutoScalingGroupName=a["AutoScalingGroupName"])
         if process_names:
-            params['ScalingProcesses'] = process_names
+            params["ScalingProcesses"] = process_names
 
-        logger.debug('Suspending process(es) on {}'.format(
-            a["AutoScalingGroupName"]))
+        logger.debug("Suspending process(es) on {}".format(a["AutoScalingGroupName"]))
         client.suspend_processes(**params)
 
     return get_asg_by_name(
-        [a['AutoScalingGroupName'] for a in asgs['AutoScalingGroups']], client)
+        [a["AutoScalingGroupName"] for a in asgs["AutoScalingGroups"]], client
+    )
 
 
-def resume_processes(asg_names: List[str] = None,
-                     tags: List[Dict[str, str]] = None,
-                     process_names: List[str] = None,
-                     configuration: Configuration = None,
-                     secrets: Secrets = None) -> AWSResponse:
+def resume_processes(
+    asg_names: List[str] = None,
+    tags: List[Dict[str, str]] = None,
+    process_names: List[str] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Resumes 1 or more suspended processes on a list of auto scaling groups.
 
@@ -264,33 +292,39 @@ def resume_processes(asg_names: List[str] = None,
     if process_names:
         validate_processes(process_names)
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     if asg_names:
         asgs = get_asg_by_name(asg_names, client)
     else:
         asgs = get_asg_by_tags(tags, client)
 
-    for a in asgs['AutoScalingGroups']:
-        params = dict(AutoScalingGroupName=a['AutoScalingGroupName'])
+    for a in asgs["AutoScalingGroups"]:
+        params = dict(AutoScalingGroupName=a["AutoScalingGroupName"])
         if process_names:
-            params['ScalingProcesses'] = process_names
+            params["ScalingProcesses"] = process_names
 
-        logger.debug('Resuming process(es) {} on {}'.format(
-            process_names, a['AutoScalingGroupName']))
+        logger.debug(
+            "Resuming process(es) {} on {}".format(
+                process_names, a["AutoScalingGroupName"]
+            )
+        )
         client.resume_processes(**params)
 
     return get_asg_by_name(
-        [a['AutoScalingGroupName'] for a in asgs['AutoScalingGroups']], client)
+        [a["AutoScalingGroupName"] for a in asgs["AutoScalingGroups"]], client
+    )
 
 
-def detach_random_instances(asg_names: List[str] = None,
-                            tags: List[dict] = None,
-                            instance_count: int = None,
-                            instance_percent: int = None,
-                            decrement_capacity: bool = False,
-                            configuration: Configuration = None,
-                            secrets: Secrets = None) -> AWSResponse:
+def detach_random_instances(
+    asg_names: List[str] = None,
+    tags: List[dict] = None,
+    instance_count: int = None,
+    instance_percent: int = None,
+    decrement_capacity: bool = False,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Detaches one or more random instances from an autoscaling group
 
@@ -316,10 +350,11 @@ def detach_random_instances(asg_names: List[str] = None,
     validate_asgs(asg_names, tags)
 
     if not any([instance_count, instance_percent]):
-        raise FailedActivity('You must specify either "instance_count" or '
-                             '"instance_percent"')
+        raise FailedActivity(
+            'You must specify either "instance_count" or ' '"instance_percent"'
+        )
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     if asg_names:
         asgs = get_asg_by_name(asg_names, client)
@@ -327,40 +362,48 @@ def detach_random_instances(asg_names: List[str] = None,
         asgs = get_asg_by_tags(tags, client)
 
     results = {}
-    for a in asgs['AutoScalingGroups']:
+    for a in asgs["AutoScalingGroups"]:
         # Filter out all instances not currently 'InService'
-        instances = [e['InstanceId'] for e in a['Instances'] if e[
-            'LifecycleState'] == 'InService']
+        instances = [
+            e["InstanceId"]
+            for e in a["Instances"]
+            if e["LifecycleState"] == "InService"
+        ]
 
         if instance_percent:
-            instance_count = int(float(
-                len(instances) * float(instance_percent)) / 100)
+            instance_count = int(float(len(instances) * float(instance_percent)) / 100)
 
         if instance_count > len(instances):
             raise FailedActivity(
-                'You are attempting to detach more instances '
-                'than exist on asg %s' % (a['AutoScalingGroupName']))
+                "You are attempting to detach more instances "
+                "than exist on asg %s" % (a["AutoScalingGroupName"])
+            )
 
         instances = random.sample(instances, instance_count)
         instances = sorted(instances)
 
         response = client.detach_instances(
-            AutoScalingGroupName=a['AutoScalingGroupName'],
+            AutoScalingGroupName=a["AutoScalingGroupName"],
             InstanceIds=instances,
-            ShouldDecrementDesiredCapacity=decrement_capacity)
-        results.setdefault('Activities', []).extend(response['Activities'])
-        results.setdefault('DetachingInstances', []).append({
-            'AutoScalingGroupName': a['AutoScalingGroupName'],
-            'InstanceIds': instances
-        })
+            ShouldDecrementDesiredCapacity=decrement_capacity,
+        )
+        results.setdefault("Activities", []).extend(response["Activities"])
+        results.setdefault("DetachingInstances", []).append(
+            {
+                "AutoScalingGroupName": a["AutoScalingGroupName"],
+                "InstanceIds": instances,
+            }
+        )
     return results
 
 
-def change_subnets(subnets: List[str],
-                   asg_names: List[str] = None,
-                   tags: List[dict] = None,
-                   configuration: Configuration = None,
-                   secrets: Secrets = None):
+def change_subnets(
+    subnets: List[str],
+    asg_names: List[str] = None,
+    tags: List[dict] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+):
     """
     Adds/removes subnets on autoscaling groups
 
@@ -379,69 +422,76 @@ def change_subnets(subnets: List[str],
     ]
     """
     validate_asgs(asg_names, tags)
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     if asg_names:
         asgs = get_asg_by_name(asg_names, client)
     else:
         asgs = get_asg_by_tags(tags, client)
 
-    for a in asgs['AutoScalingGroups']:
+    for a in asgs["AutoScalingGroups"]:
         client.update_auto_scaling_group(
-            AutoScalingGroupName=a['AutoScalingGroupName'],
-            VPCZoneIdentifier=','.join(subnets))
+            AutoScalingGroupName=a["AutoScalingGroupName"],
+            VPCZoneIdentifier=",".join(subnets),
+        )
 
 
-def detach_random_volume(asg_names: List[str] = None,
-                         tags: List[Dict[str, str]] = None,
-                         force: bool = True,
-                         configuration: Configuration = None,
-                         secrets: Secrets = None) -> List[AWSResponse]:
+def detach_random_volume(
+    asg_names: List[str] = None,
+    tags: List[Dict[str, str]] = None,
+    force: bool = True,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
-        Detaches a random (non root) ebs volume from ec2 instances
-        associated to an ASG
+    Detaches a random (non root) ebs volume from ec2 instances
+    associated to an ASG
 
-        Parameters:
-            One of:
-                asg_names: a list of one or more asg names
-                tags: a list of key/value pair to identify asg(s) by
+    Parameters:
+        One of:
+            asg_names: a list of one or more asg names
+            tags: a list of key/value pair to identify asg(s) by
 
-            force: force detach volume (default: true)
+        force: force detach volume (default: true)
 
-        `tags` are expected as a list of dictionary objects:
-        [
-            {'Key': 'TagKey1', 'Value': 'TagValue1'},
-            {'Key': 'TagKey2', 'Value': 'TagValue2'},
-            ...
-        ]
+    `tags` are expected as a list of dictionary objects:
+    [
+        {'Key': 'TagKey1', 'Value': 'TagValue1'},
+        {'Key': 'TagKey2', 'Value': 'TagValue2'},
+        ...
+    ]
     """
     validate_asgs(asg_names, tags)
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     if asg_names:
         asgs = get_asg_by_name(asg_names, client)
     else:
         asgs = get_asg_by_tags(tags, client)
 
-    ec2_client = aws_client('ec2', configuration, secrets)
+    ec2_client = aws_client("ec2", configuration, secrets)
     results = []
-    for a in asgs['AutoScalingGroups']:
-        instances = [e['InstanceId'] for e in a['Instances']]
+    for a in asgs["AutoScalingGroups"]:
+        instances = [e["InstanceId"] for e in a["Instances"]]
         if not instances:
-            raise FailedActivity('no instances found for asg: %s' % (
-                a['AutoScalingGroupName']))
+            raise FailedActivity(
+                "no instances found for asg: %s" % (a["AutoScalingGroupName"])
+            )
         volumes = get_random_instance_volume(ec2_client, instances)
 
         for v in volumes:
-            results.append(detach_instance_volume(
-                ec2_client, force, a['AutoScalingGroupName'], v))
+            results.append(
+                detach_instance_volume(ec2_client, force, a["AutoScalingGroupName"], v)
+            )
     return results
 
 
-def attach_volume(asg_names: List[str] = None,
-                  tags: List[Dict[str, str]] = None,
-                  configuration: Configuration = None,
-                  secrets: Secrets = None) -> List[AWSResponse]:
+def attach_volume(
+    asg_names: List[str] = None,
+    tags: List[Dict[str, str]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Attaches ebs volumes that have been previously detached by CTK
 
@@ -458,189 +508,206 @@ def attach_volume(asg_names: List[str] = None,
         ]
     """
     validate_asgs(asg_names, tags)
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     if asg_names:
         asgs = get_asg_by_name(asg_names, client)
     else:
         asgs = get_asg_by_tags(tags, client)
 
-    ec2_client = aws_client('ec2', configuration, secrets)
+    ec2_client = aws_client("ec2", configuration, secrets)
     volumes = get_detached_volumes(ec2_client)
     if not volumes:
-        raise FailedActivity('No volumes detached by ChaosTookit found')
+        raise FailedActivity("No volumes detached by ChaosTookit found")
 
     results = []
     for volume in volumes:
-        for t in volume['Tags']:
-            if t['Key'] != 'ChaosToolkitDetached':
+        for t in volume["Tags"]:
+            if t["Key"] != "ChaosToolkitDetached":
                 continue
-            attach_data = t['Value'].split(';')
+            attach_data = t["Value"].split(";")
             if len(attach_data) != 3:
                 continue
 
-            device_name = attach_data[0].split('=')[-1]
-            instance_id = attach_data[1].split('=')[-1]
-            asg_name = attach_data[2].split('=')[-1]
+            device_name = attach_data[0].split("=")[-1]
+            instance_id = attach_data[1].split("=")[-1]
+            asg_name = attach_data[2].split("=")[-1]
 
-            if asg_name not in [a['AutoScalingGroupName'] for a in asgs[
-                    'AutoScalingGroups']]:
+            if asg_name not in [
+                a["AutoScalingGroupName"] for a in asgs["AutoScalingGroups"]
+            ]:
                 continue
-            results.append(attach_instance_volume(
-                client, instance_id, volume['VolumeId'], device_name))
+            results.append(
+                attach_instance_volume(
+                    client, instance_id, volume["VolumeId"], device_name
+                )
+            )
     return results
 
 
 ###############################################################################
 # Private functions
 ###############################################################################
-def validate_asgs(asg_names: List[str] = None,
-                  tags: List[Dict[str, str]] = None):
+def validate_asgs(asg_names: List[str] = None, tags: List[Dict[str, str]] = None):
     if not any([asg_names, tags]):
         raise FailedActivity(
-            'one of the following arguments are required: asg_names or tags')
+            "one of the following arguments are required: asg_names or tags"
+        )
 
     if all([asg_names, tags]):
         raise FailedActivity(
-            'only one of the following arguments are allowed: asg_names/tags')
+            "only one of the following arguments are allowed: asg_names/tags"
+        )
 
 
-def get_asg_by_name(asg_names: List[str],
-                    client: boto3.client) -> AWSResponse:
-    logger.debug('Searching for ASG(s): {}.'.format(asg_names))
+def get_asg_by_name(asg_names: List[str], client: boto3.client) -> AWSResponse:
+    logger.debug("Searching for ASG(s): {}.".format(asg_names))
 
     asgs = client.describe_auto_scaling_groups(AutoScalingGroupNames=asg_names)
 
-    if not asgs.get('AutoScalingGroups', []):
-        raise FailedActivity(
-            'Unable to locate ASG(s): {}'.format(asg_names))
+    if not asgs.get("AutoScalingGroups", []):
+        raise FailedActivity("Unable to locate ASG(s): {}".format(asg_names))
 
-    found_asgs = [a['AutoScalingGroupName'] for a in asgs['AutoScalingGroups']]
+    found_asgs = [a["AutoScalingGroupName"] for a in asgs["AutoScalingGroups"]]
     invalid_asgs = [a for a in asg_names if a not in found_asgs]
     if invalid_asgs:
-        raise FailedActivity('No ASG(s) found with name(s): {}'.format(
-            invalid_asgs))
+        raise FailedActivity("No ASG(s) found with name(s): {}".format(invalid_asgs))
     return asgs
 
 
-def get_asg_by_tags(tags: List[Dict[str, str]],
-                    client: boto3.client) -> AWSResponse:
+def get_asg_by_tags(tags: List[Dict[str, str]], client: boto3.client) -> AWSResponse:
     params = []
     for t in tags:
-        params.extend([
-            {'Name': 'key', 'Values': [t['Key']]},
-            {'Name': 'value', 'Values': [t['Value']]}])
-    paginator = client.get_paginator('describe_tags')
+        params.extend(
+            [
+                {"Name": "key", "Values": [t["Key"]]},
+                {"Name": "value", "Values": [t["Value"]]},
+            ]
+        )
+    paginator = client.get_paginator("describe_tags")
     results = set()
     for p in paginator.paginate(Filters=params):
-        for a in p['Tags']:
-            if a['ResourceType'] != 'auto-scaling-group':
+        for a in p["Tags"]:
+            if a["ResourceType"] != "auto-scaling-group":
                 continue
-            results.add(a['ResourceId'])
+            results.add(a["ResourceId"])
 
     if not results:
-        raise FailedActivity(
-            'No ASG(s) found with matching tag(s): {}.'.format(tags))
+        raise FailedActivity("No ASG(s) found with matching tag(s): {}.".format(tags))
     return get_asg_by_name(list(results), client)
 
 
 def get_random_instance_volume(
-        client: boto3.client, instance_ids: List[str]) -> List[Dict[str, str]]:
+    client: boto3.client, instance_ids: List[str]
+) -> List[Dict[str, str]]:
     results = {}
     try:
-        response = client.describe_instances(
-            InstanceIds=instance_ids)['Reservations']
+        response = client.describe_instances(InstanceIds=instance_ids)["Reservations"]
         for r in response:
-            for e in r.get('Instances', []):
-                instance_id = e['InstanceId']
-                bdm = e.get('BlockDeviceMappings', [])
+            for e in r.get("Instances", []):
+                instance_id = e["InstanceId"]
+                bdm = e.get("BlockDeviceMappings", [])
                 for b in bdm:
                     # skip root devices
-                    if b['DeviceName'] in ('/dev/sda1', '/dev/xvda'):
+                    if b["DeviceName"] in ("/dev/sda1", "/dev/xvda"):
                         continue
                     results.setdefault(instance_id, []).append(
-                        {b['DeviceName']: b['Ebs']['VolumeId']})
+                        {b["DeviceName"]: b["Ebs"]["VolumeId"]}
+                    )
 
         volumes = []
         for r in results:
             # select 1 volume at random
             volume = random.sample(results[r], 1)[0]
             for k, v in volume.items():
-                volumes.append(
-                    {'InstanceId': r, 'DeviceName': k, 'VolumeId': v})
+                volumes.append({"InstanceId": r, "DeviceName": k, "VolumeId": v})
         return volumes
     except ClientError as e:
-        raise FailedActivity('Unable to describe asg instances: %s' % (
-            e.response['Error']['Message']))
+        raise FailedActivity(
+            "Unable to describe asg instances: %s" % (e.response["Error"]["Message"])
+        )
 
 
 def validate_processes(process_names: List[str]):
-    valid_processes = ['Launch', 'Terminate', 'HealthCheck', 'AZRebalance',
-                       'AlarmNotification', 'ScheduledActions',
-                       'AddToLoadBalancer', 'ReplaceUnhealthy']
+    valid_processes = [
+        "Launch",
+        "Terminate",
+        "HealthCheck",
+        "AZRebalance",
+        "AlarmNotification",
+        "ScheduledActions",
+        "AddToLoadBalancer",
+        "ReplaceUnhealthy",
+    ]
 
     invalid_processes = [p for p in process_names if p not in valid_processes]
     if invalid_processes:
-        raise FailedActivity('invalid process(es): {} not in {}.'.format(
-            invalid_processes, valid_processes))
+        raise FailedActivity(
+            "invalid process(es): {} not in {}.".format(
+                invalid_processes, valid_processes
+            )
+        )
 
 
-def detach_instance_volume(client: boto3.client,
-                           force: bool,
-                           asg_name: str,
-                           volume_data: Dict[str, str]) -> AWSResponse:
+def detach_instance_volume(
+    client: boto3.client, force: bool, asg_name: str, volume_data: Dict[str, str]
+) -> AWSResponse:
     try:
         response = client.detach_volume(
-            Device=volume_data['DeviceName'],
-            InstanceId=volume_data['InstanceId'],
-            VolumeId=volume_data['VolumeId'],
-            Force=force)
+            Device=volume_data["DeviceName"],
+            InstanceId=volume_data["InstanceId"],
+            VolumeId=volume_data["VolumeId"],
+            Force=force,
+        )
 
         # tag volume with instance information (to reattach on rollback)
         client.create_tags(
-            Resources=[volume_data['VolumeId']],
+            Resources=[volume_data["VolumeId"]],
             Tags=[
                 {
-                    'Key': 'ChaosToolkitDetached',
-                    'Value': 'DeviceName=%s;InstanceId=%s;ASG=%s' % (
-                        volume_data['DeviceName'], volume_data['InstanceId'],
-                        asg_name)
-                }])
+                    "Key": "ChaosToolkitDetached",
+                    "Value": "DeviceName=%s;InstanceId=%s;ASG=%s"
+                    % (volume_data["DeviceName"], volume_data["InstanceId"], asg_name),
+                }
+            ],
+        )
         return response
     except ClientError as e:
-        raise FailedActivity('unable to detach volume %s from %s: %s' % (
-            volume_data['VolumeId'], volume_data['InstanceId'],
-            e.response['Error']['Message']))
+        raise FailedActivity(
+            "unable to detach volume %s from %s: %s"
+            % (
+                volume_data["VolumeId"],
+                volume_data["InstanceId"],
+                e.response["Error"]["Message"],
+            )
+        )
 
 
-def get_detached_volumes(client: boto3.client,
-                         next_token: str = None,
-                         results: List[Dict[str, Any]] = None):
+def get_detached_volumes(
+    client: boto3.client, next_token: str = None, results: List[Dict[str, Any]] = None
+):
     results = results or []
-    params = dict(
-        Filters=[{'Name': 'tag-key', 'Values': ['ChaosToolkitDetached']}])
+    params = dict(Filters=[{"Name": "tag-key", "Values": ["ChaosToolkitDetached"]}])
     if next_token:
-        params['NextToken'] = next_token
+        params["NextToken"] = next_token
     response = client.describe_volumes(**params)
-    results.extend([r for r in response['Volumes']])
-    if response.get('NextToken'):
-        get_detached_volumes(response['NextToken'], results)
+    results.extend([r for r in response["Volumes"]])
+    if response.get("NextToken"):
+        get_detached_volumes(response["NextToken"], results)
     return results
 
 
-def attach_instance_volume(client: boto3.client,
-                           instance_id: str,
-                           volume_id: str,
-                           mount_point: str) -> AWSResponse:
+def attach_instance_volume(
+    client: boto3.client, instance_id: str, volume_id: str, mount_point: str
+) -> AWSResponse:
     try:
         response = client.attach_volume(
-            Device=mount_point,
-            InstanceId=instance_id,
-            VolumeId=volume_id)
-        logger.debug('Attached volume %s to instance %s' % (
-            volume_id, instance_id))
+            Device=mount_point, InstanceId=instance_id, VolumeId=volume_id
+        )
+        logger.debug("Attached volume %s to instance %s" % (volume_id, instance_id))
     except ClientError as e:
         raise FailedActivity(
-            'Unable to attach volume %s to instance %s: %s' % (
-                volume_id, instance_id, e.response['Error']['Message']))
+            "Unable to attach volume %s to instance %s: %s"
+            % (volume_id, instance_id, e.response["Error"]["Message"])
+        )
     return response

--- a/chaosaws/asg/probes.py
+++ b/chaosaws/asg/probes.py
@@ -4,24 +4,34 @@ from sys import maxsize
 from typing import Any, Dict, List, Union
 
 import boto3
-from chaosaws import aws_client
-from chaosaws.types import AWSResponse
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 from logzero import logger
+
+from chaosaws import aws_client
+from chaosaws.types import AWSResponse
 from chaosaws.utils import breakup_iterable
 
-__all__ = ["desired_equals_healthy", "desired_equals_healthy_tags",
-           "wait_desired_equals_healthy", "wait_desired_equals_healthy_tags",
-           "is_scaling_in_progress", "process_is_suspended", "has_subnets",
-           "describe_auto_scaling_groups", "instance_count_by_health",
-           "wait_desired_not_equals_healthy_tags"]
+__all__ = [
+    "desired_equals_healthy",
+    "desired_equals_healthy_tags",
+    "wait_desired_equals_healthy",
+    "wait_desired_equals_healthy_tags",
+    "is_scaling_in_progress",
+    "process_is_suspended",
+    "has_subnets",
+    "describe_auto_scaling_groups",
+    "instance_count_by_health",
+    "wait_desired_not_equals_healthy_tags",
+]
 
 
-def describe_auto_scaling_groups(asg_names: List[str] = None,
-                                 tags: List[Dict[str, Any]] = None,
-                                 configuration: Configuration = None,
-                                 secrets: Secrets = None) -> AWSResponse:
+def describe_auto_scaling_groups(
+    asg_names: List[str] = None,
+    tags: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Returns AWS descriptions for provided ASG(s)
 
@@ -37,7 +47,7 @@ def describe_auto_scaling_groups(asg_names: List[str] = None,
         ...
     ]
     """
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
     if asg_names:
         return get_asg_by_name(asg_names, client)
     elif tags:
@@ -46,9 +56,9 @@ def describe_auto_scaling_groups(asg_names: List[str] = None,
         raise FailedActivity('Must specify either "asg_names" or "tags"')
 
 
-def desired_equals_healthy(asg_names: List[str],
-                           configuration: Configuration = None,
-                           secrets: Secrets = None) -> bool:
+def desired_equals_healthy(
+    asg_names: List[str], configuration: Configuration = None, secrets: Secrets = None
+) -> bool:
     """
     If desired number matches the number of healthy instances
     for each of the auto-scaling groups
@@ -57,20 +67,20 @@ def desired_equals_healthy(asg_names: List[str],
     """
 
     if not asg_names:
-        raise FailedActivity(
-            "Non-empty list of auto scaling groups is required")
+        raise FailedActivity("Non-empty list of auto scaling groups is required")
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
-    groups_descr = client.describe_auto_scaling_groups(
-        AutoScalingGroupNames=asg_names)
+    groups_descr = client.describe_auto_scaling_groups(AutoScalingGroupNames=asg_names)
 
     return is_desired_equals_healthy(groups_descr)
 
 
-def desired_equals_healthy_tags(tags: List[Dict[str, str]],
-                                configuration: Configuration = None,
-                                secrets: Secrets = None) -> bool:
+def desired_equals_healthy_tags(
+    tags: List[Dict[str, str]],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> bool:
     """
     If desired number matches the number of healthy instances
 
@@ -88,19 +98,20 @@ def desired_equals_healthy_tags(tags: List[Dict[str, str]],
     """
 
     if not tags:
-        raise FailedActivity(
-            "Non-empty tags is required")
+        raise FailedActivity("Non-empty tags is required")
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
     groups_descr = get_asg_by_tags(tags, client)
 
     return is_desired_equals_healthy(groups_descr)
 
 
-def wait_desired_equals_healthy(asg_names: List[str],
-                                configuration: Configuration = None,
-                                timeout: Union[int, float] = 300,
-                                secrets: Secrets = None) -> int:
+def wait_desired_equals_healthy(
+    asg_names: List[str],
+    configuration: Configuration = None,
+    timeout: Union[int, float] = 300,
+    secrets: Secrets = None,
+) -> int:
     """
     Wait until desired number matches the number of healthy instances
     for each of the auto-scaling groups
@@ -110,16 +121,16 @@ def wait_desired_equals_healthy(asg_names: List[str],
     """
 
     if not asg_names:
-        raise FailedActivity(
-            "Non-empty list of auto scaling groups is required")
+        raise FailedActivity("Non-empty list of auto scaling groups is required")
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     start = time.time()
 
     while True:
         groups_descr = client.describe_auto_scaling_groups(
-            AutoScalingGroupNames=asg_names)
+            AutoScalingGroupNames=asg_names
+        )
         result = is_desired_equals_healthy(groups_descr)
 
         if (time.time() - start) > timeout:
@@ -133,10 +144,12 @@ def wait_desired_equals_healthy(asg_names: List[str],
         time.sleep(0.1)
 
 
-def wait_desired_not_equals_healthy_tags(tags: List[Dict[str, str]],
-                                         timeout: Union[int, float] = 300,
-                                         configuration: Configuration = None,
-                                         secrets: Secrets = None) -> int:
+def wait_desired_not_equals_healthy_tags(
+    tags: List[Dict[str, str]],
+    timeout: Union[int, float] = 300,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> int:
     """
     Wait until desired number doesn't match the number of healthy instances
     for each of the auto-scaling groups matching tags provided
@@ -154,10 +167,9 @@ def wait_desired_not_equals_healthy_tags(tags: List[Dict[str, str]],
     """
 
     if not tags:
-        raise FailedActivity(
-            "Non-empty tags is required")
+        raise FailedActivity("Non-empty tags is required")
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     start = time.time()
 
@@ -179,10 +191,12 @@ def wait_desired_not_equals_healthy_tags(tags: List[Dict[str, str]],
         time.sleep(0.1)
 
 
-def wait_desired_equals_healthy_tags(tags: List[Dict[str, str]],
-                                     timeout: Union[int, float] = 300,
-                                     configuration: Configuration = None,
-                                     secrets: Secrets = None) -> int:
+def wait_desired_equals_healthy_tags(
+    tags: List[Dict[str, str]],
+    timeout: Union[int, float] = 300,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> int:
     """
     Wait until desired number matches the number of healthy instances
     for each of the auto-scaling groups matching tags provided
@@ -200,10 +214,9 @@ def wait_desired_equals_healthy_tags(tags: List[Dict[str, str]],
     """
 
     if not tags:
-        raise FailedActivity(
-            "Non-empty tags is required")
+        raise FailedActivity("Non-empty tags is required")
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     start = time.time()
 
@@ -226,9 +239,11 @@ def wait_desired_equals_healthy_tags(tags: List[Dict[str, str]],
         time.sleep(0.1)
 
 
-def is_scaling_in_progress(tags: List[Dict[str, str]],
-                           configuration: Configuration = None,
-                           secrets: Secrets = None) -> bool:
+def is_scaling_in_progress(
+    tags: List[Dict[str, str]],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> bool:
     """
     Check if there is any scaling activity in progress for ASG matching tags
 
@@ -236,16 +251,17 @@ def is_scaling_in_progress(tags: List[Dict[str, str]],
     """
 
     if not tags:
-        raise FailedActivity(
-            "Non-empty tags is required")
+        raise FailedActivity("Non-empty tags is required")
 
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
     groups_descr = get_asg_by_tags(tags, client)
 
-    for group_descr in groups_descr['AutoScalingGroups']:
-        for instance in group_descr['Instances']:
-            if instance['LifecycleState'] != 'InService' \
-                    or instance['HealthStatus'] != 'Healthy':
+    for group_descr in groups_descr["AutoScalingGroups"]:
+        for instance in group_descr["Instances"]:
+            if (
+                instance["LifecycleState"] != "InService"
+                or instance["HealthStatus"] != "Healthy"
+            ):
 
                 logger.debug("Scaling activities in progress: {}".format(True))
                 return True
@@ -254,74 +270,84 @@ def is_scaling_in_progress(tags: List[Dict[str, str]],
     return False
 
 
-def process_is_suspended(asg_names: List[str] = None,
-                         tags: List[Dict[str, str]] = None,
-                         process_names: List[str] = None,
-                         configuration: Configuration = None,
-                         secrets: Secrets = None) -> bool:
+def process_is_suspended(
+    asg_names: List[str] = None,
+    tags: List[Dict[str, str]] = None,
+    process_names: List[str] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> bool:
     """
     Determines if one or more processes on an ASG are suspended.
 
     :returns Boolean
     """
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     if not any([asg_names, tags]):
         raise FailedActivity(
-            'one of the following arguments are required: asg_names or tags')
+            "one of the following arguments are required: asg_names or tags"
+        )
 
     if all([asg_names, tags]):
         raise FailedActivity(
-            'only one of the following arguments are allowed: asg_names/tags')
+            "only one of the following arguments are allowed: asg_names/tags"
+        )
 
     if asg_names:
         asgs = get_asg_by_name(asg_names, client)
     else:
         asgs = get_asg_by_tags(tags, client)
 
-    for a in asgs['AutoScalingGroups']:
-        suspended = [p.get('ProcessName') for p in a['SuspendedProcesses']]
+    for a in asgs["AutoScalingGroups"]:
+        suspended = [p.get("ProcessName") for p in a["SuspendedProcesses"]]
         if not all(p in suspended for p in process_names):
             return False
     return True
 
 
-def has_subnets(subnets: List[str],
-                asg_names: List[str] = None,
-                tags: List[Dict[str, str]] = None,
-                configuration: Configuration = None,
-                secrets: Secrets = None) -> bool:
+def has_subnets(
+    subnets: List[str],
+    asg_names: List[str] = None,
+    tags: List[Dict[str, str]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> bool:
     """
     Determines if the provided autoscaling groups are in the provided subnets
 
     :returns boolean
     """
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
 
     if not any([asg_names, tags]):
         raise FailedActivity(
-            'one of the following arguments are required: asg_names or tags')
+            "one of the following arguments are required: asg_names or tags"
+        )
 
     if all([asg_names, tags]):
         raise FailedActivity(
-            'only one of the following arguments are allowed: asg_names/tags')
+            "only one of the following arguments are allowed: asg_names/tags"
+        )
 
     if asg_names:
         asgs = get_asg_by_name(asg_names, client)
     else:
         asgs = get_asg_by_tags(tags, client)
 
-    for a in asgs['AutoScalingGroups']:
-        if sorted(a['VPCZoneIdentifier'].split(',')) != sorted(subnets):
+    for a in asgs["AutoScalingGroups"]:
+        if sorted(a["VPCZoneIdentifier"].split(",")) != sorted(subnets):
             return False
     return True
 
 
-def instance_count_by_health(asg_names: List[str] = None,
-                             tags: List[Dict[str, str]] = None,
-                             count_healthy: bool = True,
-                             configuration: Configuration = None,
-                             secrets: Secrets = None) -> int:
+def instance_count_by_health(
+    asg_names: List[str] = None,
+    tags: List[Dict[str, str]] = None,
+    count_healthy: bool = True,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> int:
     """Reports the number of instances currently in the ASG by their health
     status
 
@@ -340,18 +366,18 @@ def instance_count_by_health(asg_names: List[str] = None,
         ...
     ]
     """
-    client = aws_client('autoscaling', configuration, secrets)
+    client = aws_client("autoscaling", configuration, secrets)
     asgs = discover_scaling_groups(client, asg_names, tags)
 
-    status = 'Healthy'
+    status = "Healthy"
     if not count_healthy:
-        status = 'Unhealthy'
+        status = "Unhealthy"
 
     result = 0
-    for a in asgs['AutoScalingGroups']:
-        instances = a['Instances']
+    for a in asgs["AutoScalingGroups"]:
+        instances = a["Instances"]
         for instance in instances:
-            if instance['HealthStatus'] == status:
+            if instance["HealthStatus"] == status:
                 result += 1
     return result
 
@@ -359,99 +385,103 @@ def instance_count_by_health(asg_names: List[str] = None,
 ###############################################################################
 # Private functions
 ###############################################################################
-def discover_scaling_groups(client: boto3.client,
-                            asgs: List[str] = None,
-                            tags: List[Dict[str, Any]] = None) -> AWSResponse:
+def discover_scaling_groups(
+    client: boto3.client, asgs: List[str] = None, tags: List[Dict[str, Any]] = None
+) -> AWSResponse:
     if not any([asgs, tags]):
         raise FailedActivity(
-            'missing one of the required parameters: asg_names or tags')
+            "missing one of the required parameters: asg_names or tags"
+        )
     if not asgs:
         asgs = []
 
     if tags:
         tag_filter = []
         for t in tags:
-            tag_filter.append({'Name': t['Key'], 'Values': [t['Value']]})
-        paginator = client.get_paginator('describe_tags')
+            tag_filter.append({"Name": t["Key"], "Values": [t["Value"]]})
+        paginator = client.get_paginator("describe_tags")
         for p in paginator.paginate(Filters=tag_filter):
-            asgs.extend([t['ResourceId'] for t in p['Tags'] if t[
-                'ResourceId'] not in asgs])
+            asgs.extend(
+                [t["ResourceId"] for t in p["Tags"] if t["ResourceId"] not in asgs]
+            )
 
-    results = {'AutoScalingGroups': []}
+    results = {"AutoScalingGroups": []}
     for group in breakup_iterable(asgs, 50):
-        response = client.describe_auto_scaling_groups(
-            AutoScalingGroupNames=group)
-        results['AutoScalingGroups'].extend(response['AutoScalingGroups'])
+        response = client.describe_auto_scaling_groups(AutoScalingGroupNames=group)
+        results["AutoScalingGroups"].extend(response["AutoScalingGroups"])
     return results
 
 
-def get_asg_by_name(asg_names: List[str],
-                    client: boto3.client) -> AWSResponse:
-    results = {'AutoScalingGroups': []}
-    paginator = client.get_paginator('describe_auto_scaling_groups')
+def get_asg_by_name(asg_names: List[str], client: boto3.client) -> AWSResponse:
+    results = {"AutoScalingGroups": []}
+    paginator = client.get_paginator("describe_auto_scaling_groups")
     for p in paginator.paginate(AutoScalingGroupNames=asg_names):
-        results['AutoScalingGroups'].extend(p['AutoScalingGroups'])
+        results["AutoScalingGroups"].extend(p["AutoScalingGroups"])
 
-    valid_asgs = [
-        a['AutoScalingGroupName'] for a in results['AutoScalingGroups']]
+    valid_asgs = [a["AutoScalingGroupName"] for a in results["AutoScalingGroups"]]
     invalid_asgs = [a for a in asg_names if a not in valid_asgs]
 
     if invalid_asgs:
-        raise FailedActivity('No ASG(s) found matching: {}'.format(
-            invalid_asgs))
+        raise FailedActivity("No ASG(s) found matching: {}".format(invalid_asgs))
     return results
 
 
-def get_asg_by_tags(tags: Union[dict, List[Dict[str, str]]],
-                    client: boto3.client) -> AWSResponse:
+def get_asg_by_tags(
+    tags: Union[dict, List[Dict[str, str]]], client: boto3.client
+) -> AWSResponse:
     # The following is needed because AWS API does not support filters
     # on auto-scaling groups
 
     # fetch all ASGs using paginator
     # TODO: simplify this function (similar to actions) & update unit tests
-    page_iterator = client.get_paginator(
-        'describe_auto_scaling_groups').paginate(
-        PaginationConfig={'PageSize': 100})
+    page_iterator = client.get_paginator("describe_auto_scaling_groups").paginate(
+        PaginationConfig={"PageSize": 100}
+    )
 
-    asg_descrs = {'AutoScalingGroups': []}
+    asg_descrs = {"AutoScalingGroups": []}
 
     for page in page_iterator:
-        asg_descrs['AutoScalingGroups'].extend(page['AutoScalingGroups'])
+        asg_descrs["AutoScalingGroups"].extend(page["AutoScalingGroups"])
 
-    filter_set = set(map(lambda x: "=".join([x['Key'], x['Value']]), tags))
+    filter_set = set(map(lambda x: "=".join([x["Key"], x["Value"]]), tags))
 
-    group_sets = list(map(lambda g: {
-        'Name': g['AutoScalingGroupName'],
-        'Tags': set(map(
-            lambda t: "=".join([t['Key'], t['Value']]), g['Tags'])
-        )}, asg_descrs['AutoScalingGroups']))
+    group_sets = list(
+        map(
+            lambda g: {
+                "Name": g["AutoScalingGroupName"],
+                "Tags": set(map(lambda t: "=".join([t["Key"], t["Value"]]), g["Tags"])),
+            },
+            asg_descrs["AutoScalingGroups"],
+        )
+    )
 
-    filtered_groups = [g['Name']
-                       for g in group_sets if filter_set.issubset(g['Tags'])]
+    filtered_groups = [g["Name"] for g in group_sets if filter_set.issubset(g["Tags"])]
 
     logger.debug("filtered groups: {}".format(filtered_groups))
 
     if filtered_groups:
         groups_descr = client.describe_auto_scaling_groups(
-            AutoScalingGroupNames=filtered_groups)
+            AutoScalingGroupNames=filtered_groups
+        )
 
         return groups_descr
     else:
-        raise FailedActivity(
-            "No auto-scaling groups matched the tags provided")
+        raise FailedActivity("No auto-scaling groups matched the tags provided")
 
 
 def is_desired_equals_healthy(groups_descr: Dict) -> bool:
     result = False
-    for group_descr in groups_descr['AutoScalingGroups']:
+    for group_descr in groups_descr["AutoScalingGroups"]:
         healthy_cnt = Counter()
 
-        for instance in group_descr['Instances']:
-            if instance['LifecycleState'] == 'InService':
-                healthy_cnt[instance['HealthStatus']] += 1
+        for instance in group_descr["Instances"]:
+            if instance["LifecycleState"] == "InService":
+                healthy_cnt[instance["HealthStatus"]] += 1
 
-        if healthy_cnt['Healthy'] and group_descr[
-                'DesiredCapacity'] == healthy_cnt['Healthy']:
+        if (
+            healthy_cnt["Healthy"]
+            and group_descr["DesiredCapacity"] == healthy_cnt["Healthy"]
+        ):
             result = True
             continue
 

--- a/chaosaws/awslambda/actions.py
+++ b/chaosaws/awslambda/actions.py
@@ -4,26 +4,33 @@ from json.decoder import JSONDecodeError
 from typing import Any, Dict
 
 import boto3
-from chaoslib.exceptions import FailedActivity
 from botocore.exceptions import ClientError
+from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ["invoke_function", "put_function_concurrency",
-           "delete_function_concurrency", "put_function_timeout",
-           "put_function_memory_size", "delete_event_source_mapping",
-           "toggle_event_source_mapping_state"]
+__all__ = [
+    "invoke_function",
+    "put_function_concurrency",
+    "delete_function_concurrency",
+    "put_function_timeout",
+    "put_function_memory_size",
+    "delete_event_source_mapping",
+    "toggle_event_source_mapping_state",
+]
 
 
-def invoke_function(function_name: str,
-                    function_arguments: Dict[str, Any] = None,
-                    invocation_type: str = 'RequestResponse',
-                    client_context: Dict[str, Any] = None,
-                    qualifier: str = None,
-                    configuration: Configuration = None,
-                    secrets: Secrets = None) -> AWSResponse:
+def invoke_function(
+    function_name: str,
+    function_arguments: Dict[str, Any] = None,
+    invocation_type: str = "RequestResponse",
+    client_context: Dict[str, Any] = None,
+    qualifier: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Invokes Lambda.
 
@@ -32,64 +39,62 @@ def invoke_function(function_name: str,
     """  # noqa: E501
     client = aws_client("lambda", configuration, secrets)
     request_kwargs = {
-        'FunctionName': function_name,
-        'InvocationType': invocation_type,
-        'LogType': 'None'
+        "FunctionName": function_name,
+        "InvocationType": invocation_type,
+        "LogType": "None",
     }
     if function_arguments is not None:
-        request_kwargs['Payload'] = json.dumps(function_arguments)
+        request_kwargs["Payload"] = json.dumps(function_arguments)
     if client_context is not None:
         client_context_jsonbytes = json.dumps(client_context).encode()
         client_context_b64str = b64encode(client_context_jsonbytes).decode()
-        request_kwargs['ClientContext'] = client_context_b64str
+        request_kwargs["ClientContext"] = client_context_b64str
     if qualifier is not None:
-        request_kwargs['Qualifier'] = qualifier
+        request_kwargs["Qualifier"] = qualifier
     try:
         response = client.invoke(**request_kwargs)
     except Exception as x:
         raise FailedActivity(
-            "failed invoking function '{}': '{}'".format(
-                function_name, str(x)
-            )
+            "failed invoking function '{}': '{}'".format(function_name, str(x))
         )
-    if 'Payload' in response:
+    if "Payload" in response:
         # The payload is of type StreamingBody and
         # cannot be directly serialized into JSON
-        response_payload = response['Payload'].read().decode()
-        response.pop('Payload', None)
+        response_payload = response["Payload"].read().decode()
+        response.pop("Payload", None)
         try:
-            response['Payload'] = json.loads(response_payload)
+            response["Payload"] = json.loads(response_payload)
         except JSONDecodeError:
-            response['Payload'] = response_payload
+            response["Payload"] = response_payload
     return response
 
 
-def put_function_concurrency(function_name: str,
-                             concurrent_executions: int,
-                             configuration: Configuration = None,
-                             secrets: Secrets = None) -> AWSResponse:
+def put_function_concurrency(
+    function_name: str,
+    concurrent_executions: int,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Throttles Lambda by setting reserved concurrency amount.
     """
     client = aws_client("lambda", configuration, secrets)
     if not function_name:
-        raise FailedActivity(
-            "you must specify the lambda function name"
-        )
+        raise FailedActivity("you must specify the lambda function name")
     try:
         return client.put_function_concurrency(
             FunctionName=function_name,
-            ReservedConcurrentExecutions=concurrent_executions
+            ReservedConcurrentExecutions=concurrent_executions,
         )
     except Exception as x:
         raise FailedActivity(
-            "failed throttling lambda function '{}': '{}'".format(
-                function_name, str(x)))
+            "failed throttling lambda function '{}': '{}'".format(function_name, str(x))
+        )
 
 
-def delete_function_concurrency(function_name: str,
-                                configuration: Configuration = None,
-                                secrets: Secrets = None) -> AWSResponse:
+def delete_function_concurrency(
+    function_name: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Removes concurrency limit applied to the specified Lambda
     """
@@ -97,37 +102,43 @@ def delete_function_concurrency(function_name: str,
     return client.delete_function_concurrency(FunctionName=function_name)
 
 
-def put_function_timeout(function_name: str, timeout: int,
-                         configuration: Configuration = None,
-                         secrets: Secrets = None) -> AWSResponse:
+def put_function_timeout(
+    function_name: str,
+    timeout: int,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Sets the function timeout.
 
     Input timeout argument is specified in seconds.
     """
     client = aws_client("lambda", configuration, secrets)
-    return _update_function_configuration(function_name=function_name,
-                                          client=client,
-                                          timeout=timeout)
+    return _update_function_configuration(
+        function_name=function_name, client=client, timeout=timeout
+    )
 
 
-def put_function_memory_size(function_name: str, memory_size: int,
-                             configuration: Configuration = None,
-                             secrets: Secrets = None) -> AWSResponse:
+def put_function_memory_size(
+    function_name: str,
+    memory_size: int,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Sets the function memory size.
 
     Input memory_size argument is specified in megabytes.
     """
     client = aws_client("lambda", configuration, secrets)
-    return _update_function_configuration(function_name=function_name,
-                                          client=client,
-                                          memory_size=memory_size)
+    return _update_function_configuration(
+        function_name=function_name, client=client, memory_size=memory_size
+    )
 
 
-def delete_event_source_mapping(event_uuid: str,
-                                configuration: Configuration = None,
-                                secrets: Secrets = None) -> AWSResponse:
+def delete_event_source_mapping(
+    event_uuid: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Delete an event source mapping
 
@@ -140,13 +151,15 @@ def delete_event_source_mapping(event_uuid: str,
     try:
         return client.delete_event_source_mapping(UUID=event_uuid)
     except ClientError as e:
-        raise FailedActivity(e.response['Error']['Message'])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
-def toggle_event_source_mapping_state(event_uuid: str,
-                                      enabled: bool,
-                                      configuration: Configuration = None,
-                                      secrets: Secrets = None) -> AWSResponse:
+def toggle_event_source_mapping_state(
+    event_uuid: str,
+    enabled: bool,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Toggle an event source mapping to be disabled or enabled
 
@@ -158,24 +171,23 @@ def toggle_event_source_mapping_state(event_uuid: str,
     """
     client = aws_client("lambda", configuration, secrets)
     try:
-        return client.update_event_source_mapping(
-            UUID=event_uuid, Enabled=enabled)
+        return client.update_event_source_mapping(UUID=event_uuid, Enabled=enabled)
     except ClientError as e:
-        raise FailedActivity(e.response['Error']['Message'])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
 ###############################################################################
 # Private functions
 ###############################################################################
-def _update_function_configuration(function_name: str,
-                                   client: boto3.client,
-                                   timeout: int = None,
-                                   memory_size: int = None) -> AWSResponse:
-    request_kwargs = {
-        'FunctionName': function_name
-    }
+def _update_function_configuration(
+    function_name: str,
+    client: boto3.client,
+    timeout: int = None,
+    memory_size: int = None,
+) -> AWSResponse:
+    request_kwargs = {"FunctionName": function_name}
     if timeout is not None:
-        request_kwargs['Timeout'] = timeout
+        request_kwargs["Timeout"] = timeout
     if memory_size is not None:
-        request_kwargs['MemorySize'] = memory_size
+        request_kwargs["MemorySize"] = memory_size
     return client.update_function_configuration(**request_kwargs)

--- a/chaosaws/awslambda/probes.py
+++ b/chaosaws/awslambda/probes.py
@@ -1,19 +1,22 @@
 import boto3
+from botocore.exceptions import ClientError
+from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-from botocore.exceptions import ClientError
-from chaoslib.exceptions import FailedActivity
+__all__ = [
+    "get_function_concurrency",
+    "get_function_timeout",
+    "get_function_memory_size",
+    "list_event_source_mapping",
+]
 
-__all__ = ["get_function_concurrency", "get_function_timeout",
-           "get_function_memory_size", "list_event_source_mapping"]
 
-
-def get_function_concurrency(function_name: str, configuration:
-                             Configuration = None,
-                             secrets: Secrets = None) -> bool:
+def get_function_concurrency(
+    function_name: str, configuration: Configuration = None, secrets: Secrets = None
+) -> bool:
     """
     Get configuration information of lambda by its function name
     """
@@ -22,40 +25,48 @@ def get_function_concurrency(function_name: str, configuration:
     return result["Concurrency"]["ReservedConcurrentExecutions"]
 
 
-def get_function_timeout(function_name: str,
-                         qualifier: str = None,
-                         configuration: Configuration = None,
-                         secrets: Secrets = None) -> int:
+def get_function_timeout(
+    function_name: str,
+    qualifier: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> int:
     """
     Get the configured timeout of a lambda function.
 
     The returned timeout is specified in number of seconds.
     """
     client = aws_client("lambda", configuration, secrets)
-    function_configuration = _get_function_configuration(function_name, client,
-                                                         qualifier)
-    return function_configuration.get('Timeout')
+    function_configuration = _get_function_configuration(
+        function_name, client, qualifier
+    )
+    return function_configuration.get("Timeout")
 
 
-def get_function_memory_size(function_name: str,
-                             qualifier: str = None,
-                             configuration: Configuration = None,
-                             secrets: Secrets = None) -> int:
+def get_function_memory_size(
+    function_name: str,
+    qualifier: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> int:
     """
     Get the configured memory size of a lambda function.
 
     The returned memory size is specified in megabytes.
     """
     client = aws_client("lambda", configuration, secrets)
-    function_configuration = _get_function_configuration(function_name, client,
-                                                         qualifier)
-    return function_configuration.get('MemorySize')
+    function_configuration = _get_function_configuration(
+        function_name, client, qualifier
+    )
+    return function_configuration.get("MemorySize")
 
 
-def list_event_source_mapping(source_arn: str = None,
-                              function_name: str = None,
-                              configuration: Configuration = None,
-                              secrets: Secrets = None) -> AWSResponse:
+def list_event_source_mapping(
+    source_arn: str = None,
+    function_name: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     List event source mappings for the provided lambda function or ARN of the
     event source
@@ -68,30 +79,29 @@ def list_event_source_mapping(source_arn: str = None,
     """
     if not any([source_arn, function_name]):
         raise FailedActivity(
-            'must specify at least one of "source_arn" or "function_name"')
+            'must specify at least one of "source_arn" or "function_name"'
+        )
 
     client = aws_client("lambda", configuration, secrets)
 
     params = {
-        **({'EventSourceArn': source_arn} if source_arn else {}),
-        **({'FunctionName': function_name} if function_name else {})
+        **({"EventSourceArn": source_arn} if source_arn else {}),
+        **({"FunctionName": function_name} if function_name else {}),
     }
 
     try:
         return client.list_event_source_mappings(**params)
     except ClientError as e:
-        raise FailedActivity(e.response['Error']['Message'])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
 ###############################################################################
 # Private functions
 ###############################################################################
-def _get_function_configuration(function_name: str,
-                                client: boto3.client,
-                                qualifier: str = None) -> AWSResponse:
-    request_kwargs = {
-        'FunctionName': function_name
-    }
+def _get_function_configuration(
+    function_name: str, client: boto3.client, qualifier: str = None
+) -> AWSResponse:
+    request_kwargs = {"FunctionName": function_name}
     if qualifier is not None:
-        request_kwargs['Qualifier'] = qualifier
+        request_kwargs["Qualifier"] = qualifier
     return client.get_function_configuration(**request_kwargs)

--- a/chaosaws/cloudwatch/actions.py
+++ b/chaosaws/cloudwatch/actions.py
@@ -9,15 +9,27 @@ from logzero import logger
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ["delete_rule", "disable_rule", "enable_rule", "put_metric_data",
-           "put_rule", "put_rule_targets", "remove_rule_targets"]
+__all__ = [
+    "delete_rule",
+    "disable_rule",
+    "enable_rule",
+    "put_metric_data",
+    "put_rule",
+    "put_rule_targets",
+    "remove_rule_targets",
+]
 
 
-def put_rule(rule_name: str, schedule_expression: str = None,
-             event_pattern: str = None, state: str = None,
-             description: str = None, role_arn: str = None,
-             configuration: Configuration = None,
-             secrets: Secrets = None) -> AWSResponse:
+def put_rule(
+    rule_name: str,
+    schedule_expression: str = None,
+    event_pattern: str = None,
+    state: str = None,
+    description: str = None,
+    role_arn: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Creates or updates a CloudWatch event rule.
 
@@ -26,20 +38,22 @@ def put_rule(rule_name: str, schedule_expression: str = None,
     """  # noqa: E501
     client = aws_client("events", configuration, secrets)
     kwargs = {
-        'Name': rule_name,
-        **({'ScheduleExpression': schedule_expression}
-           if schedule_expression else {}),
-        **({'EventPattern': event_pattern} if event_pattern else {}),
-        **({'State': state} if state else {}),
-        **({'Description': description} if description else {}),
-        **({'RoleArn': role_arn} if role_arn else {})
+        "Name": rule_name,
+        **({"ScheduleExpression": schedule_expression} if schedule_expression else {}),
+        **({"EventPattern": event_pattern} if event_pattern else {}),
+        **({"State": state} if state else {}),
+        **({"Description": description} if description else {}),
+        **({"RoleArn": role_arn} if role_arn else {}),
     }
     return client.put_rule(**kwargs)
 
 
-def put_rule_targets(rule_name: str, targets: List[Dict[str, Any]],
-                     configuration: Configuration = None,
-                     secrets: Secrets = None) -> AWSResponse:
+def put_rule_targets(
+    rule_name: str,
+    targets: List[Dict[str, Any]],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Creates or update CloudWatch event rule targets.
 
@@ -50,9 +64,9 @@ def put_rule_targets(rule_name: str, targets: List[Dict[str, Any]],
     return client.put_targets(Rule=rule_name, Targets=targets)
 
 
-def disable_rule(rule_name: str,
-                 configuration: Configuration = None,
-                 secrets: Secrets = None) -> AWSResponse:
+def disable_rule(
+    rule_name: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Disables a CloudWatch rule.
     """
@@ -60,8 +74,9 @@ def disable_rule(rule_name: str,
     return client.disable_rule(Name=rule_name)
 
 
-def enable_rule(rule_name: str, configuration: Configuration = None,
-                secrets: Secrets = None) -> AWSResponse:
+def enable_rule(
+    rule_name: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Enables a CloudWatch rule.
     """
@@ -69,9 +84,12 @@ def enable_rule(rule_name: str, configuration: Configuration = None,
     return client.enable_rule(Name=rule_name)
 
 
-def delete_rule(rule_name: str, force: bool = False,
-                configuration: Configuration = None,
-                secrets: Secrets = None) -> AWSResponse:
+def delete_rule(
+    rule_name: str,
+    force: bool = False,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Deletes a CloudWatch rule.
 
@@ -85,9 +103,12 @@ def delete_rule(rule_name: str, force: bool = False,
     return client.delete_rule(Name=rule_name)
 
 
-def remove_rule_targets(rule_name: str, target_ids: List[str] = None,
-                        configuration: Configuration = None,
-                        secrets: Secrets = None) -> AWSResponse:
+def remove_rule_targets(
+    rule_name: str,
+    target_ids: List[str] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Removes CloudWatch rule targets. If no target ids are provided all targets will be removed.
     """  # noqa: E501
@@ -97,10 +118,12 @@ def remove_rule_targets(rule_name: str, target_ids: List[str] = None,
     return _remove_rule_targets(rule_name, target_ids, client)
 
 
-def put_metric_data(namespace: str,
-                    metric_data: List[Dict[str, Any]],
-                    configuration: Configuration = None,
-                    secrets: Secrets = None):
+def put_metric_data(
+    namespace: str,
+    metric_data: List[Dict[str, Any]],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+):
     """
     Publish metric data points to CloudWatch
 
@@ -128,51 +151,48 @@ def put_metric_data(namespace: str,
 
     For additional information, consult: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch.html#CloudWatch.Client.put_metric_data
     """  # noqa: E501
-    params = {
-        'Namespace': namespace,
-        'MetricData': metric_data
-    }
+    params = {"Namespace": namespace, "MetricData": metric_data}
 
-    client = aws_client('cloudwatch', configuration, secrets)
+    client = aws_client("cloudwatch", configuration, secrets)
 
     try:
         client.put_metric_data(**params)
     except ClientError as e:
-        raise FailedActivity(e.response['Error']['Message'])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
 ###############################################################################
 # Private functions
 ###############################################################################
-def _remove_rule_targets(rule_name: str,
-                         target_ids: Union[str, List[str]],
-                         client: boto3.client):
+def _remove_rule_targets(
+    rule_name: str, target_ids: Union[str, List[str]], client: boto3.client
+):
     """
     Removes provided CloudWatch rule targets.
     """
     logger.debug(
         "Removing {} targets from rule {}: {}".format(
-            len(target_ids), rule_name, target_ids)
+            len(target_ids), rule_name, target_ids
+        )
     )
     return client.remove_targets(Rule=rule_name, Ids=target_ids)
 
 
-def _get_rule_target_ids(rule_name: str, client: boto3.client,
-                         limit: int = None):
+def _get_rule_target_ids(rule_name: str, client: boto3.client, limit: int = None):
     """
     Return all targets for a provided CloudWatch rule name.
     """
     request_kwargs = {
-        'Rule': rule_name,
-        **({'Limit': limit} if limit else {}),
+        "Rule": rule_name,
+        **({"Limit": limit} if limit else {}),
     }
 
     targets = []
     while True:
         response = client.list_targets_by_rule(**request_kwargs)
-        targets += response['Targets']
-        next_token = response.get('NextToken')
+        targets += response["Targets"]
+        next_token = response.get("NextToken")
         if next_token is None:
             break
-        request_kwargs['NextToken'] = next_token
-    return [t['Id'] for t in targets]
+        request_kwargs["NextToken"] = next_token
+    return [t["Id"] for t in targets]

--- a/chaosaws/ec2/actions.py
+++ b/chaosaws/ec2/actions.py
@@ -5,21 +5,33 @@ from typing import Any, Dict, List, Union
 
 import boto3
 from botocore.exceptions import ClientError
-from chaosaws import aws_client
-from chaosaws.types import AWSResponse
-from chaoslib.exceptions import FailedActivity, ActivityFailed
+from chaoslib.exceptions import ActivityFailed, FailedActivity
 from chaoslib.types import Configuration, Secrets
 from logzero import logger
 
-__all__ = ["stop_instance", "stop_instances", "terminate_instances",
-           "terminate_instance", "start_instances", "restart_instances",
-           "detach_random_volume", "attach_volume"]
+from chaosaws import aws_client
+from chaosaws.types import AWSResponse
+
+__all__ = [
+    "stop_instance",
+    "stop_instances",
+    "terminate_instances",
+    "terminate_instance",
+    "start_instances",
+    "restart_instances",
+    "detach_random_volume",
+    "attach_volume",
+]
 
 
-def stop_instance(instance_id: str = None, az: str = None, force: bool = False,
-                  filters: List[Dict[str, Any]] = None,
-                  configuration: Configuration = None,
-                  secrets: Secrets = None) -> List[AWSResponse]:
+def stop_instance(
+    instance_id: str = None,
+    az: str = None,
+    force: bool = False,
+    filters: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Stop a single EC2 instance.
 
@@ -32,39 +44,46 @@ def stop_instance(instance_id: str = None, az: str = None, force: bool = False,
     if not az and not instance_id and not filters:
         raise FailedActivity(
             "To stop an EC2 instance, you must specify either the instance id,"
-            " an AZ to pick a random instance from, or a set of filters.")
+            " an AZ to pick a random instance from, or a set of filters."
+        )
 
     if az and not instance_id and not filters:
-        logger.warning('Based on configuration provided I am going to '
-                       'stop a random instance in AZ %s!' % az)
+        logger.warning(
+            "Based on configuration provided I am going to "
+            "stop a random instance in AZ %s!" % az
+        )
 
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
 
     if not instance_id:
         filters = deepcopy(filters) if filters else []
 
         if az:
-            filters.append({'Name': 'availability-zone', 'Values': [az]})
+            filters.append({"Name": "availability-zone", "Values": [az]})
         instance_types = pick_random_instance(filters, client)
 
         if not instance_types:
-            raise FailedActivity(
-                "No instances in availability zone: {}".format(az))
+            raise FailedActivity("No instances in availability zone: {}".format(az))
     else:
         instance_types = get_instance_type_by_id([instance_id], client)
 
     logger.debug(
-        "Picked EC2 instance '{}' from AZ '{}' to be stopped".format(
-            instance_types, az))
+        "Picked EC2 instance '{}' from AZ '{}' to be stopped".format(instance_types, az)
+    )
 
-    return stop_instances_any_type(instance_types=instance_types,
-                                   force=force, client=client)
+    return stop_instances_any_type(
+        instance_types=instance_types, force=force, client=client
+    )
 
 
-def stop_instances(instance_ids: List[str] = None, az: str = None,
-                   filters: List[Dict[str, Any]] = None,
-                   force: bool = False, configuration: Configuration = None,
-                   secrets: Secrets = None) -> List[AWSResponse]:
+def stop_instances(
+    instance_ids: List[str] = None,
+    az: str = None,
+    filters: List[Dict[str, Any]] = None,
+    force: bool = False,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Stop the given EC2 instances or, if none is provided, all instances
     of the given availability zone. If you need more control, you can
@@ -75,39 +94,47 @@ def stop_instances(instance_ids: List[str] = None, az: str = None,
     if not az and not instance_ids and not filters:
         raise FailedActivity(
             "To stop EC2 instances, you must specify either the instance ids,"
-            " an AZ to pick random instances from, or a set of filters.")
+            " an AZ to pick random instances from, or a set of filters."
+        )
 
     if az and not instance_ids and not filters:
-        logger.warning('Based on configuration provided I am going to '
-                       'stop all instances in AZ %s!' % az)
+        logger.warning(
+            "Based on configuration provided I am going to "
+            "stop all instances in AZ %s!" % az
+        )
 
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
 
     if not instance_ids:
         filters = deepcopy(filters) if filters else []
 
         if az:
-            filters.append({'Name': 'availability-zone', 'Values': [az]})
+            filters.append({"Name": "availability-zone", "Values": [az]})
         instance_types = list_instances_by_type(filters, client)
 
         if not instance_types:
-            raise FailedActivity(
-                "No instances in availability zone: {}".format(az))
+            raise FailedActivity("No instances in availability zone: {}".format(az))
     else:
         instance_types = get_instance_type_by_id(instance_ids, client)
 
     logger.debug(
         "Picked EC2 instances '{}' from AZ '{}' to be stopped".format(
-            str(instance_types), az))
+            str(instance_types), az
+        )
+    )
 
-    return stop_instances_any_type(instance_types=instance_types,
-                                   force=force, client=client)
+    return stop_instances_any_type(
+        instance_types=instance_types, force=force, client=client
+    )
 
 
-def terminate_instance(instance_id: str = None, az: str = None,
-                       filters: List[Dict[str, Any]] = None,
-                       configuration: Configuration = None,
-                       secrets: Secrets = None) -> List[AWSResponse]:
+def terminate_instance(
+    instance_id: str = None,
+    az: str = None,
+    filters: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Terminates a single EC2 instance.
 
@@ -119,40 +146,48 @@ def terminate_instance(instance_id: str = None, az: str = None,
     """
 
     if not any([instance_id, az, filters]):
-        raise FailedActivity('To terminate an EC2, you must specify the '
-                             'instance-id, an Availability Zone, or provide a '
-                             'set of filters')
+        raise FailedActivity(
+            "To terminate an EC2, you must specify the "
+            "instance-id, an Availability Zone, or provide a "
+            "set of filters"
+        )
 
     if az and not any([instance_id, filters]):
-        logger.warning('Based on configuration provided I am going to '
-                       'terminate a random instance in AZ %s!' % az)
+        logger.warning(
+            "Based on configuration provided I am going to "
+            "terminate a random instance in AZ %s!" % az
+        )
 
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
     if not instance_id:
         filters = deepcopy(filters) or []
 
         if az:
-            filters.append({'Name': 'availability-zone', 'Values': [az]})
-            logger.debug('Looking for instances in AZ: %s' % az)
+            filters.append({"Name": "availability-zone", "Values": [az]})
+            logger.debug("Looking for instances in AZ: %s" % az)
 
         # Randomly select an instance
         instance_types = pick_random_instance(filters, client)
 
         if not instance_types:
             raise FailedActivity(
-                'No instances found matching filters: %s' % str(filters))
+                "No instances found matching filters: %s" % str(filters)
+            )
 
-        logger.debug('Instance selected: %s' % str(instance_types))
+        logger.debug("Instance selected: %s" % str(instance_types))
     else:
         instance_types = get_instance_type_by_id([instance_id], client)
 
     return terminate_instances_any_type(instance_types, client)
 
 
-def terminate_instances(instance_ids: List[str] = None, az: str = None,
-                        filters: List[Dict[str, Any]] = None,
-                        configuration: Configuration = None,
-                        secrets: Secrets = None) -> List[AWSResponse]:
+def terminate_instances(
+    instance_ids: List[str] = None,
+    az: str = None,
+    filters: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Terminates multiple EC2 instances
 
@@ -165,41 +200,48 @@ def terminate_instances(instance_ids: List[str] = None, az: str = None,
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_instances
     """
     if not any([instance_ids, az, filters]):
-        raise FailedActivity('To terminate instances, you must specify the '
-                             'instance-id, an Availability Zone, or provide a '
-                             'set of filters')
+        raise FailedActivity(
+            "To terminate instances, you must specify the "
+            "instance-id, an Availability Zone, or provide a "
+            "set of filters"
+        )
 
     if az and not any([instance_ids, filters]):
-        logger.warning('Based on configuration provided I am going to '
-                       'terminate all instances in AZ %s!' % az)
+        logger.warning(
+            "Based on configuration provided I am going to "
+            "terminate all instances in AZ %s!" % az
+        )
 
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
     if not instance_ids:
         filters = deepcopy(filters) or []
 
         if az:
-            filters.append({'Name': 'availability-zone', 'Values': [az]})
-            logger.debug('Looking for instances in AZ: %s' % az)
+            filters.append({"Name": "availability-zone", "Values": [az]})
+            logger.debug("Looking for instances in AZ: %s" % az)
 
         # Select instances based on filters
         instance_types = list_instances_by_type(filters, client)
 
         if not instance_types:
             raise FailedActivity(
-                'No instances found matching filters: %s' % str(filters))
+                "No instances found matching filters: %s" % str(filters)
+            )
 
-        logger.debug('Instances in AZ %s selected: %s}.' % (
-            az, str(instance_types)))
+        logger.debug("Instances in AZ %s selected: %s}." % (az, str(instance_types)))
     else:
         instance_types = get_instance_type_by_id(instance_ids, client)
 
     return terminate_instances_any_type(instance_types, client)
 
 
-def start_instances(instance_ids: List[str] = None, az: str = None,
-                    filters: List[Dict[str, Any]] = None,
-                    configuration: Configuration = None,
-                    secrets: Secrets = None) -> List[AWSResponse]:
+def start_instances(
+    instance_ids: List[str] = None,
+    az: str = None,
+    filters: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Starts one or more EC2 instances.
 
@@ -210,41 +252,48 @@ def start_instances(instance_ids: List[str] = None, az: str = None,
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_instances
     """
     if not any([instance_ids, az, filters]):
-        raise FailedActivity('To start instances, you must specify the '
-                             'instance-id, an Availability Zone, or provide a '
-                             'set of filters')
+        raise FailedActivity(
+            "To start instances, you must specify the "
+            "instance-id, an Availability Zone, or provide a "
+            "set of filters"
+        )
 
     if az and not any([instance_ids, filters]):
-        logger.warning('Based on configuration provided I am going to '
-                       'start all instances in AZ %s!' % az)
+        logger.warning(
+            "Based on configuration provided I am going to "
+            "start all instances in AZ %s!" % az
+        )
 
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
 
     if not instance_ids:
         filters = deepcopy(filters) or []
 
         if az:
-            filters.append({'Name': 'availability-zone', 'Values': [az]})
-            logger.debug('Looking for instances in AZ: %s' % az)
+            filters.append({"Name": "availability-zone", "Values": [az]})
+            logger.debug("Looking for instances in AZ: %s" % az)
 
         # Select instances based on filters
         instance_types = list_instances_by_type(filters, client)
 
         if not instance_types:
             raise FailedActivity(
-                'No instances found matching filters: %s' % str(filters))
+                "No instances found matching filters: %s" % str(filters)
+            )
 
-        logger.debug('Instances in AZ %s selected: %s}.' % (
-            az, str(instance_types)))
+        logger.debug("Instances in AZ %s selected: %s}." % (az, str(instance_types)))
     else:
         instance_types = get_instance_type_by_id(instance_ids, client)
     return start_instances_any_type(instance_types, client)
 
 
-def restart_instances(instance_ids: List[str] = None, az: str = None,
-                      filters: List[Dict[str, Any]] = None,
-                      configuration: Configuration = None,
-                      secrets: Secrets = None) -> List[AWSResponse]:
+def restart_instances(
+    instance_ids: List[str] = None,
+    az: str = None,
+    filters: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Restarts one or more EC2 instances.
 
@@ -255,60 +304,68 @@ def restart_instances(instance_ids: List[str] = None, az: str = None,
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_instances
     """
     if not any([instance_ids, az, filters]):
-        raise FailedActivity('To restart instances, you must specify the '
-                             'instance-id, an Availability Zone, or provide a '
-                             'set of filters')
+        raise FailedActivity(
+            "To restart instances, you must specify the "
+            "instance-id, an Availability Zone, or provide a "
+            "set of filters"
+        )
 
     if az and not any([instance_ids, filters]):
-        logger.warning('Based on configuration provided I am going to '
-                       'restart all instances in AZ %s!' % az)
+        logger.warning(
+            "Based on configuration provided I am going to "
+            "restart all instances in AZ %s!" % az
+        )
 
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
 
     if not instance_ids:
         filters = deepcopy(filters) or []
 
         if az:
-            filters.append({'Name': 'availability-zone', 'Values': [az]})
-            logger.debug('Looking for instances in AZ: %s' % az)
+            filters.append({"Name": "availability-zone", "Values": [az]})
+            logger.debug("Looking for instances in AZ: %s" % az)
 
         # Select instances based on filters
         instance_types = list_instances_by_type(filters, client)
 
         if not instance_types:
             raise FailedActivity(
-                'No instances found matching filters: %s' % str(filters))
+                "No instances found matching filters: %s" % str(filters)
+            )
 
-        logger.debug('Instances in AZ %s selected: %s}.' % (
-            az, str(instance_types)))
+        logger.debug("Instances in AZ %s selected: %s}." % (az, str(instance_types)))
     else:
         instance_types = get_instance_type_by_id(instance_ids, client)
     return restart_instances_any_type(instance_types, client)
 
 
-def detach_random_volume(instance_ids: List[str] = None,
-                         filters: List[Dict[str, Any]] = None,
-                         force: bool = True,
-                         configuration: Configuration = None,
-                         secrets: Secrets = None) -> List[AWSResponse]:
+def detach_random_volume(
+    instance_ids: List[str] = None,
+    filters: List[Dict[str, Any]] = None,
+    force: bool = True,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
-        Detaches a random ebs volume (non root) from one or more EC2 instances
+    Detaches a random ebs volume (non root) from one or more EC2 instances
 
-        Parameters:
-            One of:
-                instance_ids: a list of one or more ec2 instance ids
-                filters: a list of key/value pairs to pull ec2 instances
+    Parameters:
+        One of:
+            instance_ids: a list of one or more ec2 instance ids
+            filters: a list of key/value pairs to pull ec2 instances
 
-            force: force detach volume (default: true)
+        force: force detach volume (default: true)
 
-        Additional filters may be used to narrow the scope:
-        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_instances
+    Additional filters may be used to narrow the scope:
+    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_instances
     """
     if not any([instance_ids, filters]):
-        raise FailedActivity('To detach volumes, you must specify the '
-                             'instance_id or provide a set of filters')
+        raise FailedActivity(
+            "To detach volumes, you must specify the "
+            "instance_id or provide a set of filters"
+        )
 
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
 
     if not instance_ids:
         filters = deepcopy(filters) or []
@@ -322,10 +379,12 @@ def detach_random_volume(instance_ids: List[str] = None,
     return results
 
 
-def attach_volume(instance_ids: List[str] = None,
-                  filters: List[Dict[str, Any]] = None,
-                  configuration: Configuration = None,
-                  secrets: Secrets = None) -> List[AWSResponse]:
+def attach_volume(
+    instance_ids: List[str] = None,
+    filters: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Attaches a previously detached EBS volume to its associated EC2 instance.
 
@@ -337,7 +396,7 @@ def attach_volume(instance_ids: List[str] = None,
             instance_ids: list: instance ids
             filters: list: key/value pairs to pull ec2 instances
     """
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
 
     if not instance_ids and not filters:
         instances = []
@@ -350,25 +409,28 @@ def attach_volume(instance_ids: List[str] = None,
     volumes = get_detached_volumes(client)
     results = []
     for volume in volumes:
-        for t in volume['Tags']:
-            if t['Key'] != 'ChaosToolkitDetached':
+        for t in volume["Tags"]:
+            if t["Key"] != "ChaosToolkitDetached":
                 continue
-            attach_data = t['Value'].split(';')
-            device_name = attach_data[0].split('=')[-1]
-            instance_id = attach_data[1].split('=')[-1]
+            attach_data = t["Value"].split(";")
+            device_name = attach_data[0].split("=")[-1]
+            instance_id = attach_data[1].split("=")[-1]
 
-            if not instances or instance_id in [
-                    e['InstanceId'] for e in instances]:
-                results.append(attach_instance_volume(
-                    client, instance_id, volume['VolumeId'], device_name))
+            if not instances or instance_id in [e["InstanceId"] for e in instances]:
+                results.append(
+                    attach_instance_volume(
+                        client, instance_id, volume["VolumeId"], device_name
+                    )
+                )
     return results
 
 
 ###############################################################################
 # Private functions
 ###############################################################################
-def list_instances_by_type(filters: List[Dict[str, Any]],
-                           client: boto3.client) -> Dict[str, Any]:
+def list_instances_by_type(
+    filters: List[Dict[str, Any]], client: boto3.client
+) -> Dict[str, Any]:
     """
     Return all instance ids matching the given filters by type
     (InstanceLifecycle) ie spot, on demand, etc.
@@ -380,9 +442,11 @@ def list_instances_by_type(filters: List[Dict[str, Any]],
     return get_instance_type_from_response(res)
 
 
-def list_instances(client: boto3.client,
-                   filters: List[Dict[str, Any]] = None,
-                   instance_ids: List[str] = None) -> List[Dict[str, Any]]:
+def list_instances(
+    client: boto3.client,
+    filters: List[Dict[str, Any]] = None,
+    instance_ids: List[str] = None,
+) -> List[Dict[str, Any]]:
     """
     Return all instance ids matching either the filters or provided list of ids
 
@@ -394,17 +458,18 @@ def list_instances(client: boto3.client,
         params = dict(InstanceIds=instance_ids)
 
     results = []
-    response = client.describe_instances(**params)['Reservations']
+    response = client.describe_instances(**params)["Reservations"]
     for r in response:
-        for e in r['Instances']:
+        for e in r["Instances"]:
             results.append(e)
     return results
 
 
 def list_instance_volumes(
-        client: boto3.client,
-        instance_ids: List[str] = None,
-        filters: List[Dict[str, Any]] = None) -> List[AWSResponse]:
+    client: boto3.client,
+    instance_ids: List[str] = None,
+    filters: List[Dict[str, Any]] = None,
+) -> List[AWSResponse]:
     """
     Return all (non root) instance volumes for instances matching either
     the provided filters or instance ids (do not group by type)
@@ -414,34 +479,35 @@ def list_instance_volumes(
     else:
         params = dict(InstanceIds=instance_ids)
 
-    response = client.describe_instances(**params)['Reservations']
+    response = client.describe_instances(**params)["Reservations"]
 
     if not response:
-        raise FailedActivity('no instances found matching: %s' % str(params))
+        raise FailedActivity("no instances found matching: %s" % str(params))
 
     results = {}
     for r in response:
-        for e in r['Instances']:
-            instance_id = e['InstanceId']
-            bdm = e.get('BlockDeviceMappings', [])
+        for e in r["Instances"]:
+            instance_id = e["InstanceId"]
+            bdm = e.get("BlockDeviceMappings", [])
             for b in bdm:
-                if b['DeviceName'] in ('/dev/sda1', '/dev/xvda'):
+                if b["DeviceName"] in ("/dev/sda1", "/dev/xvda"):
                     continue
                 results.setdefault(instance_id, []).append(
-                    {b['DeviceName']: b['Ebs']['VolumeId']})
+                    {b["DeviceName"]: b["Ebs"]["VolumeId"]}
+                )
 
     volumes = []
     for r in results:
         # select 1 volume at random
         volume = random.sample(results[r], 1)[0]
         for k, v in volume.items():
-            volumes.append(
-                {'InstanceId': r, 'DeviceName': k, 'VolumeId': v})
+            volumes.append({"InstanceId": r, "DeviceName": k, "VolumeId": v})
     return volumes
 
 
-def pick_random_instance(filters: List[Dict[str, Any]],
-                         client: boto3.client) -> Union[str, dict, None]:
+def pick_random_instance(
+    filters: List[Dict[str, Any]], client: boto3.client
+) -> Union[str, dict, None]:
     """
     Select an instance at random based on the returned list of instances
     matching the given filter.
@@ -450,8 +516,9 @@ def pick_random_instance(filters: List[Dict[str, Any]],
     if not instances_type:
         return
 
-    random_id = random.choice([item for sublist in instances_type.values()
-                               for item in sublist])
+    random_id = random.choice(
+        [item for sublist in instances_type.values() for item in sublist]
+    )
 
     for k, v in instances_type.items():
         if random_id in v:
@@ -465,20 +532,19 @@ def get_instance_type_from_response(response: Dict) -> Dict:
     instances_type = defaultdict(List)
     # reservations are instances that were started together
 
-    for reservation in response['Reservations']:
-        for inst in reservation['Instances']:
+    for reservation in response["Reservations"]:
+        for inst in reservation["Instances"]:
             # when this field is missing, we assume "normal"
             # which means On-Demand or Reserved
             # this seems what the last line of the docs imply at
             # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-purchasing-options.html
-            lifecycle = inst.get('InstanceLifecycle', 'normal')
+            lifecycle = inst.get("InstanceLifecycle", "normal")
 
             if lifecycle not in instances_type.keys():
                 # adding empty list (value) for new instance type (key)
                 instances_type[lifecycle] = []
 
-            instances_type[lifecycle].append(
-                inst['InstanceId'])
+            instances_type[lifecycle].append(inst["InstanceId"])
 
     return instances_type
 
@@ -490,20 +556,19 @@ def get_spot_request_ids_from_response(response: Dict) -> List[str]:
     """
     spot_request_ids = []
 
-    for reservation in response['Reservations']:
-        for inst in reservation['Instances']:
+    for reservation in response["Reservations"]:
+        for inst in reservation["Instances"]:
             # when this field is missing, we assume "normal"
             # which means On-Demand or Reserved
-            lifecycle = inst.get('InstanceLifecycle', 'normal')
+            lifecycle = inst.get("InstanceLifecycle", "normal")
 
-            if lifecycle == 'spot':
-                spot_request_ids.append(inst['SpotInstanceRequestId'])
+            if lifecycle == "spot":
+                spot_request_ids.append(inst["SpotInstanceRequestId"])
 
     return spot_request_ids
 
 
-def get_instance_type_by_id(instance_ids: List[str],
-                            client: boto3.client) -> Dict:
+def get_instance_type_by_id(instance_ids: List[str], client: boto3.client) -> Dict:
     """
     Return dict object with instance ids grouped by instance types
     """
@@ -513,159 +578,160 @@ def get_instance_type_by_id(instance_ids: List[str],
     return get_instance_type_from_response(res)
 
 
-def stop_instances_any_type(instance_types: dict = None,
-                            force: bool = False,
-                            client: boto3.client = None
-                            ) -> List[AWSResponse]:
+def stop_instances_any_type(
+    instance_types: dict = None, force: bool = False, client: boto3.client = None
+) -> List[AWSResponse]:
     """
     Stop instances regardless of the instance type (on demand, spot)
     """
 
     response = []
-    if 'normal' in instance_types:
-        logger.debug("Stopping instances: {}".format(instance_types['normal']))
+    if "normal" in instance_types:
+        logger.debug("Stopping instances: {}".format(instance_types["normal"]))
 
         response.append(
-            client.stop_instances(
-                InstanceIds=instance_types['normal'],
-                Force=force))
+            client.stop_instances(InstanceIds=instance_types["normal"], Force=force)
+        )
 
-    if 'spot' in instance_types:
+    if "spot" in instance_types:
         # TODO: proper support for spot fleets
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet.html
 
         # To properly stop spot instances have to cancel spot requests first
         spot_request_ids = get_spot_request_ids_from_response(
-            client.describe_instances(InstanceIds=instance_types['spot']))
+            client.describe_instances(InstanceIds=instance_types["spot"])
+        )
 
         logger.debug("Canceling spot requests: {}".format(spot_request_ids))
-        client.cancel_spot_instance_requests(
-            SpotInstanceRequestIds=spot_request_ids)
-        logger.debug("Terminating spot instances: {}".format(
-            instance_types['spot']))
+        client.cancel_spot_instance_requests(SpotInstanceRequestIds=spot_request_ids)
+        logger.debug("Terminating spot instances: {}".format(instance_types["spot"]))
 
-        response.append(client.terminate_instances(
-            InstanceIds=instance_types['spot']))
+        response.append(client.terminate_instances(InstanceIds=instance_types["spot"]))
 
-    if 'scheduled' in instance_types:
+    if "scheduled" in instance_types:
         # TODO: add support for scheduled instances
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-scheduled-instances.html
         raise FailedActivity("Scheduled instances support is not implemented")
     return response
 
 
-def terminate_instances_any_type(instance_types: dict = None,
-                                 client: boto3.client = None
-                                 ) -> List[AWSResponse]:
+def terminate_instances_any_type(
+    instance_types: dict = None, client: boto3.client = None
+) -> List[AWSResponse]:
     """
     Terminates instance(s) regardless of type
     """
     response = []
 
     for k, v in instance_types.items():
-        logger.debug('Terminating %s instance(s): %s' % (k, instance_types[k]))
-        if k == 'spot':
+        logger.debug("Terminating %s instance(s): %s" % (k, instance_types[k]))
+        if k == "spot":
             instances = get_spot_request_ids_from_response(
-                client.describe_instances(InstanceIds=v))
+                client.describe_instances(InstanceIds=v)
+            )
             # Cancel spot request prior to termination
-            client.cancel_spot_instance_requests(
-                SpotInstanceRequestIds=instances)
+            client.cancel_spot_instance_requests(SpotInstanceRequestIds=instances)
             response.append(client.terminate_instances(InstanceIds=v))
             continue
         response.append(client.terminate_instances(InstanceIds=v))
     return response
 
 
-def start_instances_any_type(instance_types: dict,
-                             client: boto3.client) -> List[AWSResponse]:
+def start_instances_any_type(
+    instance_types: dict, client: boto3.client
+) -> List[AWSResponse]:
     """
     Starts one or more instances regardless of type
     """
     results = []
     for k, v in instance_types.items():
-        logger.debug('Starting %s instance(s): %s' % (k, v))
+        logger.debug("Starting %s instance(s): %s" % (k, v))
         response = client.start_instances(InstanceIds=v)
-        results.extend(response.get('StartingInstances', []))
+        results.extend(response.get("StartingInstances", []))
     return results
 
 
-def restart_instances_any_type(instance_types: dict,
-                               client: boto3.client):
+def restart_instances_any_type(instance_types: dict, client: boto3.client):
     """
     Restarts one or more instances regardless of type
     """
     results = []
     for k, v in instance_types.items():
-        logger.debug('Restarting %s instance(s): %s' % (k, v))
+        logger.debug("Restarting %s instance(s): %s" % (k, v))
         client.reboot_instances(InstanceIds=v)
     return results
 
 
-def detach_instance_volume(client: boto3.client,
-                           force: bool,
-                           volume: Dict[str, str]) -> AWSResponse:
+def detach_instance_volume(
+    client: boto3.client, force: bool, volume: Dict[str, str]
+) -> AWSResponse:
     """
     Detach volume from an instance
     """
     try:
         response = client.detach_volume(
-            Device=volume['DeviceName'],
-            InstanceId=volume['InstanceId'],
-            VolumeId=volume['VolumeId'],
-            Force=force)
+            Device=volume["DeviceName"],
+            InstanceId=volume["InstanceId"],
+            VolumeId=volume["VolumeId"],
+            Force=force,
+        )
 
         # tag volume with instance information (to reattach on rollback)
         client.create_tags(
-            Resources=[volume['VolumeId']],
+            Resources=[volume["VolumeId"]],
             Tags=[
                 {
-                    'Key': 'ChaosToolkitDetached',
-                    'Value': 'DeviceName=%s;InstanceId=%s' % (
-                        volume['DeviceName'], volume['InstanceId'])
-                }])
+                    "Key": "ChaosToolkitDetached",
+                    "Value": "DeviceName=%s;InstanceId=%s"
+                    % (volume["DeviceName"], volume["InstanceId"]),
+                }
+            ],
+        )
         return response
     except ClientError as e:
-        raise FailedActivity('unable to detach volume %s from %s: %s' % (
-            volume['VolumeId'], volume['InstanceId'],
-            e.response['Error']['Message']))
+        raise FailedActivity(
+            "unable to detach volume %s from %s: %s"
+            % (volume["VolumeId"], volume["InstanceId"], e.response["Error"]["Message"])
+        )
 
 
 def get_detached_volumes(client: boto3.client):
     results = []
-    paginator = client.get_paginator('describe_volumes')
+    paginator = client.get_paginator("describe_volumes")
     for p in paginator.paginate(
-            Filters=[{'Name': 'tag-key', 'Values': ['ChaosToolkitDetached']}]):
-        for v in p['Volumes']:
+        Filters=[{"Name": "tag-key", "Values": ["ChaosToolkitDetached"]}]
+    ):
+        for v in p["Volumes"]:
             results.append(v)
     return results
 
 
-def attach_instance_volume(client: boto3.client,
-                           instance_id: str,
-                           volume_id: str,
-                           mount_point: str) -> AWSResponse:
+def attach_instance_volume(
+    client: boto3.client, instance_id: str, volume_id: str, mount_point: str
+) -> AWSResponse:
     try:
         response = client.attach_volume(
-            Device=mount_point,
-            InstanceId=instance_id,
-            VolumeId=volume_id)
-        logger.debug('Attached volume %s to instance %s' % (
-            volume_id, instance_id))
+            Device=mount_point, InstanceId=instance_id, VolumeId=volume_id
+        )
+        logger.debug("Attached volume %s to instance %s" % (volume_id, instance_id))
     except ClientError as e:
         raise FailedActivity(
-            'Unable to attach volume %s to instance %s: %s' % (
-                volume_id, instance_id, e.response['Error']['Message']))
+            "Unable to attach volume %s to instance %s: %s"
+            % (volume_id, instance_id, e.response["Error"]["Message"])
+        )
     return response
 
 
-def authorize_security_group_ingress(requested_security_group_id: str,
-                                     ip_protocol: str,
-                                     from_port: int,
-                                     to_port: int,
-                                     ingress_security_group_id: str = None,
-                                     cidr_ip: str = None,
-                                     configuration: Configuration = None,
-                                     secrets: Secrets = None) -> AWSResponse:
+def authorize_security_group_ingress(
+    requested_security_group_id: str,
+    ip_protocol: str,
+    from_port: int,
+    to_port: int,
+    ingress_security_group_id: str = None,
+    cidr_ip: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Add one ingress rule to a security group
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.authorize_security_group_ingress
@@ -678,32 +744,34 @@ def authorize_security_group_ingress(requested_security_group_id: str,
     - cidr_ip: the IPv6 CIDR range.
     You can either specify this or ingress_security_group_id
     """  # noqa: E501
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
     request_kwargs = create_ingress_kwargs(
         requested_security_group_id,
         ip_protocol,
         from_port,
         to_port,
         ingress_security_group_id,
-        cidr_ip
+        cidr_ip,
     )
     try:
         response = client.authorize_security_group_ingress(**request_kwargs)
         return response
     except ClientError as e:
         raise ActivityFailed(
-            'Failed to add ingress rule: {}'.format(
-                e.response["Error"]["Message"]))
+            "Failed to add ingress rule: {}".format(e.response["Error"]["Message"])
+        )
 
 
-def revoke_security_group_ingress(requested_security_group_id: str,
-                                  ip_protocol: str,
-                                  from_port: int,
-                                  to_port: int,
-                                  ingress_security_group_id: str = None,
-                                  cidr_ip: str = None,
-                                  configuration: Configuration = None,
-                                  secrets: Secrets = None) -> AWSResponse:
+def revoke_security_group_ingress(
+    requested_security_group_id: str,
+    ip_protocol: str,
+    from_port: int,
+    to_port: int,
+    ingress_security_group_id: str = None,
+    cidr_ip: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Remove one ingress rule from a security group
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.revoke_security_group_ingress
@@ -715,51 +783,57 @@ def revoke_security_group_ingress(requested_security_group_id: str,
     - ingress_security_group_id: id of the securiy group to allow access to. You can either specify this or cidr_ip.
     - cidr_ip: the IPv6 CIDR range. You can either specify this or ingress_security_group_id
     """  # noqa: E501
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
     request_kwargs = create_ingress_kwargs(
         requested_security_group_id,
         ip_protocol,
         from_port,
         to_port,
         ingress_security_group_id,
-        cidr_ip
+        cidr_ip,
     )
     try:
         response = client.revoke_security_group_ingress(**request_kwargs)
         return response
     except ClientError as e:
         raise ActivityFailed(
-            'Failed to remove ingress rule: {}'.format(
-                e.response["Error"]["Message"]))
+            "Failed to remove ingress rule: {}".format(e.response["Error"]["Message"])
+        )
 
 
-def create_ingress_kwargs(requested_security_group_id: str,
-                          ip_protocol: str,
-                          from_port: int,
-                          to_port: int,
-                          ingress_security_group_id: str = None,
-                          cidr_ip: str = None,) -> Dict[str, any]:
+def create_ingress_kwargs(
+    requested_security_group_id: str,
+    ip_protocol: str,
+    from_port: int,
+    to_port: int,
+    ingress_security_group_id: str = None,
+    cidr_ip: str = None,
+) -> Dict[str, any]:
     request_kwargs = {
-        'GroupId': requested_security_group_id,
-        'IpPermissions': [
+        "GroupId": requested_security_group_id,
+        "IpPermissions": [
             {
-                'IpProtocol': ip_protocol,
-                'IpRanges': [{
-                    # conditionally assign the following
-                    # 'CidrIp': cidr_ip
-                }],
-                'FromPort': from_port,
-                'ToPort': to_port,
-                'UserIdGroupPairs': [{
-                    # conditionally assign the following
-                    # 'GroupId': ingress_security_group_id
-                }]
+                "IpProtocol": ip_protocol,
+                "IpRanges": [
+                    {
+                        # conditionally assign the following
+                        # 'CidrIp': cidr_ip
+                    }
+                ],
+                "FromPort": from_port,
+                "ToPort": to_port,
+                "UserIdGroupPairs": [
+                    {
+                        # conditionally assign the following
+                        # 'GroupId': ingress_security_group_id
+                    }
+                ],
             }
-        ]
+        ],
     }
-    req = request_kwargs['IpPermissions'][0]
+    req = request_kwargs["IpPermissions"][0]
     if cidr_ip is not None:
-        req['IpRanges'][0]['CidrIp'] = cidr_ip
+        req["IpRanges"][0]["CidrIp"] = cidr_ip
     if ingress_security_group_id is not None:
-        req['UserIdGroupPairs'][0]['GroupId'] = ingress_security_group_id
+        req["UserIdGroupPairs"][0]["GroupId"] = ingress_security_group_id
     return request_kwargs

--- a/chaosaws/ec2/actions.py
+++ b/chaosaws/ec2/actions.py
@@ -572,7 +572,6 @@ def get_instance_type_by_id(instance_ids: List[str], client: boto3.client) -> Di
     """
     Return dict object with instance ids grouped by instance types
     """
-    instances_type = defaultdict(List)
     res = client.describe_instances(InstanceIds=instance_ids)
 
     return get_instance_type_from_response(res)

--- a/chaosaws/ec2/probes.py
+++ b/chaosaws/ec2/probes.py
@@ -1,16 +1,19 @@
 from typing import Any, Dict, List
 
+from chaoslib.exceptions import FailedActivity
+from chaoslib.types import Configuration, Secrets
+
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
-from chaoslib.types import Configuration, Secrets
-from chaoslib.exceptions import FailedActivity
 
 __all__ = ["describe_instances", "count_instances", "instance_state"]
 
 
-def describe_instances(filters: List[Dict[str, Any]],
-                       configuration: Configuration = None,
-                       secrets: Secrets = None) -> AWSResponse:
+def describe_instances(
+    filters: List[Dict[str, Any]],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Describe instances following the specified filters.
 
@@ -18,14 +21,16 @@ def describe_instances(filters: List[Dict[str, Any]],
 
     for details on said filters.
     """  # noqa: E501
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
 
     return client.describe_instances(Filters=filters)
 
 
-def count_instances(filters: List[Dict[str, Any]],
-                    configuration: Configuration = None,
-                    secrets: Secrets = None) -> int:
+def count_instances(
+    filters: List[Dict[str, Any]],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> int:
     """
     Return count of instances matching the specified filters.
 
@@ -33,35 +38,39 @@ def count_instances(filters: List[Dict[str, Any]],
 
     for details on said filters.
     """  # noqa: E501
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
     result = client.describe_instances(Filters=filters)
 
-    return len(result['Reservations'])
+    return len(result["Reservations"])
 
 
-def instance_state(state: str,
-                   instance_ids: List[str] = None,
-                   filters: List[Dict[str, Any]] = None,
-                   configuration: Configuration = None,
-                   secrets: Secrets = None) -> bool:
+def instance_state(
+    state: str,
+    instance_ids: List[str] = None,
+    filters: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> bool:
     """
     Determines if EC2 instances match desired state
 
     For additional filter options, please refer to the documentation found:
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_instances
     """
-    client = aws_client('ec2', configuration, secrets)
+    client = aws_client("ec2", configuration, secrets)
 
     if not any([instance_ids, filters]):
-        raise FailedActivity('Probe "instance_state" missing required '
-                             'parameter "instance_ids" or "filters"')
+        raise FailedActivity(
+            'Probe "instance_state" missing required '
+            'parameter "instance_ids" or "filters"'
+        )
 
     if instance_ids:
         instances = client.describe_instances(InstanceIds=instance_ids)
     else:
         instances = client.describe_instances(Filters=filters)
 
-    for i in instances['Reservations'][0]['Instances']:
-        if i['State']['Name'] != state:
+    for i in instances["Reservations"][0]["Instances"]:
+        if i["State"]["Name"] != state:
             return False
     return True

--- a/chaosaws/ecs/actions.py
+++ b/chaosaws/ecs/actions.py
@@ -1,6 +1,6 @@
 import random
 import re
-from typing import List, Union, Dict
+from typing import Dict, List, Union
 
 import boto3
 from botocore.exceptions import ClientError
@@ -12,20 +12,29 @@ from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
 __all__ = [
-    "stop_random_tasks", "stop_task", "delete_service", "tag_resource",
-    "delete_cluster", "deregister_container_instance", "untag_resource",
-    "update_desired_count", "set_service_placement_strategy",
-    "set_service_deployment_configuration", "update_container_instances_state"
+    "stop_random_tasks",
+    "stop_task",
+    "delete_service",
+    "tag_resource",
+    "delete_cluster",
+    "deregister_container_instance",
+    "untag_resource",
+    "update_desired_count",
+    "set_service_placement_strategy",
+    "set_service_deployment_configuration",
+    "update_container_instances_state",
 ]
 
 
-def stop_random_tasks(cluster: str,
-                      task_count: int = None,
-                      task_percent: int = None,
-                      service: str = None,
-                      reason: str = 'Chaos Testing',
-                      configuration: Configuration = None,
-                      secrets: Secrets = None) -> List[AWSResponse]:
+def stop_random_tasks(
+    cluster: str,
+    task_count: int = None,
+    task_percent: int = None,
+    service: str = None,
+    reason: str = "Chaos Testing",
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Stop a random number of tasks based on given task_count or task_percent
 
@@ -42,22 +51,23 @@ def stop_random_tasks(cluster: str,
     :return: List[Dict[str, Any]]
     """
     if not any([task_count, task_percent]) or all([task_count, task_percent]):
-        raise FailedActivity(
-            'Must specify one of "task_count", "task_percent"')
+        raise FailedActivity('Must specify one of "task_count", "task_percent"')
 
     client = aws_client("ecs", configuration, secrets)
     validate(client, cluster, service)
 
     tasks = list_running_tasks_in_cluster(
-        cluster=cluster, client=client, service=service)
+        cluster=cluster, client=client, service=service
+    )
 
     if task_percent:
         task_count = int(float(len(tasks) * float(task_percent)) / 100)
 
     if len(tasks) < task_count:
         raise FailedActivity(
-            'Not enough running tasks in {} to satisfy '
-            'stop count {} ({})'.format(cluster, task_count, len(tasks)))
+            "Not enough running tasks in {} to satisfy "
+            "stop count {} ({})".format(cluster, task_count, len(tasks))
+        )
 
     tasks = random.sample(tasks, task_count)
 
@@ -65,17 +75,23 @@ def stop_random_tasks(cluster: str,
     for task in tasks:
         logger.debug("Stopping ECS task: {}".format(task))
         response = client.stop_task(cluster=cluster, task=task, reason=reason)
-        results.append({
-            'Task_Id': response['task']['taskArn'],
-            'Desired_Status': response['task']['desiredStatus']
-        })
+        results.append(
+            {
+                "Task_Id": response["task"]["taskArn"],
+                "Desired_Status": response["task"]["desiredStatus"],
+            }
+        )
     return results
 
 
-def stop_task(cluster: str = None, task_id: str = None, service: str = None,
-              reason: str = 'Chaos Testing',
-              configuration: Configuration = None,
-              secrets: Secrets = None) -> AWSResponse:
+def stop_task(
+    cluster: str = None,
+    task_id: str = None,
+    service: str = None,
+    reason: str = "Chaos Testing",
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Stop a given ECS task instance. If no task_id provided, a random task of
     the given service is stopped.
@@ -86,8 +102,7 @@ def stop_task(cluster: str = None, task_id: str = None, service: str = None,
     if not task_id and service:
         tasks = list_tasks(cluster=cluster, client=client, service=service)
         if not tasks:
-            raise FailedActivity(
-                "No ECS tasks found for service: {}".format(service))
+            raise FailedActivity("No ECS tasks found for service: {}".format(service))
         task_id = random.choice(tasks)
         task_id = task_id.rsplit("/", 1)[1]
 
@@ -95,10 +110,13 @@ def stop_task(cluster: str = None, task_id: str = None, service: str = None,
     return client.stop_task(cluster=cluster, task=task_id, reason=reason)
 
 
-def delete_service(service: str = None, cluster: str = None,
-                   service_pattern: str = None,
-                   configuration: Configuration = None,
-                   secrets: Secrets = None) -> AWSResponse:
+def delete_service(
+    service: str = None,
+    cluster: str = None,
+    service_pattern: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Update a given ECS service by updating it to set the desired count of tasks
     to 0 then delete it. If not provided, a random one will be picked up
@@ -112,37 +130,34 @@ def delete_service(service: str = None, cluster: str = None,
     if not service:
         services = list_services_arns(cluster=cluster, client=client)
         if not services:
-            raise FailedActivity(
-                "No ECS services found in cluster: {}".format(
-                    cluster))
+            raise FailedActivity("No ECS services found in cluster: {}".format(cluster))
 
         # should we filter the number of services to take into account?
         if service_pattern:
-            services = filter_services(services=services,
-                                       pattern=service_pattern)
+            services = filter_services(services=services, pattern=service_pattern)
             if not services:
                 raise FailedActivity(
-                    "No ECS services matching pattern: {}".format(
-                        service_pattern))
+                    "No ECS services matching pattern: {}".format(service_pattern)
+                )
 
         service = random.choice(services)
         service = service.rsplit("/", 1)[1]
 
     logger.debug("Updating ECS service: {}".format(service))
-    client.update_service(cluster=cluster, service=service,
-                          desiredCount=0,
-                          deploymentConfiguration={
-                              'maximumPercent': 100,
-                              'minimumHealthyPercent': 0
-                          })
+    client.update_service(
+        cluster=cluster,
+        service=service,
+        desiredCount=0,
+        deploymentConfiguration={"maximumPercent": 100, "minimumHealthyPercent": 0},
+    )
 
     logger.debug("Deleting ECS service: {}".format(service))
     return client.delete_service(cluster=cluster, service=service)
 
 
-def delete_cluster(cluster: str,
-                   configuration: Configuration = None,
-                   secrets: Secrets = None) -> AWSResponse:
+def delete_cluster(
+    cluster: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Delete an ECS cluster
 
@@ -156,11 +171,13 @@ def delete_cluster(cluster: str,
     return client.delete_cluster(cluster=cluster)
 
 
-def deregister_container_instance(cluster: str,
-                                  instance_id: str,
-                                  force: bool = False,
-                                  configuration: Configuration = None,
-                                  secrets: Secrets = None) -> AWSResponse:
+def deregister_container_instance(
+    cluster: str,
+    instance_id: str,
+    force: bool = False,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Deregister an ECS container
 
@@ -177,16 +194,21 @@ def deregister_container_instance(cluster: str,
     client = aws_client("ecs", configuration, secrets)
     logger.debug(
         "Deregistering container instance '{}' from ECS cluster: {}".format(
-            instance_id, cluster))
+            instance_id, cluster
+        )
+    )
     return client.deregister_container_instance(
-        cluster=cluster, containerInstance=instance_id, force=force)
+        cluster=cluster, containerInstance=instance_id, force=force
+    )
 
 
-def update_desired_count(cluster: str,
-                         service: str,
-                         desired_count: int,
-                         configuration: Configuration = None,
-                         secrets: Secrets = None) -> AWSResponse:
+def update_desired_count(
+    cluster: str,
+    service: str,
+    desired_count: int,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Set the number of desired tasks for an ECS service
 
@@ -217,16 +239,18 @@ def update_desired_count(cluster: str,
     validate(client, cluster, service)
 
     return client.update_service(
-        cluster=cluster, service=service, desiredCount=desired_count)
+        cluster=cluster, service=service, desiredCount=desired_count
+    )
 
 
 def set_service_deployment_configuration(
-        cluster: str,
-        service: str,
-        maximum_percent: int = 200,
-        minimum_healthy_percent: int = 100,
-        configuration: Configuration = None,
-        secrets: Secrets = None) -> AWSResponse:
+    cluster: str,
+    service: str,
+    maximum_percent: int = 200,
+    minimum_healthy_percent: int = 100,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Sets the maximum healthy count and minimum healthy percentage values for
     a services deployment configuration
@@ -242,34 +266,36 @@ def set_service_deployment_configuration(
     :return: Dict[str, Any]
     """
     if minimum_healthy_percent > maximum_percent:
-        raise FailedActivity('minimum_healthy_percent cannot be larger '
-                             'than maximum_percent')
+        raise FailedActivity(
+            "minimum_healthy_percent cannot be larger " "than maximum_percent"
+        )
 
     client = aws_client("ecs", configuration, secrets)
 
     if not validate_cluster(cluster, client):
-        raise FailedActivity('unable to locate cluster: %s' % cluster)
+        raise FailedActivity("unable to locate cluster: %s" % cluster)
     if not validate_service(cluster, service, client):
-        raise FailedActivity('unable to locate service: %s on %s' % (
-            service, cluster))
+        raise FailedActivity("unable to locate service: %s on %s" % (service, cluster))
 
     params = {
-        'cluster': cluster,
-        'service': service,
-        'deploymentConfiguration': {
-            'maximumPercent': maximum_percent,
-            'minimumHealthyPercent': minimum_healthy_percent
-        }
+        "cluster": cluster,
+        "service": service,
+        "deploymentConfiguration": {
+            "maximumPercent": maximum_percent,
+            "minimumHealthyPercent": minimum_healthy_percent,
+        },
     }
     return client.update_service(**params)
 
 
-def set_service_placement_strategy(cluster: str,
-                                   service: str,
-                                   placement_type: str,
-                                   placement_field: str = None,
-                                   configuration: Configuration = None,
-                                   secrets: Secrets = None) -> AWSResponse:
+def set_service_placement_strategy(
+    cluster: str,
+    service: str,
+    placement_type: str,
+    placement_field: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Sets the service's instance placement strategy
 
@@ -283,36 +309,41 @@ def set_service_placement_strategy(cluster: str,
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    if placement_type in ('spread', 'binpack') and not placement_field:
-        raise FailedActivity('"placement_field" is required when using '
-                             '"spread" or "binpack"')
+    if placement_type in ("spread", "binpack") and not placement_field:
+        raise FailedActivity(
+            '"placement_field" is required when using ' '"spread" or "binpack"'
+        )
 
     client = aws_client("ecs", configuration, secrets)
     validate(client, cluster, service)
 
-    if placement_type == 'random':
+    if placement_type == "random":
         placement_field = None
 
     params = {
-        'cluster': cluster,
-        'service': service,
-        'placementStrategy': [{
-            'type': placement_type,
-            **({'field': placement_field} if placement_field else {})
-        }]
+        "cluster": cluster,
+        "service": service,
+        "placementStrategy": [
+            {
+                "type": placement_type,
+                **({"field": placement_field} if placement_field else {}),
+            }
+        ],
     }
 
     try:
         return client.update_service(**params)
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
-def tag_resource(tags: List[Dict[str, str]],
-                 resource_arn: str,
-                 configuration: Configuration = None,
-                 secrets: Secrets = None):
+def tag_resource(
+    tags: List[Dict[str, str]],
+    resource_arn: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+):
     """
     Tags the provided resource(s) with provided tags
 
@@ -336,18 +367,20 @@ def tag_resource(tags: List[Dict[str, str]],
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    client = aws_client('ecs', configuration, secrets)
+    client = aws_client("ecs", configuration, secrets)
     try:
         client.tag_resource(resourceArn=resource_arn, tags=tags)
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
-def untag_resource(tag_keys: List[str],
-                   resource_arn: str,
-                   configuration: Configuration = None,
-                   secrets: Secrets = None):
+def untag_resource(
+    tag_keys: List[str],
+    resource_arn: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+):
     """
     Removes the given tags from the provided resource
 
@@ -368,19 +401,21 @@ def untag_resource(tag_keys: List[str],
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    client = aws_client('ecs', configuration, secrets)
+    client = aws_client("ecs", configuration, secrets)
     try:
         client.untag_resource(resourceArn=resource_arn, tagKeys=tag_keys)
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
-def update_container_instances_state(cluster: str,
-                                     container_instances: List[str],
-                                     status: str,
-                                     configuration: Configuration = None,
-                                     secrets: Secrets = None) -> AWSResponse:
+def update_container_instances_state(
+    cluster: str,
+    container_instances: List[str],
+    status: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Modify the status of an ACTIVE ECS container instance
 
@@ -391,56 +426,54 @@ def update_container_instances_state(cluster: str,
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    client = aws_client('ecs', configuration, secrets)
+    client = aws_client("ecs", configuration, secrets)
     validate(client, cluster)
 
     try:
         return client.update_container_instance_state(
-            cluster=cluster,
-            containerInstances=container_instances,
-            status=status)
+            cluster=cluster, containerInstances=container_instances, status=status
+        )
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
 ###############################################################################
 # Private functions
 ###############################################################################
-def validate(client: boto3.client,
-             cluster: str = None,
-             service: str = None):
+def validate(client: boto3.client, cluster: str = None, service: str = None):
     """Validate that a service and/or cluster exists"""
     if cluster:
-        response = client.describe_clusters(clusters=[cluster])['clusters']
+        response = client.describe_clusters(clusters=[cluster])["clusters"]
         if not response:
-            raise FailedActivity('unable to locate cluster: %s' % cluster)
+            raise FailedActivity("unable to locate cluster: %s" % cluster)
 
     if service:
-        response = client.describe_services(
-            cluster=cluster, services=[service])['services']
+        response = client.describe_services(cluster=cluster, services=[service])[
+            "services"
+        ]
         if not response:
             raise FailedActivity(
-                'unable to locate service: %s on cluster: %s' % (
-                    service, cluster))
+                "unable to locate service: %s on cluster: %s" % (service, cluster)
+            )
 
 
 def validate_cluster(cluster: str, client: boto3.client) -> Union[str, None]:
     """Validates the provided cluster exists"""
-    cluster = client.describe_clusters(clusters=[cluster])['clusters']
+    cluster = client.describe_clusters(clusters=[cluster])["clusters"]
     if not cluster:
         return
-    return cluster[0]['clusterArn']
+    return cluster[0]["clusterArn"]
 
 
 def validate_service(
-        cluster: str, service: str, client: boto3.client) -> Union[str, None]:
+    cluster: str, service: str, client: boto3.client
+) -> Union[str, None]:
     """Validates the provided service exists in the cluster"""
-    service = client.describe_services(
-        cluster=cluster, services=[service])['services']
+    service = client.describe_services(cluster=cluster, services=[service])["services"]
     if not service:
         return
-    return service[0]['serviceArn']
+    return service[0]["serviceArn"]
 
 
 def list_services_arns(cluster: str, client: boto3.client) -> List[str]:
@@ -449,14 +482,14 @@ def list_services_arns(cluster: str, client: boto3.client) -> List[str]:
 
     def _list(next_token=None):
         params = {
-            'cluster': cluster,
-            **({'nextToken': next_token} if next_token else {})
+            "cluster": cluster,
+            **({"nextToken": next_token} if next_token else {}),
         }
         response = client.list_services(**params)
-        services.extend(response['serviceArns'])
+        services.extend(response["serviceArns"])
 
-        if response.get('nextToken'):
-            _list(response['nextToken'])
+        if response.get("nextToken"):
+            _list(response["nextToken"])
 
     _list()
     return services
@@ -473,39 +506,39 @@ def list_tasks(cluster: str, service: str, client: boto3.client) -> List[str]:
 
     def _list(next_token=None):
         params = {
-            'cluster': cluster,
-            'maxResults': 100,
-            **({'serviceName': service} if service else {}),
-            **({'nextToken': next_token} if next_token else {})
+            "cluster": cluster,
+            "maxResults": 100,
+            **({"serviceName": service} if service else {}),
+            **({"nextToken": next_token} if next_token else {}),
         }
         response = client.list_tasks(**params)
-        tasks.extend(response['taskArns'])
+        tasks.extend(response["taskArns"])
 
-        if response.get('nextToken'):
-            _list(response['nextToken'])
+        if response.get("nextToken"):
+            _list(response["nextToken"])
 
     _list()
     return tasks
 
 
-def list_running_tasks_in_cluster(cluster: str,
-                                  client: boto3.client,
-                                  service: str = None) -> List[str]:
+def list_running_tasks_in_cluster(
+    cluster: str, client: boto3.client, service: str = None
+) -> List[str]:
     tasks = []
 
     def _list(next_token=None):
         params = {
-            'cluster': cluster,
-            'maxResults': 100,
-            'desiredStatus': 'RUNNING',
-            **({'serviceName': service} if service else {}),
-            **({'nextToken': next_token} if next_token else {})
+            "cluster": cluster,
+            "maxResults": 100,
+            "desiredStatus": "RUNNING",
+            **({"serviceName": service} if service else {}),
+            **({"nextToken": next_token} if next_token else {}),
         }
         response = client.list_tasks(**params)
-        tasks.extend(response['taskArns'])
+        tasks.extend(response["taskArns"])
 
-        if response.get('nextToken'):
-            _list(response['nextToken'])
+        if response.get("nextToken"):
+            _list(response["nextToken"])
 
     _list()
     return tasks

--- a/chaosaws/ecs/probes.py
+++ b/chaosaws/ecs/probes.py
@@ -4,38 +4,48 @@ from chaoslib.types import Configuration, Secrets
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ["service_is_deploying", "are_all_desired_tasks_running",
-           "describe_cluster", "describe_service", "describe_tasks"]
+__all__ = [
+    "service_is_deploying",
+    "are_all_desired_tasks_running",
+    "describe_cluster",
+    "describe_service",
+    "describe_tasks",
+]
 
 
-def service_is_deploying(cluster: str,
-                         service: str,
-                         configuration: Configuration = None,
-                         secrets: Secrets = None) -> bool:
+def service_is_deploying(
+    cluster: str,
+    service: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> bool:
     """Checks to make sure there is not an in progress deployment"""
     client = aws_client("ecs", configuration, secrets)
     response = client.describe_services(cluster=cluster, services=[service])
-    services = response.get('services', [])
+    services = response.get("services", [])
     if not services:
-        raise FailedActivity('Error retrieving service data from AWS')
-    return len(services[0].get('deployments')) > 1
+        raise FailedActivity("Error retrieving service data from AWS")
+    return len(services[0].get("deployments")) > 1
 
 
-def are_all_desired_tasks_running(cluster: str, service: str,
-                                  configuration: Configuration = None,
-                                  secrets: Secrets = None) -> bool:
+def are_all_desired_tasks_running(
+    cluster: str,
+    service: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> bool:
     """Checks to make sure desired and running tasks counts are equal"""
     client = aws_client("ecs", configuration, secrets)
     response = client.describe_services(cluster=cluster, services=[service])
-    services = response.get('services', [])
+    services = response.get("services", [])
     if not services:
-        raise FailedActivity('Error retrieving service data from AWS')
-    return services[0]['desiredCount'] == services[0]['runningCount']
+        raise FailedActivity("Error retrieving service data from AWS")
+    return services[0]["desiredCount"] == services[0]["runningCount"]
 
 
-def describe_cluster(cluster: str,
-                     configuration: Configuration = None,
-                     secrets: Secrets = None) -> AWSResponse:
+def describe_cluster(
+    cluster: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Returns AWS response describing the specified cluster
 
@@ -67,16 +77,17 @@ def describe_cluster(cluster: str,
     client = aws_client("ecs", configuration, secrets)
     response = client.describe_clusters(clusters=[cluster])
 
-    if not response.get('clusters', []):
-        raise FailedActivity('Error retrieving information for cluster %s' % (
-            cluster))
+    if not response.get("clusters", []):
+        raise FailedActivity("Error retrieving information for cluster %s" % (cluster))
     return response
 
 
-def describe_service(cluster: str,
-                     service: str,
-                     configuration: Configuration = None,
-                     secrets: Secrets = None) -> AWSResponse:
+def describe_service(
+    cluster: str,
+    service: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Returns AWS response describing the specified cluster service
 
@@ -109,15 +120,16 @@ def describe_service(cluster: str,
     client = aws_client("ecs", configuration, secrets)
     response = client.describe_services(cluster=cluster, services=[service])
 
-    if not response.get('services', []):
-        raise FailedActivity('Unable to collect service %s on cluster %s' % (
-            cluster, service))
+    if not response.get("services", []):
+        raise FailedActivity(
+            "Unable to collect service %s on cluster %s" % (cluster, service)
+        )
     return response
 
 
-def describe_tasks(cluster: str,
-                   configuration: Configuration = None,
-                   secrets: Secrets = None) -> AWSResponse:
+def describe_tasks(
+    cluster: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Returns AWS response describing the tasks for a provided cluster
 
@@ -147,16 +159,15 @@ def describe_tasks(cluster: str,
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.describe_tasks
     """
     client = aws_client("ecs", configuration, secrets)
-    paginator = client.get_paginator('list_tasks')
+    paginator = client.get_paginator("list_tasks")
     tasks = []
 
     for p in paginator.paginate(cluster=cluster):
-        for t in p.get('taskArns', []):
+        for t in p.get("taskArns", []):
             tasks.append(t)
 
     if not tasks:
-        raise FailedActivity('Unable to find any tasks for cluster %s' % (
-            cluster))
+        raise FailedActivity("Unable to find any tasks for cluster %s" % (cluster))
 
     response = client.describe_tasks(cluster=cluster, tasks=tasks)
     return response

--- a/chaosaws/eks/actions.py
+++ b/chaosaws/eks/actions.py
@@ -9,21 +9,27 @@ from chaosaws.types import AWSResponse
 __all__ = ["create_cluster", "delete_cluster"]
 
 
-def create_cluster(name: str, role_arn: str, vpc_config: Dict[str, Any],
-                   version: str = None, configuration: Configuration = None,
-                   secrets: Secrets = None) -> AWSResponse:
+def create_cluster(
+    name: str,
+    role_arn: str,
+    vpc_config: Dict[str, Any],
+    version: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Create a new EKS cluster.
     """
     client = aws_client("eks", configuration, secrets)
     logger.debug("Creating EKS cluster: {}".format(name))
     return client.create_cluster(
-        name=name, version=version, roleArn=role_arn,
-        resourcesVpcConfig=vpc_config)
+        name=name, version=version, roleArn=role_arn, resourcesVpcConfig=vpc_config
+    )
 
 
-def delete_cluster(name: str = None, configuration: Configuration = None,
-                   secrets: Secrets = None) -> AWSResponse:
+def delete_cluster(
+    name: str = None, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Delete the given EKS cluster.
     """

--- a/chaosaws/eks/probes.py
+++ b/chaosaws/eks/probes.py
@@ -7,8 +7,9 @@ from chaosaws.types import AWSResponse
 __all__ = ["describe_cluster", "list_clusters"]
 
 
-def describe_cluster(name: str, configuration: Configuration = None,
-                     secrets: Secrets = None) -> AWSResponse:
+def describe_cluster(
+    name: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Describe an EKS cluster.
     """
@@ -20,8 +21,9 @@ def describe_cluster(name: str, configuration: Configuration = None,
         return None
 
 
-def list_clusters(configuration: Configuration = None,
-                  secrets: Secrets = None) -> AWSResponse:
+def list_clusters(
+    configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     List EKS clusters available to the authenticated account.
     """

--- a/chaosaws/elasticache/actions.py
+++ b/chaosaws/elasticache/actions.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 import boto3
 from chaoslib.exceptions import FailedActivity
@@ -8,14 +8,19 @@ from logzero import logger
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ["reboot_cache_clusters", "delete_cache_clusters",
-           "delete_replication_groups"]
+__all__ = [
+    "reboot_cache_clusters",
+    "delete_cache_clusters",
+    "delete_replication_groups",
+]
 
 
-def reboot_cache_clusters(cluster_ids: List[str],
-                          node_ids: List[str] = None,
-                          configuration: Configuration = None,
-                          secrets: Secrets = None) -> List[AWSResponse]:
+def reboot_cache_clusters(
+    cluster_ids: List[str],
+    node_ids: List[str] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Reboots one or more nodes in a cache cluster.
     If no node ids are supplied, all nodes in the cluster will be rebooted
@@ -24,22 +29,26 @@ def reboot_cache_clusters(cluster_ids: List[str],
         cluster_ids: list: a list of one or more cache cluster ids
         node_ids: list: a list of one or more node ids in to the cluster
     """
-    client = aws_client('elasticache', configuration, secrets)
+    client = aws_client("elasticache", configuration, secrets)
     cache_clusters = describe_cache_clusters(cluster_ids, client)
 
     results = []
     for c in cache_clusters:
         node_ids = validate_cluster_nodes(c, node_ids)
-        results.append(client.reboot_cache_cluster(
-            CacheClusterId=c['CacheClusterId'],
-            CacheNodeIdsToReboot=node_ids)['CacheCluster'])
+        results.append(
+            client.reboot_cache_cluster(
+                CacheClusterId=c["CacheClusterId"], CacheNodeIdsToReboot=node_ids
+            )["CacheCluster"]
+        )
     return results
 
 
-def delete_cache_clusters(cluster_ids: List[str],
-                          final_snapshot_id: str = None,
-                          configuration: Configuration = None,
-                          secrets: Secrets = None) -> List[AWSResponse]:
+def delete_cache_clusters(
+    cluster_ids: List[str],
+    final_snapshot_id: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Deletes one or more cache clusters and creates a final snapshot
 
@@ -47,25 +56,27 @@ def delete_cache_clusters(cluster_ids: List[str],
          cluster_ids: list: a list of one or more cache cluster ids
          final_snapshot_id: str: an identifier to give the final snapshot
     """
-    client = aws_client('elasticache', configuration, secrets)
+    client = aws_client("elasticache", configuration, secrets)
     cache_clusters = describe_cache_clusters(cluster_ids, client)
 
     results = []
     for c in cache_clusters:
-        logger.debug('Deleting Cache Cluster: %s.' % c['CacheClusterId'])
+        logger.debug("Deleting Cache Cluster: %s." % c["CacheClusterId"])
 
-        params = dict(CacheClusterId=c['CacheClusterId'])
+        params = dict(CacheClusterId=c["CacheClusterId"])
         if final_snapshot_id:
-            params['FinalSnapshotIdentifier'] = final_snapshot_id
-        results.append(client.delete_cache_cluster(**params)['CacheCluster'])
+            params["FinalSnapshotIdentifier"] = final_snapshot_id
+        results.append(client.delete_cache_cluster(**params)["CacheCluster"])
     return results
 
 
-def delete_replication_groups(group_ids: List[str],
-                              final_snapshot_id: str = None,
-                              retain_primary_cluster: bool = True,
-                              configuration: Configuration = None,
-                              secrets: Secrets = None) -> List[AWSResponse]:
+def delete_replication_groups(
+    group_ids: List[str],
+    final_snapshot_id: str = None,
+    retain_primary_cluster: bool = True,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Deletes one or more replication groups and creates a final snapshot
 
@@ -75,66 +86,69 @@ def delete_replication_groups(group_ids: List[str],
         retain_primary_cluster: bool (default: True): delete only the read
             replicas associated to the replication group, not the primary
     """
-    client = aws_client('elasticache', configuration, secrets)
+    client = aws_client("elasticache", configuration, secrets)
     replication_groups = describe_replication_groups(group_ids, client)
 
     results = []
     for r in replication_groups:
-        logger.debug('Deleting Replication Group: %s' % (
-            r['ReplicationGroupId']))
+        logger.debug("Deleting Replication Group: %s" % (r["ReplicationGroupId"]))
         if retain_primary_cluster:
-            logger.debug('Deleting only read replicas.')
+            logger.debug("Deleting only read replicas.")
 
         params = dict(
-            ReplicationGroupId=r['ReplicationGroupId'],
-            RetainPrimaryCluster=retain_primary_cluster)
+            ReplicationGroupId=r["ReplicationGroupId"],
+            RetainPrimaryCluster=retain_primary_cluster,
+        )
 
         if final_snapshot_id:
-            params['FinalSnapshotIdentifier'] = final_snapshot_id
+            params["FinalSnapshotIdentifier"] = final_snapshot_id
 
-        results.append(client.delete_replication_group(
-            **params)['ReplicationGroup'])
+        results.append(client.delete_replication_group(**params)["ReplicationGroup"])
     return results
 
 
 ###############################################################################
 # Private functions
 ###############################################################################
-def describe_cache_clusters(cluster_ids: List[str],
-                            client: boto3.client) -> List[AWSResponse]:
+def describe_cache_clusters(
+    cluster_ids: List[str], client: boto3.client
+) -> List[AWSResponse]:
     results = []
     for c in cluster_ids:
         response = client.describe_cache_clusters(
-            CacheClusterId=c,
-            ShowCacheNodeInfo=True)['CacheClusters']
+            CacheClusterId=c, ShowCacheNodeInfo=True
+        )["CacheClusters"]
 
         if not response:
-            raise FailedActivity('Cache cluster %s not found.' % c)
+            raise FailedActivity("Cache cluster %s not found." % c)
 
         for r in response:
             results.append(r)
     return results
 
 
-def describe_replication_groups(group_ids: List[str],
-                                client: boto3.client) -> List[AWSResponse]:
+def describe_replication_groups(
+    group_ids: List[str], client: boto3.client
+) -> List[AWSResponse]:
     results = []
     for g in group_ids:
-        response = client.describe_replication_groups(
-            ReplicationGroupId=g)['ReplicationGroups']
+        response = client.describe_replication_groups(ReplicationGroupId=g)[
+            "ReplicationGroups"
+        ]
 
         if not response:
-            raise FailedActivity('Replication group %s not found.' % g)
+            raise FailedActivity("Replication group %s not found." % g)
 
         for r in response:
             results.append(r)
     return results
 
 
-def validate_cluster_nodes(cache_cluster: Dict[str, Any],
-                           node_ids: List[str] = None) -> List[str]:
+def validate_cluster_nodes(
+    cache_cluster: Dict[str, Any], node_ids: List[str] = None
+) -> List[str]:
     missing_nodes = []
-    actual_nodes = [n['CacheNodeId'] for n in cache_cluster['CacheNodes']]
+    actual_nodes = [n["CacheNodeId"] for n in cache_cluster["CacheNodes"]]
     if not node_ids:
         return actual_nodes
 
@@ -143,6 +157,8 @@ def validate_cluster_nodes(cache_cluster: Dict[str, Any],
             missing_nodes.append(n)
 
     if missing_nodes:
-        raise FailedActivity('Cache Cluster %s has no node(s) matching: %s' % (
-            cache_cluster['CacheClusterId'], missing_nodes))
+        raise FailedActivity(
+            "Cache Cluster %s has no node(s) matching: %s"
+            % (cache_cluster["CacheClusterId"], missing_nodes)
+        )
     return node_ids

--- a/chaosaws/elasticache/probes.py
+++ b/chaosaws/elasticache/probes.py
@@ -5,15 +5,20 @@ from chaoslib.types import Configuration, Secrets
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ['describe_cache_cluster', 'get_cache_node_count',
-           'get_cache_node_status',
-           'count_cache_clusters_from_replication_group']
+__all__ = [
+    "describe_cache_cluster",
+    "get_cache_node_count",
+    "get_cache_node_status",
+    "count_cache_clusters_from_replication_group",
+]
 
 
-def describe_cache_cluster(cluster_id: str,
-                           show_node_info: bool = False,
-                           configuration: Configuration = None,
-                           secrets: Secrets = None) -> AWSResponse:
+def describe_cache_cluster(
+    cluster_id: str,
+    show_node_info: bool = False,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Returns cache cluster data for given cluster
 
     :param cluster_id: str: the name of the cache cluster
@@ -43,24 +48,27 @@ def describe_cache_cluster(cluster_id: str,
     Full list of possible paths can be found:
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elasticache.html#ElastiCache.Client.describe_cache_clusters
     """
-    params = dict(CacheClusterId=cluster_id,
-                  ShowCacheNodeInfo=show_node_info or False)
-    client = aws_client('elasticache', configuration, secrets)
+    params = dict(CacheClusterId=cluster_id, ShowCacheNodeInfo=show_node_info or False)
+    client = aws_client("elasticache", configuration, secrets)
 
     try:
         response = client.describe_cache_clusters(**params)
-        if not response.get('CacheClusters'):
-            raise FailedActivity('describe_cache_cluster failed: unable to '
-                                 'find cache cluster with id: %s' % cluster_id)
+        if not response.get("CacheClusters"):
+            raise FailedActivity(
+                "describe_cache_cluster failed: unable to "
+                "find cache cluster with id: %s" % cluster_id
+            )
         return response
     except ClientError as e:
-        raise FailedActivity('describe_cache_cluster failed: (%s) %s' % (
-            e.response['Error']['Code'], e.response['Error']['Message']))
+        raise FailedActivity(
+            "describe_cache_cluster failed: (%s) %s"
+            % (e.response["Error"]["Code"], e.response["Error"]["Message"])
+        )
 
 
-def get_cache_node_count(cluster_id: str,
-                         configuration: Configuration = None,
-                         secrets: Secrets = None) -> int:
+def get_cache_node_count(
+    cluster_id: str, configuration: Configuration = None, secrets: Secrets = None
+) -> int:
     """Returns the number of cache nodes associated to the cluster
 
     :param cluster_id: str: the name of the cache cluster
@@ -83,13 +91,14 @@ def get_cache_node_count(cluster_id: str,
     }
     """
     response = describe_cache_cluster(
-        cluster_id, configuration=configuration, secrets=secrets)
-    return response['CacheClusters'][0].get('NumCacheNodes', 0)
+        cluster_id, configuration=configuration, secrets=secrets
+    )
+    return response["CacheClusters"][0].get("NumCacheNodes", 0)
 
 
-def get_cache_node_status(cluster_id: str,
-                          configuration: Configuration = None,
-                          secrets: Secrets = None) -> str:
+def get_cache_node_status(
+    cluster_id: str, configuration: Configuration = None, secrets: Secrets = None
+) -> str:
     """Returns the status of the given cache cluster
 
     :param cluster_id: str: the name of the cache cluster
@@ -113,14 +122,15 @@ def get_cache_node_status(cluster_id: str,
 
     """
     response = describe_cache_cluster(
-        cluster_id, configuration=configuration, secrets=secrets)
-    return response['CacheClusters'][0].get('CacheClusterStatus', '')
+        cluster_id, configuration=configuration, secrets=secrets
+    )
+    return response["CacheClusters"][0].get("CacheClusterStatus", "")
 
 
 def count_cache_clusters_from_replication_group(
-        replication_group_id: str,
-        configuration: Configuration = None,
-        secrets: Secrets = None
+    replication_group_id: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
 ) -> int:
     """
     Returns the number of cache clusters that are part of the given
@@ -147,9 +157,7 @@ def count_cache_clusters_from_replication_group(
             }
         }
     """
-    client = aws_client(
-        "elasticache", configuration=configuration, secrets=secrets
-    )
+    client = aws_client("elasticache", configuration=configuration, secrets=secrets)
 
     response = client.describe_replication_groups(
         ReplicationGroupId=replication_group_id
@@ -158,8 +166,7 @@ def count_cache_clusters_from_replication_group(
     rep_groups = response.get("ReplicationGroups", [])
     if not rep_groups:
         raise FailedActivity(
-            "Error retrieving ReplicationGroups for "
-            "{}".format(replication_group_id)
+            "Error retrieving ReplicationGroups for " "{}".format(replication_group_id)
         )
 
     return len(rep_groups[0].get("MemberClusters", []))

--- a/chaosaws/elbv2/actions.py
+++ b/chaosaws/elbv2/actions.py
@@ -84,13 +84,13 @@ def set_security_groups(
         raise FailedActivity("Cannot change security groups of network load balancers.")
 
     results = []
-    for l in load_balancers["application"]:
+    for load_balancer in load_balancers["application"]:
         response = client.set_security_groups(
-            LoadBalancerArn=l, SecurityGroups=security_group_ids
+            LoadBalancerArn=load_balancer, SecurityGroups=security_group_ids
         )
 
         # add load balancer arn to response
-        response["LoadBalancerArn"] = l
+        response["LoadBalancerArn"] = load_balancer
         results.append(response)
     return results
 
@@ -137,9 +137,9 @@ def set_subnets(
         raise FailedActivity("Cannot change subnets of network load balancers.")
 
     results = []
-    for l in load_balancers["application"]:
-        response = client.set_subnets(LoadBalancerArn=l, Subnets=subnet_ids)
-        response["LoadBalancerArn"] = l
+    for load_balancer in load_balancers["application"]:
+        response = client.set_subnets(LoadBalancerArn=load_balancer, Subnets=subnet_ids)
+        response["LoadBalancerArn"] = load_balancer
         results.append(response)
     return results
 
@@ -162,9 +162,9 @@ def delete_load_balancer(
         if k not in ("application", "network"):
             continue
 
-        for l in v:
-            logger.debug("Deleting load balancer %s" % l)
-            client.delete_load_balancer(LoadBalancerArn=l)
+        for load_balancer in v:
+            logger.debug("Deleting load balancer %s" % load_balancer)
+            client.delete_load_balancer(LoadBalancerArn=load_balancer)
 
 
 ###############################################################################
@@ -201,7 +201,11 @@ def get_load_balancer_arns(
     except ClientError as e:
         raise FailedActivity(e.response["Error"]["Message"])
 
-    missing_lbs = [l for l in load_balancer_names if l not in results["Names"]]
+    missing_lbs = [
+        load_balancer
+        for load_balancer in load_balancer_names
+        if load_balancer not in results["Names"]
+    ]
     if missing_lbs:
         raise FailedActivity(
             "Unable to locate load balancer(s): {}".format(missing_lbs)

--- a/chaosaws/elbv2/actions.py
+++ b/chaosaws/elbv2/actions.py
@@ -3,47 +3,58 @@ from typing import Dict, List
 
 import boto3
 from botocore.exceptions import ClientError
-from logzero import logger
-
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
+from logzero import logger
+
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ["deregister_target", "set_security_groups", "set_subnets",
-           "delete_load_balancer"]
+__all__ = [
+    "deregister_target",
+    "set_security_groups",
+    "set_subnets",
+    "delete_load_balancer",
+]
 
 
-def deregister_target(tg_name: str,
-                      configuration: Configuration = None,
-                      secrets: Secrets = None) -> AWSResponse:
+def deregister_target(
+    tg_name: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """Deregisters one random target from target group"""
-    client = aws_client('elbv2', configuration, secrets)
+    client = aws_client("elbv2", configuration, secrets)
     tg_arn = get_target_group_arns(tg_names=[tg_name], client=client)
     tg_health = get_targets_health_description(tg_arns=tg_arn, client=client)
-    random_target = random.choice(
-        tg_health[tg_name]['TargetHealthDescriptions'])
+    random_target = random.choice(tg_health[tg_name]["TargetHealthDescriptions"])
 
-    logger.debug("Deregistering target {} from target group {}".format(
-        random_target['Target']['Id'], tg_name))
+    logger.debug(
+        "Deregistering target {} from target group {}".format(
+            random_target["Target"]["Id"], tg_name
+        )
+    )
 
     try:
         return client.deregister_targets(
             TargetGroupArn=tg_arn[tg_name],
-            Targets=[{
-                'Id': random_target['Target']['Id'],
-                'Port': random_target['Target']['Port']
-            }]
+            Targets=[
+                {
+                    "Id": random_target["Target"]["Id"],
+                    "Port": random_target["Target"]["Port"],
+                }
+            ],
         )
     except ClientError as e:
-        raise FailedActivity('Exception detaching %s: %s' % (
-            tg_name, e.response['Error']['Message']))
+        raise FailedActivity(
+            "Exception detaching %s: %s" % (tg_name, e.response["Error"]["Message"])
+        )
 
 
-def set_security_groups(load_balancer_names: List[str],
-                        security_group_ids: List[str],
-                        configuration: Configuration = None,
-                        secrets: Secrets = None) -> List[AWSResponse]:
+def set_security_groups(
+    load_balancer_names: List[str],
+    security_group_ids: List[str],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Changes the security groups for the specified load balancer(s).
     This action will replace the existing security groups on an application
@@ -63,30 +74,33 @@ def set_security_groups(load_balancer_names: List[str],
         ]
     """
     security_group_ids = get_security_groups(
-        security_group_ids, aws_client('ec2', configuration, secrets))
+        security_group_ids, aws_client("ec2", configuration, secrets)
+    )
 
-    client = aws_client('elbv2', configuration, secrets)
+    client = aws_client("elbv2", configuration, secrets)
     load_balancers = get_load_balancer_arns(load_balancer_names, client)
 
-    if load_balancers.get('network', []):
-        raise FailedActivity(
-            'Cannot change security groups of network load balancers.')
+    if load_balancers.get("network", []):
+        raise FailedActivity("Cannot change security groups of network load balancers.")
 
     results = []
-    for l in load_balancers['application']:
+    for l in load_balancers["application"]:
         response = client.set_security_groups(
-            LoadBalancerArn=l, SecurityGroups=security_group_ids)
+            LoadBalancerArn=l, SecurityGroups=security_group_ids
+        )
 
         # add load balancer arn to response
-        response['LoadBalancerArn'] = l
+        response["LoadBalancerArn"] = l
         results.append(response)
     return results
 
 
-def set_subnets(load_balancer_names: List[str],
-                subnet_ids: List[str],
-                configuration: Configuration = None,
-                secrets: Secrets = None) -> List[AWSResponse]:
+def set_subnets(
+    load_balancer_names: List[str],
+    subnet_ids: List[str],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[AWSResponse]:
     """
     Changes the subnets for the specified application load balancer(s)
     This action will replace the existing security groups on an application
@@ -114,51 +128,51 @@ def set_subnets(load_balancer_names: List[str],
             ...
         ]
     """
-    subnet_ids = get_subnets(
-        subnet_ids, aws_client('ec2', configuration, secrets))
+    subnet_ids = get_subnets(subnet_ids, aws_client("ec2", configuration, secrets))
 
-    client = aws_client('elbv2', configuration, secrets)
+    client = aws_client("elbv2", configuration, secrets)
     load_balancers = get_load_balancer_arns(load_balancer_names, client)
 
-    if load_balancers.get('network', []):
-        raise FailedActivity(
-            'Cannot change subnets of network load balancers.')
+    if load_balancers.get("network", []):
+        raise FailedActivity("Cannot change subnets of network load balancers.")
 
     results = []
-    for l in load_balancers['application']:
-        response = client.set_subnets(
-            LoadBalancerArn=l, Subnets=subnet_ids)
-        response['LoadBalancerArn'] = l
+    for l in load_balancers["application"]:
+        response = client.set_subnets(LoadBalancerArn=l, Subnets=subnet_ids)
+        response["LoadBalancerArn"] = l
         results.append(response)
     return results
 
 
-def delete_load_balancer(load_balancer_names: List[str],
-                         configuration: Configuration = None,
-                         secrets: Secrets = None):
+def delete_load_balancer(
+    load_balancer_names: List[str],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+):
     """
     Deletes the provided load balancer(s).
 
     Parameters:
         - load_balancer_names: a list of load balancer names
     """
-    client = aws_client('elbv2', configuration, secrets)
+    client = aws_client("elbv2", configuration, secrets)
     load_balancers = get_load_balancer_arns(load_balancer_names, client)
 
     for k, v in load_balancers.items():
-        if k not in ('application', 'network'):
+        if k not in ("application", "network"):
             continue
 
         for l in v:
-            logger.debug('Deleting load balancer %s' % l)
+            logger.debug("Deleting load balancer %s" % l)
             client.delete_load_balancer(LoadBalancerArn=l)
 
 
 ###############################################################################
 # Private functions
 ###############################################################################
-def get_load_balancer_arns(load_balancer_names: List[str],
-                           client: boto3.client) -> Dict[str, List[str]]:
+def get_load_balancer_arns(
+    load_balancer_names: List[str], client: boto3.client
+) -> Dict[str, List[str]]:
     """
     Returns load balancer arns categorized by the type of load balancer
 
@@ -169,40 +183,41 @@ def get_load_balancer_arns(load_balancer_names: List[str],
     }
     """
     results = {}
-    logger.debug('Searching for load balancer name(s): {}.'.format(
-        load_balancer_names))
+    logger.debug("Searching for load balancer name(s): {}.".format(load_balancer_names))
 
     try:
-        response = client.describe_load_balancers(
-            Names=load_balancer_names)
+        response = client.describe_load_balancers(Names=load_balancer_names)
 
-        for lb in response['LoadBalancers']:
-            if lb['State']['Code'] != 'active':
+        for lb in response["LoadBalancers"]:
+            if lb["State"]["Code"] != "active":
                 raise FailedActivity(
-                    'Invalid state for load balancer {}: '
-                    '{} is not active'.format(
-                        lb['LoadBalancerName'], lb['State']['Code']))
-            results.setdefault(lb['Type'], []).append(
-                lb['LoadBalancerArn'])
-            results.setdefault('Names', []).append(lb['LoadBalancerName'])
+                    "Invalid state for load balancer {}: "
+                    "{} is not active".format(
+                        lb["LoadBalancerName"], lb["State"]["Code"]
+                    )
+                )
+            results.setdefault(lb["Type"], []).append(lb["LoadBalancerArn"])
+            results.setdefault("Names", []).append(lb["LoadBalancerName"])
     except ClientError as e:
-        raise FailedActivity(e.response['Error']['Message'])
+        raise FailedActivity(e.response["Error"]["Message"])
 
-    missing_lbs = [l for l in load_balancer_names if l not in results['Names']]
+    missing_lbs = [l for l in load_balancer_names if l not in results["Names"]]
     if missing_lbs:
         raise FailedActivity(
-            'Unable to locate load balancer(s): {}'.format(missing_lbs))
+            "Unable to locate load balancer(s): {}".format(missing_lbs)
+        )
 
     if not results:
         raise FailedActivity(
-            'Unable to find any load balancer(s) matching name(s): {}'.format(
-                load_balancer_names))
+            "Unable to find any load balancer(s) matching name(s): {}".format(
+                load_balancer_names
+            )
+        )
 
     return results
 
 
-def get_target_group_arns(tg_names: List[str],
-                          client: boto3.client) -> Dict:
+def get_target_group_arns(tg_names: List[str], client: boto3.client) -> Dict:
     """
     Return list of target group ARNs based on list of target group names
 
@@ -212,20 +227,18 @@ def get_target_group_arns(tg_names: List[str],
         ....
     }
     """
-    logger.debug("Target group name(s): {} Looking for ARN"
-                 .format(str(tg_names)))
+    logger.debug("Target group name(s): {} Looking for ARN".format(str(tg_names)))
     res = client.describe_target_groups(Names=tg_names)
     tg_arns = {}
 
-    for tg in res['TargetGroups']:
-        tg_arns[tg['TargetGroupName']] = tg['TargetGroupArn']
+    for tg in res["TargetGroups"]:
+        tg_arns[tg["TargetGroupName"]] = tg["TargetGroupArn"]
     logger.debug("Target groups ARN: {}".format(str(tg_arns)))
 
     return tg_arns
 
 
-def get_targets_health_description(tg_arns: Dict,
-                                   client: boto3.client) -> Dict:
+def get_targets_health_description(tg_arns: Dict, client: boto3.client) -> Dict:
     """
     Return TargetHealthDescriptions by targetgroups
     Structure:
@@ -237,45 +250,44 @@ def get_targets_health_description(tg_arns: Dict,
         ....
     }
     """
-    logger.debug("Target group ARN: {} Getting health descriptions"
-                 .format(str(tg_arns)))
+    logger.debug(
+        "Target group ARN: {} Getting health descriptions".format(str(tg_arns))
+    )
     tg_health_descr = {}
 
     for tg in tg_arns:
         tg_health_descr[tg] = {}
-        tg_health_descr[tg]['TargetGroupArn'] = tg_arns[tg]
-        tg_health_descr[tg]['TargetHealthDescriptions'] = \
-            client.describe_target_health(TargetGroupArn=tg_arns[tg])[
-            'TargetHealthDescriptions']
-    logger.debug("Health descriptions for target group(s) are: {}"
-                 .format(str(tg_health_descr)))
+        tg_health_descr[tg]["TargetGroupArn"] = tg_arns[tg]
+        tg_health_descr[tg]["TargetHealthDescriptions"] = client.describe_target_health(
+            TargetGroupArn=tg_arns[tg]
+        )["TargetHealthDescriptions"]
+    logger.debug(
+        "Health descriptions for target group(s) are: {}".format(str(tg_health_descr))
+    )
     return tg_health_descr
 
 
 def get_security_groups(sg_ids: List[str], client: boto3.client) -> List[str]:
     try:
-        response = client.describe_security_groups(
-            GroupIds=sg_ids)['SecurityGroups']
-        results = [r['GroupId'] for r in response]
+        response = client.describe_security_groups(GroupIds=sg_ids)["SecurityGroups"]
+        results = [r["GroupId"] for r in response]
     except ClientError as e:
-        raise FailedActivity(e.response['Error']['Message'])
+        raise FailedActivity(e.response["Error"]["Message"])
 
     missing_sgs = [s for s in sg_ids if s not in results]
     if missing_sgs:
-        raise FailedActivity('Invalid security group id(s): {}'.format(
-            missing_sgs))
+        raise FailedActivity("Invalid security group id(s): {}".format(missing_sgs))
     return results
 
 
 def get_subnets(subnet_ids: List[str], client: boto3.client) -> List[str]:
     try:
-        response = client.describe_subnets(SubnetIds=subnet_ids)['Subnets']
-        results = [r['SubnetId'] for r in response]
+        response = client.describe_subnets(SubnetIds=subnet_ids)["Subnets"]
+        results = [r["SubnetId"] for r in response]
     except ClientError as e:
-        raise FailedActivity(e.response['Error']['Message'])
+        raise FailedActivity(e.response["Error"]["Message"])
 
     missing_subnets = [s for s in subnet_ids if s not in results]
     if missing_subnets:
-        raise FailedActivity('Invalid subnet id(s): {}'.format(
-            missing_subnets))
+        raise FailedActivity("Invalid subnet id(s): {}".format(missing_subnets))
     return results

--- a/chaosaws/elbv2/probes.py
+++ b/chaosaws/elbv2/probes.py
@@ -2,48 +2,46 @@ from collections import Counter
 from typing import Any, Dict, List
 
 import boto3
+from chaoslib.exceptions import FailedActivity
+from chaoslib.types import Configuration, Secrets
 from logzero import logger
 
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
-from chaoslib.exceptions import FailedActivity
-from chaoslib.types import Configuration, Secrets
 
 __all__ = ["targets_health_count", "all_targets_healthy"]
 
 
-def targets_health_count(tg_names: List[str],
-                         configuration: Configuration = None,
-                         secrets: Secrets = None) -> AWSResponse:
+def targets_health_count(
+    tg_names: List[str], configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Count of healthy/unhealthy targets per targetgroup
     """
 
     if not tg_names:
-        raise FailedActivity(
-            "Non-empty list of target groups is required")
+        raise FailedActivity("Non-empty list of target groups is required")
 
-    client = aws_client('elbv2', configuration, secrets)
+    client = aws_client("elbv2", configuration, secrets)
 
-    return get_targets_health_count(tg_names=tg_names,
-                                    client=client)
+    return get_targets_health_count(tg_names=tg_names, client=client)
 
 
-def all_targets_healthy(tg_names: List[str],
-                        configuration: Configuration = None,
-                        secrets: Secrets = None) -> AWSResponse:
+def all_targets_healthy(
+    tg_names: List[str], configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """
     Return true/false based on if all targets for listed
     target groups are healthy
     """
 
     if not tg_names:
-        raise FailedActivity(
-            "Non-empty list of target groups is required")
+        raise FailedActivity("Non-empty list of target groups is required")
 
-    client = aws_client('elbv2', configuration, secrets)
-    logger.debug("Checking if all targets are healthy for targets: {}"
-                 .format(str(tg_names)))
+    client = aws_client("elbv2", configuration, secrets)
+    logger.debug(
+        "Checking if all targets are healthy for targets: {}".format(str(tg_names))
+    )
     tg_arns = get_target_group_arns(tg_names=tg_names, client=client)
     tg_health = get_targets_health_description(tg_arns=tg_arns, client=client)
     result = True
@@ -51,8 +49,8 @@ def all_targets_healthy(tg_names: List[str],
     for tg in tg_health:
         time_to_break = False
 
-        for health_descr in tg_health[tg]['TargetHealthDescriptions']:
-            if health_descr['TargetHealth']['State'] != 'healthy':
+        for health_descr in tg_health[tg]["TargetHealthDescriptions"]:
+            if health_descr["TargetHealth"]["State"] != "healthy":
                 result = False
                 time_to_break = True
 
@@ -67,8 +65,7 @@ def all_targets_healthy(tg_names: List[str],
 ###############################################################################
 # Private functions
 ###############################################################################
-def get_target_group_arns(tg_names: List[str],
-                          client: boto3.client) -> Dict:
+def get_target_group_arns(tg_names: List[str], client: boto3.client) -> Dict:
     """
     Return list of target group ARNs based on list of target group names
 
@@ -78,20 +75,18 @@ def get_target_group_arns(tg_names: List[str],
         ....
     }
     """
-    logger.debug("Target group name(s): {} Looking for ARN"
-                 .format(str(tg_names)))
+    logger.debug("Target group name(s): {} Looking for ARN".format(str(tg_names)))
     res = client.describe_target_groups(Names=tg_names)
     tg_arns = {}
 
-    for tg in res['TargetGroups']:
-        tg_arns[tg['TargetGroupName']] = tg['TargetGroupArn']
+    for tg in res["TargetGroups"]:
+        tg_arns[tg["TargetGroupName"]] = tg["TargetGroupArn"]
     logger.debug("Target groups ARNs: {}".format(str(tg_arns)))
 
     return tg_arns
 
 
-def get_targets_health_description(tg_arns: Dict,
-                                   client: boto3.client) -> Dict:
+def get_targets_health_description(tg_arns: Dict, client: boto3.client) -> Dict:
     """
     Return TargetHealthDescriptions by targetgroups
     Structure:
@@ -103,24 +98,25 @@ def get_targets_health_description(tg_arns: Dict,
         ....
     }
     """
-    logger.debug("Target group ARN: {} Getting health descriptions"
-                 .format(str(tg_arns)))
+    logger.debug(
+        "Target group ARN: {} Getting health descriptions".format(str(tg_arns))
+    )
     tg_health_descr = {}
 
     for tg in tg_arns:
         tg_health_descr[tg] = {}
-        tg_health_descr[tg]['TargetGroupArn'] = tg_arns[tg]
-        tg_health_descr[tg]['TargetHealthDescriptions'] = \
-            client.describe_target_health(TargetGroupArn=tg_arns[tg])[
-            'TargetHealthDescriptions']
-    logger.debug("Health descriptions for target group(s) are: {}"
-                 .format(str(tg_health_descr)))
+        tg_health_descr[tg]["TargetGroupArn"] = tg_arns[tg]
+        tg_health_descr[tg]["TargetHealthDescriptions"] = client.describe_target_health(
+            TargetGroupArn=tg_arns[tg]
+        )["TargetHealthDescriptions"]
+    logger.debug(
+        "Health descriptions for target group(s) are: {}".format(str(tg_health_descr))
+    )
 
     return tg_health_descr
 
 
-def get_targets_health_count(tg_names: List[str],
-                             client: boto3.client) -> Dict:
+def get_targets_health_count(tg_names: List[str], client: boto3.client) -> Dict:
     """
     Return number of healthy/unhealthy targets per target group
     Structure:
@@ -132,8 +128,11 @@ def get_targets_health_count(tg_names: List[str],
         ....
     }
     """
-    logger.debug("Looking for number of health targets for targetgroups: {}"
-                 .format(str(tg_names)))
+    logger.debug(
+        "Looking for number of health targets for targetgroups: {}".format(
+            str(tg_names)
+        )
+    )
     tg_arns = get_target_group_arns(tg_names=tg_names, client=client)
     tg_health = get_targets_health_description(tg_arns=tg_arns, client=client)
     tg_targets_health_count = {}
@@ -141,10 +140,11 @@ def get_targets_health_count(tg_names: List[str],
     for tg in tg_health:
         cnt = Counter()
 
-        for health_descr in tg_health[tg]['TargetHealthDescriptions']:
-            cnt[health_descr['TargetHealth']['State']] += 1
+        for health_descr in tg_health[tg]["TargetHealthDescriptions"]:
+            cnt[health_descr["TargetHealth"]["State"]] += 1
         tg_targets_health_count[tg] = dict(cnt)
-    logger.debug("Healthy targets by targetgroup: {}"
-                 .format(str(tg_targets_health_count)))
+    logger.debug(
+        "Healthy targets by targetgroup: {}".format(str(tg_targets_health_count))
+    )
 
     return tg_targets_health_count

--- a/chaosaws/elbv2/probes.py
+++ b/chaosaws/elbv2/probes.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import boto3
 from chaoslib.exceptions import FailedActivity

--- a/chaosaws/emr/actions.py
+++ b/chaosaws/emr/actions.py
@@ -6,18 +6,23 @@ from chaoslib.types import Configuration, Secrets
 from logzero import logger
 
 from chaosaws import aws_client
-from chaosaws.emr.shared import (get_instance_group, get_instance_fleet)
+from chaosaws.emr.shared import get_instance_fleet, get_instance_group
 from chaosaws.types import AWSResponse
 
-__all__ = ['modify_cluster', 'modify_instance_fleet',
-           'modify_instance_groups_instance_count',
-           'modify_instance_groups_shrink_policy']
+__all__ = [
+    "modify_cluster",
+    "modify_instance_fleet",
+    "modify_instance_groups_instance_count",
+    "modify_instance_groups_shrink_policy",
+]
 
 
-def modify_cluster(cluster_id: str,
-                   concurrency: int,
-                   configuration: Configuration = None,
-                   secrets: Secrets = None) -> AWSResponse:
+def modify_cluster(
+    cluster_id: str,
+    concurrency: int,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Set the step concurrency level on the provided cluster
 
     :param cluster_id: The cluster id
@@ -26,23 +31,25 @@ def modify_cluster(cluster_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    client = aws_client('emr', configuration, secrets)
+    client = aws_client("emr", configuration, secrets)
 
     try:
         return client.modify_cluster(
-            ClusterId=cluster_id,
-            StepConcurrencyLevel=concurrency)
+            ClusterId=cluster_id, StepConcurrencyLevel=concurrency
+        )
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
-def modify_instance_fleet(cluster_id: str,
-                          fleet_id: str,
-                          on_demand_capacity: int = None,
-                          spot_capacity: int = None,
-                          configuration: Configuration = None,
-                          secrets: Secrets = None) -> AWSResponse:
+def modify_instance_fleet(
+    cluster_id: str,
+    fleet_id: str,
+    on_demand_capacity: int = None,
+    spot_capacity: int = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Modify the on-demand and spot capacities for an instance fleet
 
     :param cluster_id: The cluster id
@@ -54,35 +61,40 @@ def modify_instance_fleet(cluster_id: str,
     :return: Dict[str, Any]
     """
     if not any([on_demand_capacity, spot_capacity]):
-        raise FailedActivity('Must provide at least one of '
-                             '["on_demand_capacity", "spot_capacity"]')
+        raise FailedActivity(
+            "Must provide at least one of " '["on_demand_capacity", "spot_capacity"]'
+        )
 
-    client = aws_client('emr', configuration, secrets)
+    client = aws_client("emr", configuration, secrets)
 
     params = {
-        'ClusterId': cluster_id,
-        'InstanceFleet': {
-            'InstanceFleetId': fleet_id,
-            **({'TargetSpotCapacity': spot_capacity} if spot_capacity else {}),
-            **({'TargetOnDemandCapacity': on_demand_capacity
-                } if on_demand_capacity else {})
-        }
+        "ClusterId": cluster_id,
+        "InstanceFleet": {
+            "InstanceFleetId": fleet_id,
+            **({"TargetSpotCapacity": spot_capacity} if spot_capacity else {}),
+            **(
+                {"TargetOnDemandCapacity": on_demand_capacity}
+                if on_demand_capacity
+                else {}
+            ),
+        },
     }
 
     try:
         client.modify_instance_fleet(**params)
         return get_instance_fleet(client, cluster_id, fleet_id)
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
 def modify_instance_groups_instance_count(
-        cluster_id: str,
-        group_id: str,
-        instance_count: int,
-        configuration: Configuration = None,
-        secrets: Secrets = None) -> AWSResponse:
+    cluster_id: str,
+    group_id: str,
+    instance_count: int,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Modify the number of instances in an instance group
 
     :param cluster_id: The cluster id
@@ -92,31 +104,31 @@ def modify_instance_groups_instance_count(
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    client = aws_client('emr', configuration, secrets)
+    client = aws_client("emr", configuration, secrets)
 
     try:
         client.modify_instance_groups(
             ClusterId=cluster_id,
-            InstanceGroups=[{
-                'InstanceGroupId': group_id,
-                'InstanceCount': instance_count
-            }]
+            InstanceGroups=[
+                {"InstanceGroupId": group_id, "InstanceCount": instance_count}
+            ],
         )
         return get_instance_group(client, cluster_id, group_id)
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
 def modify_instance_groups_shrink_policy(
-        cluster_id: str,
-        group_id: str,
-        decommission_timeout: int = None,
-        terminate_instances: List[str] = None,
-        protect_instances: List[str] = None,
-        termination_timeout: int = None,
-        configuration: Configuration = None,
-        secrets: Secrets = None) -> AWSResponse:
+    cluster_id: str,
+    group_id: str,
+    decommission_timeout: int = None,
+    terminate_instances: List[str] = None,
+    protect_instances: List[str] = None,
+    termination_timeout: int = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Modify an instance groups shrink operations
 
     :param cluster_id: The cluster id
@@ -130,41 +142,54 @@ def modify_instance_groups_shrink_policy(
     :return: Dict[str, Any]
     """
     if not any([decommission_timeout, terminate_instances, protect_instances]):
-        raise FailedActivity('Must provide at least one of ['
-                             '"decommission_timeout", "terminate_instances",'
-                             '"protect_instances"]')
+        raise FailedActivity(
+            "Must provide at least one of ["
+            '"decommission_timeout", "terminate_instances",'
+            '"protect_instances"]'
+        )
 
     if termination_timeout and not terminate_instances:
-        raise FailedActivity('Must provide "terminate_instances" when '
-                             'specifying "termination_timeout"')
+        raise FailedActivity(
+            'Must provide "terminate_instances" when '
+            'specifying "termination_timeout"'
+        )
 
     resize_policy = {
-        **({'InstancesToTerminate': terminate_instances
-            } if terminate_instances else {}),
-        **({'InstancesToProtect': protect_instances
-            } if protect_instances else {}),
-        **({'InstanceTerminationTimeout': termination_timeout
-            } if termination_timeout else {})
+        **(
+            {"InstancesToTerminate": terminate_instances} if terminate_instances else {}
+        ),
+        **({"InstancesToProtect": protect_instances} if protect_instances else {}),
+        **(
+            {"InstanceTerminationTimeout": termination_timeout}
+            if termination_timeout
+            else {}
+        ),
     }
 
     params = {
-        'ClusterId': cluster_id,
-        'InstanceGroups': [{
-            'InstanceGroupId': group_id,
-            'ShrinkPolicy': {
-                **({'DecommissionTimeout': decommission_timeout
-                    } if decommission_timeout else {}),
-                **({'InstanceResizePolicy': resize_policy
-                    } if resize_policy else {})
+        "ClusterId": cluster_id,
+        "InstanceGroups": [
+            {
+                "InstanceGroupId": group_id,
+                "ShrinkPolicy": {
+                    **(
+                        {"DecommissionTimeout": decommission_timeout}
+                        if decommission_timeout
+                        else {}
+                    ),
+                    **(
+                        {"InstanceResizePolicy": resize_policy} if resize_policy else {}
+                    ),
+                },
             }
-        }]
+        ],
     }
 
-    client = aws_client('emr', configuration, secrets)
+    client = aws_client("emr", configuration, secrets)
 
     try:
         client.modify_instance_groups(**params)
         return get_instance_group(client, cluster_id, group_id)
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])

--- a/chaosaws/emr/probes.py
+++ b/chaosaws/emr/probes.py
@@ -4,18 +4,25 @@ from chaoslib.types import Configuration, Secrets
 
 from chaosaws import aws_client
 from chaosaws.emr.shared import (
-    describe_emr_cluster, list_emr_instances, get_instance_fleet,
-    get_instance_group)
+    describe_emr_cluster,
+    get_instance_fleet,
+    get_instance_group,
+    list_emr_instances,
+)
 from chaosaws.types import AWSResponse
 
-__all__ = ['describe_cluster', 'describe_instance_fleet',
-           'describe_instance_group', 'list_cluster_fleet_instances',
-           'list_cluster_group_instances']
+__all__ = [
+    "describe_cluster",
+    "describe_instance_fleet",
+    "describe_instance_group",
+    "list_cluster_fleet_instances",
+    "list_cluster_group_instances",
+]
 
 
-def describe_cluster(cluster_id: str,
-                     configuration: Configuration = None,
-                     secrets: Secrets = None) -> AWSResponse:
+def describe_cluster(
+    cluster_id: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """Describe a single EMR cluster
 
     :param cluster_id: The cluster id
@@ -23,14 +30,16 @@ def describe_cluster(cluster_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    client = aws_client('emr', configuration, secrets)
+    client = aws_client("emr", configuration, secrets)
     return describe_emr_cluster(client, cluster_id)
 
 
-def describe_instance_fleet(cluster_id: str,
-                            fleet_id: str,
-                            configuration: Configuration = None,
-                            secrets: Secrets = None) -> AWSResponse:
+def describe_instance_fleet(
+    cluster_id: str,
+    fleet_id: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Describe a single EMR instance fleet
 
     :param cluster_id: The cluster id
@@ -39,14 +48,16 @@ def describe_instance_fleet(cluster_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    client = aws_client('emr', configuration, secrets)
+    client = aws_client("emr", configuration, secrets)
     return get_instance_fleet(client, cluster_id, fleet_id)
 
 
-def describe_instance_group(cluster_id: str,
-                            group_id: str,
-                            configuration: Configuration = None,
-                            secrets: Secrets = None) -> AWSResponse:
+def describe_instance_group(
+    cluster_id: str,
+    group_id: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Describe a single EMR instance group
 
     :param cluster_id: The cluster id
@@ -55,16 +66,18 @@ def describe_instance_group(cluster_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    client = aws_client('emr', configuration, secrets)
+    client = aws_client("emr", configuration, secrets)
     return get_instance_group(client, cluster_id, group_id)
 
 
-def list_cluster_group_instances(cluster_id: str,
-                                 group_id: str,
-                                 group_type: str = None,
-                                 instance_states: List[str] = None,
-                                 configuration: Configuration = None,
-                                 secrets: Secrets = None) -> AWSResponse:
+def list_cluster_group_instances(
+    cluster_id: str,
+    group_id: str,
+    group_type: str = None,
+    instance_states: List[str] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Get a list of instance group instances associated to the EMR cluster
 
     :param cluster_id: The cluster id
@@ -75,18 +88,24 @@ def list_cluster_group_instances(cluster_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    client = aws_client('emr', configuration, secrets)
-    return list_emr_instances(client=client, cluster_id=cluster_id,
-                              group_id=group_id, group_type=group_type,
-                              instance_states=instance_states)
+    client = aws_client("emr", configuration, secrets)
+    return list_emr_instances(
+        client=client,
+        cluster_id=cluster_id,
+        group_id=group_id,
+        group_type=group_type,
+        instance_states=instance_states,
+    )
 
 
-def list_cluster_fleet_instances(cluster_id: str,
-                                 fleet_id: str,
-                                 fleet_type: str = None,
-                                 instance_states: List[str] = None,
-                                 configuration: Configuration = None,
-                                 secrets: Secrets = None) -> AWSResponse:
+def list_cluster_fleet_instances(
+    cluster_id: str,
+    fleet_id: str,
+    fleet_type: str = None,
+    instance_states: List[str] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Get a list of instance fleet instances associated to the EMR cluster
 
     :param cluster_id: The cluster id
@@ -97,15 +116,20 @@ def list_cluster_fleet_instances(cluster_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :return: Dict[str, Any]
     """
-    client = aws_client('emr', configuration, secrets)
-    return list_emr_instances(client=client, cluster_id=cluster_id,
-                              fleet_id=fleet_id, fleet_type=fleet_type,
-                              instance_states=instance_states)
+    client = aws_client("emr", configuration, secrets)
+    return list_emr_instances(
+        client=client,
+        cluster_id=cluster_id,
+        fleet_id=fleet_id,
+        fleet_type=fleet_type,
+        instance_states=instance_states,
+    )
 
 
-def list_emr_clusters(configuration: Configuration = None,
-                      secrets: Secrets = None) -> AWSResponse:
-    client = aws_client('emr', configuration, secrets)
+def list_emr_clusters(
+    configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
+    client = aws_client("emr", configuration, secrets)
     clusters = client.list_clusters()
     for c in clusters:
         print(c)

--- a/chaosaws/emr/shared.py
+++ b/chaosaws/emr/shared.py
@@ -12,97 +12,95 @@ def describe_emr_cluster(client: boto3.client, cluster_id: str) -> AWSResponse:
     try:
         return client.describe_cluster(ClusterId=cluster_id)
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
         raise FailedActivity(e.response["Error"]["Message"])
 
 
-def list_emr_instances(client: boto3.client,
-                       cluster_id: str,
-                       group_id: str = None,
-                       group_type: str = None,
-                       fleet_id: str = None,
-                       fleet_type: str = None,
-                       instance_states: List[str] = None) -> AWSResponse:
+def list_emr_instances(
+    client: boto3.client,
+    cluster_id: str,
+    group_id: str = None,
+    group_type: str = None,
+    fleet_id: str = None,
+    fleet_type: str = None,
+    instance_states: List[str] = None,
+) -> AWSResponse:
     params = {
-        'ClusterId': cluster_id,
-        **({'InstanceGroupId': group_id} if group_id else {}),
-        **({'InstanceGroupType': group_type} if group_type else {}),
-        **({'InstanceFleetId': fleet_id} if fleet_id else {}),
-        **({'InstanceFleetType': fleet_type} if fleet_type else {}),
-        **({'InstanceStates': instance_states} if instance_states else {}),
+        "ClusterId": cluster_id,
+        **({"InstanceGroupId": group_id} if group_id else {}),
+        **({"InstanceGroupType": group_type} if group_type else {}),
+        **({"InstanceFleetId": fleet_id} if fleet_id else {}),
+        **({"InstanceFleetType": fleet_type} if fleet_type else {}),
+        **({"InstanceStates": instance_states} if instance_states else {}),
     }
 
     instances = []
 
     def _list(marker: str = None):
         if marker:
-            params['Marker'] = marker
+            params["Marker"] = marker
 
         try:
             response = client.list_instances(**params)
 
-            for r in response['Instances']:
+            for r in response["Instances"]:
                 instances.append(r)
 
-            marker = response.get('Marker')
+            marker = response.get("Marker")
             if marker:
                 _list(marker)
         except ClientError as e:
-            logger.exception(e.response['Error']['Message'])
-            raise FailedActivity(e.response['Error']['Message'])
+            logger.exception(e.response["Error"]["Message"])
+            raise FailedActivity(e.response["Error"]["Message"])
 
     _list()
-    return {'Instances': instances}
+    return {"Instances": instances}
 
 
-def get_instance_fleet(client: boto3.client,
-                       cluster_id: str,
-                       fleet_id: str) -> AWSResponse:
-    fleets = {'InstanceFleets': None}
+def get_instance_fleet(
+    client: boto3.client, cluster_id: str, fleet_id: str
+) -> AWSResponse:
+    fleets = {"InstanceFleets": None}
 
     def _list(marker: str = None):
-        params = {
-            'ClusterId': cluster_id,
-            **({'Marker': marker} if marker else {})}
+        params = {"ClusterId": cluster_id, **({"Marker": marker} if marker else {})}
 
         try:
             response = client.list_instance_fleets(**params)
-            for r in response['InstanceFleets']:
-                if r['Id'] == fleet_id:
-                    fleets['InstanceFleets'] = r
+            for r in response["InstanceFleets"]:
+                if r["Id"] == fleet_id:
+                    fleets["InstanceFleets"] = r
                     break
 
-            if response.get('Marker') and not fleets['InstanceFleets']:
-                _list(marker=response['Marker'])
+            if response.get("Marker") and not fleets["InstanceFleets"]:
+                _list(marker=response["Marker"])
         except ClientError as e:
-            logger.exception(e.response['Error']['Message'])
-            raise FailedActivity(e.response['Error']['Message'])
+            logger.exception(e.response["Error"]["Message"])
+            raise FailedActivity(e.response["Error"]["Message"])
 
     _list()
     return fleets
 
 
-def get_instance_group(client: boto3.client,
-                       cluster_id: str,
-                       group_id: str) -> AWSResponse:
-    groups = {'InstanceGroups': None}
+def get_instance_group(
+    client: boto3.client, cluster_id: str, group_id: str
+) -> AWSResponse:
+    groups = {"InstanceGroups": None}
 
     def _list(marker: str = None):
-        params = {
-            'ClusterId': cluster_id,
-            **({'Marker': marker} if marker else {})}
+        params = {"ClusterId": cluster_id, **({"Marker": marker} if marker else {})}
         try:
             response = client.list_instance_groups(**params)
-            for r in response['InstanceGroups']:
-                if r['Id'] == group_id:
-                    groups['InstanceGroups'] = r
+            for r in response["InstanceGroups"]:
+                if r["Id"] == group_id:
+                    groups["InstanceGroups"] = r
                     break
 
-            if response.get('Marker') and not groups['InstanceGroups']:
-                _list(marker=response['Marker'])
+            if response.get("Marker") and not groups["InstanceGroups"]:
+                _list(marker=response["Marker"])
         except ClientError as e:
-            logger.exception(e.response['Error']['Message'])
-            raise FailedActivity(e.response['Error']['Message'])
+            logger.exception(e.response["Error"]["Message"])
+            raise FailedActivity(e.response["Error"]["Message"])
 
     _list()
     return groups

--- a/chaosaws/iam/actions.py
+++ b/chaosaws/iam/actions.py
@@ -1,8 +1,8 @@
 import json
 from typing import Any, Dict
 
-from botocore.exceptions import BotoCoreError
 from botocore.errorfactory import BaseClientExceptions
+from botocore.exceptions import BotoCoreError
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 
@@ -12,9 +12,14 @@ from chaosaws.types import AWSResponse
 __all__ = ["attach_role_policy", "create_policy", "detach_role_policy"]
 
 
-def create_policy(name: str, policy: Dict[str, Any], path: str = "/",
-                  description: str = "", configuration: Configuration = None,
-                  secrets: Secrets = None) -> AWSResponse:
+def create_policy(
+    name: str,
+    policy: Dict[str, Any],
+    path: str = "/",
+    description: str = "",
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Create a new IAM policy
     """
@@ -25,16 +30,18 @@ def create_policy(name: str, policy: Dict[str, Any], path: str = "/",
             PolicyName=name,
             Path=path,
             PolicyDocument=json.dumps(policy),
-            Description=description or ""
+            Description=description or "",
         )
     except Exception as x:
-        raise FailedActivity(
-            "failed creating a policy: {}".format(str(x)))
+        raise FailedActivity("failed creating a policy: {}".format(str(x)))
 
 
-def attach_role_policy(arn: str, role_name: str,
-                       configuration: Configuration = None,
-                       secrets: Secrets = None) -> AWSResponse:
+def attach_role_policy(
+    arn: str,
+    role_name: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Attach a role to a policy.
     """
@@ -44,12 +51,17 @@ def attach_role_policy(arn: str, role_name: str,
     except Exception as x:
         raise FailedActivity(
             "failed attaching role '{}' to policy '{}': {}".format(
-                role_name, arn, str(x)))
+                role_name, arn, str(x)
+            )
+        )
 
 
-def detach_role_policy(arn: str, role_name: str,
-                       configuration: Configuration = None,
-                       secrets: Secrets = None) -> AWSResponse:
+def detach_role_policy(
+    arn: str,
+    role_name: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Detach a role from a policy.
     """
@@ -59,4 +71,6 @@ def detach_role_policy(arn: str, role_name: str,
     except Exception as x:
         raise FailedActivity(
             "failed detaching role '{}' from policy '{}': {}".format(
-                role_name, arn, str(x)))
+                role_name, arn, str(x)
+            )
+        )

--- a/chaosaws/iam/actions.py
+++ b/chaosaws/iam/actions.py
@@ -1,8 +1,6 @@
 import json
 from typing import Any, Dict
 
-from botocore.errorfactory import BaseClientExceptions
-from botocore.exceptions import BotoCoreError
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 

--- a/chaosaws/iam/probes.py
+++ b/chaosaws/iam/probes.py
@@ -6,8 +6,9 @@ from chaosaws import aws_client
 __all__ = ["get_policy"]
 
 
-def get_policy(arn: str, configuration: Configuration = None,
-               secrets: Secrets = None) -> bool:
+def get_policy(
+    arn: str, configuration: Configuration = None, secrets: Secrets = None
+) -> bool:
     """
     Get a policy by its ARN
     """

--- a/chaosaws/iam/probes.py
+++ b/chaosaws/iam/probes.py
@@ -1,4 +1,3 @@
-from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 
 from chaosaws import aws_client

--- a/chaosaws/rds/actions.py
+++ b/chaosaws/rds/actions.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict, List
-
 import boto3
 from botocore.exceptions import ClientError
 from chaoslib.exceptions import FailedActivity

--- a/chaosaws/rds/actions.py
+++ b/chaosaws/rds/actions.py
@@ -1,69 +1,79 @@
-import boto3
-
 from typing import Any, Dict, List
-from botocore.exceptions import ClientError
 
+import boto3
+from botocore.exceptions import ClientError
 from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ["failover_db_cluster", "reboot_db_instance", "stop_db_instance",
-           "stop_db_cluster", "delete_db_instance", "delete_db_cluster",
-           "delete_db_cluster_endpoint"]
+__all__ = [
+    "failover_db_cluster",
+    "reboot_db_instance",
+    "stop_db_instance",
+    "stop_db_cluster",
+    "delete_db_instance",
+    "delete_db_cluster",
+    "delete_db_cluster_endpoint",
+]
 
 
-def failover_db_cluster(db_cluster_identifier: str,
-                        target_db_instance_identifier: str = None,
-                        configuration: Configuration = None,
-                        secrets: Secrets = None) -> AWSResponse:
+def failover_db_cluster(
+    db_cluster_identifier: str,
+    target_db_instance_identifier: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Forces a failover for a DB cluster.
     """
     client = aws_client("rds", configuration, secrets)
     if not db_cluster_identifier:
-        raise FailedActivity(
-            "you must specify the db cluster identifier"
-        )
+        raise FailedActivity("you must specify the db cluster identifier")
     try:
         return client.failover_db_cluster(
             DBClusterIdentifier=db_cluster_identifier,
-            TargetDBInstanceIdentifier=target_db_instance_identifier
+            TargetDBInstanceIdentifier=target_db_instance_identifier,
         )
     except Exception as x:
         raise FailedActivity(
             "failed issuing a failover for DB cluster '{}': '{}'".format(
-                db_cluster_identifier, str(x)))
+                db_cluster_identifier, str(x)
+            )
+        )
 
 
-def reboot_db_instance(db_instance_identifier: str,
-                       force_failover: bool = False,
-                       configuration: Configuration = None,
-                       secrets: Secrets = None) -> AWSResponse:
+def reboot_db_instance(
+    db_instance_identifier: str,
+    force_failover: bool = False,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Forces a reboot of your DB instance.
     """
     client = aws_client("rds", configuration, secrets)
     if not db_instance_identifier:
-        raise FailedActivity(
-            "you must specify the db instance identifier"
-        )
+        raise FailedActivity("you must specify the db instance identifier")
     try:
         return client.reboot_db_instance(
-            DBInstanceIdentifier=db_instance_identifier,
-            ForceFailover=force_failover
+            DBInstanceIdentifier=db_instance_identifier, ForceFailover=force_failover
         )
     except Exception as x:
         raise FailedActivity(
             "failed issuing a reboot of db instance '{}': '{}'".format(
-                db_instance_identifier, str(x)))
+                db_instance_identifier, str(x)
+            )
+        )
 
 
-def stop_db_instance(db_instance_identifier: str,
-                     db_snapshot_identifier: str = None,
-                     configuration: Configuration = None,
-                     secrets: Secrets = None) -> AWSResponse:
+def stop_db_instance(
+    db_instance_identifier: str,
+    db_snapshot_identifier: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Stops a RDS DB instance
 
@@ -72,21 +82,24 @@ def stop_db_instance(db_instance_identifier: str,
     """
     client = aws_client("rds", configuration, secrets)
 
-    params = dict(
-        DBInstanceIdentifier=db_instance_identifier)
+    params = dict(DBInstanceIdentifier=db_instance_identifier)
     if db_snapshot_identifier:
-        params['DBSnapshotIdentifier'] = db_snapshot_identifier
+        params["DBSnapshotIdentifier"] = db_snapshot_identifier
 
     try:
         return client.stop_db_instance(**params)
     except ClientError as e:
-        raise FailedActivity('Failed to stop RDS DB instance %s: %s' % (
-            db_instance_identifier, e.response['Error']['Message']))
+        raise FailedActivity(
+            "Failed to stop RDS DB instance %s: %s"
+            % (db_instance_identifier, e.response["Error"]["Message"])
+        )
 
 
-def stop_db_cluster(db_cluster_identifier: str,
-                    configuration: Configuration = None,
-                    secrets: Secrets = None) -> AWSResponse:
+def stop_db_cluster(
+    db_cluster_identifier: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Stop a RDS Cluster
 
@@ -95,19 +108,22 @@ def stop_db_cluster(db_cluster_identifier: str,
     client = aws_client("rds", configuration, secrets)
 
     try:
-        return client.stop_db_cluster(
-            DBClusterIdentifier=db_cluster_identifier)
+        return client.stop_db_cluster(DBClusterIdentifier=db_cluster_identifier)
     except ClientError as e:
-        raise FailedActivity('Failed to stop RDS DB Cluster %s: %s' % (
-            db_cluster_identifier, e.response['Error']['Message']))
+        raise FailedActivity(
+            "Failed to stop RDS DB Cluster %s: %s"
+            % (db_cluster_identifier, e.response["Error"]["Message"])
+        )
 
 
-def delete_db_instance(db_instance_identifier: str,
-                       skip_final_snapshot: bool = True,
-                       db_snapshot_identifier: str = None,
-                       delete_automated_backups: bool = True,
-                       configuration: Configuration = None,
-                       secrets: Secrets = None) -> AWSResponse:
+def delete_db_instance(
+    db_instance_identifier: str,
+    skip_final_snapshot: bool = True,
+    db_snapshot_identifier: str = None,
+    delete_automated_backups: bool = True,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Deletes a RDS instance
 
@@ -123,26 +139,33 @@ def delete_db_instance(db_instance_identifier: str,
     params = dict(
         DBInstanceIdentifier=db_instance_identifier,
         DeleteAutomatedBackups=delete_automated_backups,
-        SkipFinalSnapshot=skip_final_snapshot)
+        SkipFinalSnapshot=skip_final_snapshot,
+    )
 
     if not skip_final_snapshot:
         if not db_snapshot_identifier:
-            raise FailedActivity('You must provide a snapshot identifier if '
-                                 'taking a final DB snapshot')
-        params['FinalDBSnapshotIdentifier'] = db_snapshot_identifier
+            raise FailedActivity(
+                "You must provide a snapshot identifier if "
+                "taking a final DB snapshot"
+            )
+        params["FinalDBSnapshotIdentifier"] = db_snapshot_identifier
 
     try:
         return client.delete_db_instance(**params)
     except ClientError as e:
-        raise FailedActivity('Failed to delete RDS DB instance %s: %s' % (
-            db_instance_identifier, e.response['Error']['Message']))
+        raise FailedActivity(
+            "Failed to delete RDS DB instance %s: %s"
+            % (db_instance_identifier, e.response["Error"]["Message"])
+        )
 
 
-def delete_db_cluster(db_cluster_identifier: str,
-                      skip_final_snapshot: bool = True,
-                      db_snapshot_identifier: str = None,
-                      configuration: Configuration = None,
-                      secrets: Secrets = None) -> AWSResponse:
+def delete_db_cluster(
+    db_cluster_identifier: str,
+    skip_final_snapshot: bool = True,
+    db_snapshot_identifier: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Deletes an Aurora DB cluster
 
@@ -154,25 +177,31 @@ def delete_db_cluster(db_cluster_identifier: str,
     client = aws_client("rds", configuration, secrets)
 
     params = dict(
-        DBClusterIdentifier=db_cluster_identifier,
-        SkipFinalSnapshot=skip_final_snapshot)
+        DBClusterIdentifier=db_cluster_identifier, SkipFinalSnapshot=skip_final_snapshot
+    )
 
     if not skip_final_snapshot:
         if not db_snapshot_identifier:
-            raise FailedActivity('You must provide a snapshot identifier if '
-                                 'taking a final DB snapshot')
-        params['FinalDBSnapshotIdentifier'] = db_snapshot_identifier
+            raise FailedActivity(
+                "You must provide a snapshot identifier if "
+                "taking a final DB snapshot"
+            )
+        params["FinalDBSnapshotIdentifier"] = db_snapshot_identifier
 
     try:
         return client.delete_db_cluster(**params)
     except ClientError as e:
-        raise FailedActivity('Failed to delete RDS DB cluster %s: %s' % (
-            db_cluster_identifier, e.response['Error']['Message']))
+        raise FailedActivity(
+            "Failed to delete RDS DB cluster %s: %s"
+            % (db_cluster_identifier, e.response["Error"]["Message"])
+        )
 
 
-def delete_db_cluster_endpoint(db_cluster_identifier: str,
-                               configuration: Configuration = None,
-                               secrets: Secrets = None) -> AWSResponse:
+def delete_db_cluster_endpoint(
+    db_cluster_identifier: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Deletes the custom endpoint of an Aurora cluster
 
@@ -184,10 +213,13 @@ def delete_db_cluster_endpoint(db_cluster_identifier: str,
 
     try:
         return client.delete_db_cluster_endpoint(
-            DBClusterEndpointIdentifier=cluster['Endpoint'])
+            DBClusterEndpointIdentifier=cluster["Endpoint"]
+        )
     except ClientError as e:
-        raise FailedActivity('unable to delete endpoint for cluster %s: %s' % (
-            db_cluster_identifier, e.response['Error']['Message']))
+        raise FailedActivity(
+            "unable to delete endpoint for cluster %s: %s"
+            % (db_cluster_identifier, e.response["Error"]["Message"])
+        )
 
 
 ###############################################################################
@@ -195,8 +227,11 @@ def delete_db_cluster_endpoint(db_cluster_identifier: str,
 ###############################################################################
 def describe_db_cluster(cluster_id: str, client: boto3.client) -> AWSResponse:
     try:
-        return client.describe_db_clusters(
-            DBClusterIdentifier=cluster_id)['DBClusters'][0]
+        return client.describe_db_clusters(DBClusterIdentifier=cluster_id)[
+            "DBClusters"
+        ][0]
     except ClientError as e:
-        raise FailedActivity('unable to identify cluster %s: %s' % (
-            cluster_id, e.response['Error']['Message']))
+        raise FailedActivity(
+            "unable to identify cluster %s: %s"
+            % (cluster_id, e.response["Error"]["Message"])
+        )

--- a/chaosaws/rds/probes.py
+++ b/chaosaws/rds/probes.py
@@ -8,106 +8,109 @@ from logzero import logger
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ['instance_status', 'cluster_status', 'cluster_membership_count']
+__all__ = ["instance_status", "cluster_status", "cluster_membership_count"]
 
 
-def instance_status(instance_id: str = None,
-                    filters: List[Dict[str, Any]] = None,
-                    configuration: Configuration = None,
-                    secrets: Secrets = None) -> Union[str, List[str]]:
+def instance_status(
+    instance_id: str = None,
+    filters: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> Union[str, List[str]]:
     if (not instance_id and not filters) or (instance_id and filters):
-        raise FailedActivity('instance_id or filters are required')
+        raise FailedActivity("instance_id or filters are required")
 
-    client = aws_client('rds', configuration, secrets)
+    client = aws_client("rds", configuration, secrets)
     results = describe_db_instances(
-        client=client, instance_id=instance_id, filters=filters)
+        client=client, instance_id=instance_id, filters=filters
+    )
     if not results:
         if instance_id:
-            raise FailedActivity('no instance found matching %s' % instance_id)
+            raise FailedActivity("no instance found matching %s" % instance_id)
         if filters:
-            raise FailedActivity('no instance(s) found matching %s' % filters)
+            raise FailedActivity("no instance(s) found matching %s" % filters)
 
     # if all instances have the same status return only single value.
     # eg: "available"
     # if an instances has a different status, return list
     # eg: ["available", "creating"]
-    results = list(set([r['DBInstanceStatus'] for r in results[
-        'DBInstances']]))
+    results = list(set([r["DBInstanceStatus"] for r in results["DBInstances"]]))
     if len(results) == 1:
         return results[0]
     return results
 
 
-def cluster_status(cluster_id: str = None,
-                   filters: List[Dict[str, Any]] = None,
-                   configuration: Configuration = None,
-                   secrets: Secrets = None) -> Union[str, List[str]]:
+def cluster_status(
+    cluster_id: str = None,
+    filters: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> Union[str, List[str]]:
     if (not cluster_id and not filters) or (cluster_id and filters):
-        raise FailedActivity('cluster_id or filters are required')
+        raise FailedActivity("cluster_id or filters are required")
 
-    client = aws_client('rds', configuration, secrets)
-    results = describe_db_cluster(
-        client=client, cluster_id=cluster_id, filters=filters)
+    client = aws_client("rds", configuration, secrets)
+    results = describe_db_cluster(client=client, cluster_id=cluster_id, filters=filters)
     if not results:
         if cluster_id:
-            raise FailedActivity('no cluster found matching %s' % cluster_id)
+            raise FailedActivity("no cluster found matching %s" % cluster_id)
         if filters:
-            raise FailedActivity('no cluster(s) found matching %s' % filters)
+            raise FailedActivity("no cluster(s) found matching %s" % filters)
 
     # if all instances have the same status return only single value.
     # eg: "available"
     # if an instances has a different status, return list of unique values
     # eg: ["available", "backing-up"]
-    results = list(set([r['Status'] for r in results['DBClusters']]))
+    results = list(set([r["Status"] for r in results["DBClusters"]]))
     if len(results) == 1:
         return results[0]
     return results
 
 
-def cluster_membership_count(cluster_id: str,
-                             configuration: Configuration = None,
-                             secrets: Secrets = None) -> int:
-    client = aws_client('rds', configuration, secrets)
+def cluster_membership_count(
+    cluster_id: str, configuration: Configuration = None, secrets: Secrets = None
+) -> int:
+    client = aws_client("rds", configuration, secrets)
     results = describe_db_cluster(client=client, cluster_id=cluster_id)
     if not results:
-        raise FailedActivity('no cluster found matching %s' % cluster_id)
-    return len(results['DBClusters'][0]['DBClusterMembers'])
+        raise FailedActivity("no cluster found matching %s" % cluster_id)
+    return len(results["DBClusters"][0]["DBClusterMembers"])
 
 
 ###############################################################################
 # Private functions
 ###############################################################################
-def describe_db_instances(client: boto3.client,
-                          instance_id: str = None,
-                          filters: List[Dict[str, Any]] = None) -> AWSResponse:
-    paginator = client.get_paginator('describe_db_instances')
+def describe_db_instances(
+    client: boto3.client, instance_id: str = None, filters: List[Dict[str, Any]] = None
+) -> AWSResponse:
+    paginator = client.get_paginator("describe_db_instances")
     params = dict()
 
     if instance_id:
-        params['DBInstanceIdentifier'] = instance_id
+        params["DBInstanceIdentifier"] = instance_id
     if filters:
-        params['Filters'] = filters
+        params["Filters"] = filters
 
     results = {}
     for p in paginator.paginate(**params):
-        results.setdefault('DBInstances', []).extend(p['DBInstances'])
-    logger.info('found %s instances' % len(results['DBInstances']))
+        results.setdefault("DBInstances", []).extend(p["DBInstances"])
+    logger.info("found %s instances" % len(results["DBInstances"]))
     return results
 
 
-def describe_db_cluster(client: boto3.client,
-                        cluster_id: str = None,
-                        filters: List[Dict[str, Any]] = None) -> AWSResponse:
-    paginator = client.get_paginator('describe_db_clusters')
+def describe_db_cluster(
+    client: boto3.client, cluster_id: str = None, filters: List[Dict[str, Any]] = None
+) -> AWSResponse:
+    paginator = client.get_paginator("describe_db_clusters")
     params = dict()
 
     if cluster_id:
-        params['DBClusterIdentifier'] = cluster_id
+        params["DBClusterIdentifier"] = cluster_id
     if filters:
-        params['Filters'] = filters
+        params["Filters"] = filters
 
     results = {}
     for p in paginator.paginate(**params):
-        results.setdefault('DBClusters', []).extend(p['DBClusters'])
-    logger.info('found %s clusters' % len(results["DBClusters"]))
+        results.setdefault("DBClusters", []).extend(p["DBClusters"])
+    logger.info("found %s clusters" % len(results["DBClusters"]))
     return results

--- a/chaosaws/route53/actions.py
+++ b/chaosaws/route53/actions.py
@@ -6,15 +6,17 @@ from logzero import logger
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ['associate_vpc_with_zone', 'disassociate_vpc_from_zone']
+__all__ = ["associate_vpc_with_zone", "disassociate_vpc_from_zone"]
 
 
-def associate_vpc_with_zone(zone_id: str,
-                            vpc_id: str,
-                            vpc_region: str,
-                            comment: str = None,
-                            configuration: Configuration = None,
-                            secrets: Secrets = None) -> AWSResponse:
+def associate_vpc_with_zone(
+    zone_id: str,
+    vpc_id: str,
+    vpc_region: str,
+    comment: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Associate a VPC with a private hosted zone
 
     :param zone_id: The hosted zone id
@@ -25,28 +27,27 @@ def associate_vpc_with_zone(zone_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :returns: Dict[str, Any]
     """
-    client = aws_client('route53', configuration, secrets)
+    client = aws_client("route53", configuration, secrets)
     params = {
-        'HostedZoneId': zone_id,
-        'VPC': {
-            'VPCId': vpc_id,
-            'VPCRegion': vpc_region
-        },
-        **({'Comment': comment} if comment else {})
+        "HostedZoneId": zone_id,
+        "VPC": {"VPCId": vpc_id, "VPCRegion": vpc_region},
+        **({"Comment": comment} if comment else {}),
     }
     try:
         return client.associate_vpc_with_hosted_zone(**params)
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
-def disassociate_vpc_from_zone(zone_id: str,
-                               vpc_id: str,
-                               vpc_region: str,
-                               comment: str = None,
-                               configuration: Configuration = None,
-                               secrets: Secrets = None) -> AWSResponse:
+def disassociate_vpc_from_zone(
+    zone_id: str,
+    vpc_id: str,
+    vpc_region: str,
+    comment: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Remove an association between a VPC and a private hosted zone
 
     :param zone_id: The hosted zone id
@@ -57,17 +58,14 @@ def disassociate_vpc_from_zone(zone_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :returns: Dict[str, Any]
     """
-    client = aws_client('route53', configuration, secrets)
+    client = aws_client("route53", configuration, secrets)
     params = {
-        'HostedZoneId': zone_id,
-        'VPC': {
-            'VPCId': vpc_id,
-            'VPCRegion': vpc_region
-        },
-        **({'Comment': comment} if comment else {})
+        "HostedZoneId": zone_id,
+        "VPC": {"VPCId": vpc_id, "VPCRegion": vpc_region},
+        **({"Comment": comment} if comment else {}),
     }
     try:
         return client.disassociate_vpc_from_hosted_zone(**params)
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])

--- a/chaosaws/route53/probes.py
+++ b/chaosaws/route53/probes.py
@@ -7,12 +7,12 @@ from chaosaws import aws_client
 from chaosaws.route53.shared import hosted_zone_by_id
 from chaosaws.types import AWSResponse
 
-__all__ = ['get_hosted_zone', 'get_health_check_status', 'get_dns_answer']
+__all__ = ["get_hosted_zone", "get_health_check_status", "get_dns_answer"]
 
 
-def get_hosted_zone(zone_id: str,
-                    configuration: Configuration = None,
-                    secrets: Secrets = None) -> AWSResponse:
+def get_hosted_zone(
+    zone_id: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """Pull information regarding a specific zone id
 
     :param zone_id: The route53 zone id
@@ -20,16 +20,16 @@ def get_hosted_zone(zone_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :returns: Dict[str, Any]
     """
-    client = aws_client('route53', configuration, secrets)
+    client = aws_client("route53", configuration, secrets)
     response = hosted_zone_by_id(client, zone_id)
-    if not response['HostedZone']:
-        raise FailedActivity('Hosted Zone %s not found.' % zone_id)
+    if not response["HostedZone"]:
+        raise FailedActivity("Hosted Zone %s not found." % zone_id)
     return response
 
 
-def get_health_check_status(check_id: str,
-                            configuration: Configuration = None,
-                            secrets: Secrets = None) -> AWSResponse:
+def get_health_check_status(
+    check_id: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
     """Get the status of the specified health check
 
     :param check_id: The health check id
@@ -37,22 +37,24 @@ def get_health_check_status(check_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :returns: Dict[str, Any]
     """
-    client = aws_client('route53', configuration, secrets)
+    client = aws_client("route53", configuration, secrets)
     try:
         response = client.get_health_check_status(HealthCheckId=check_id)
-        if not response.get('HealthCheckObservations'):
-            raise FailedActivity('No results found for %s' % check_id)
+        if not response.get("HealthCheckObservations"):
+            raise FailedActivity("No results found for %s" % check_id)
         return response
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])
 
 
-def get_dns_answer(zone_id: str,
-                   record_name: str,
-                   record_type: str,
-                   configuration: Configuration = None,
-                   secrets: Secrets = None) -> AWSResponse:
+def get_dns_answer(
+    zone_id: str,
+    record_name: str,
+    record_type: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """Get the DNS response for the specified record name & type
 
     :param zone_id: The route53 zone id
@@ -62,12 +64,11 @@ def get_dns_answer(zone_id: str,
     :param secrets: values that need to be passed on to actions/probes
     :returns: Dict[str, Any]
     """
-    client = aws_client('route53', configuration, secrets)
+    client = aws_client("route53", configuration, secrets)
     try:
         return client.test_dns_answer(
-            HostedZoneId=zone_id,
-            RecordName=record_name,
-            RecordType=record_type)
+            HostedZoneId=zone_id, RecordName=record_name, RecordType=record_type
+        )
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        raise FailedActivity(e.response['Error']['Message'])
+        logger.exception(e.response["Error"]["Message"])
+        raise FailedActivity(e.response["Error"]["Message"])

--- a/chaosaws/route53/shared.py
+++ b/chaosaws/route53/shared.py
@@ -1,7 +1,8 @@
 import boto3
-from chaosaws.types import AWSResponse
-from logzero import logger
 from botocore.exceptions import ClientError
+from logzero import logger
+
+from chaosaws.types import AWSResponse
 
 
 def hosted_zone_by_id(client: boto3.client, zone_id: str) -> AWSResponse:
@@ -14,5 +15,5 @@ def hosted_zone_by_id(client: boto3.client, zone_id: str) -> AWSResponse:
     try:
         return client.get_hosted_zone(Id=zone_id)
     except ClientError as e:
-        logger.exception(e.response['Error']['Message'])
-        return {'HostedZone': []}
+        logger.exception(e.response["Error"]["Message"])
+        return {"HostedZone": []}

--- a/chaosaws/ssm/actions.py
+++ b/chaosaws/ssm/actions.py
@@ -1,12 +1,8 @@
-import random
-import re
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
-import boto3
 from botocore.exceptions import ClientError
 from chaoslib.exceptions import ActivityFailed
 from chaoslib.types import Configuration, Secrets
-from logzero import logger
 
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse

--- a/chaosaws/ssm/actions.py
+++ b/chaosaws/ssm/actions.py
@@ -14,13 +14,15 @@ from chaosaws.types import AWSResponse
 __all__ = ["create_document", "send_command", "delete_document"]
 
 
-def create_document(path_content: str,
-                    name: str,
-                    version_name: str = None,
-                    document_type: str = None,
-                    document_format: str = None,
-                    configuration: Configuration = None,
-                    secrets: Secrets = None) -> AWSResponse:
+def create_document(
+    path_content: str,
+    name: str,
+    version_name: str = None,
+    document_type: str = None,
+    document_format: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     creates a Systems Manager (SSM) document.
     An SSM document defines the actions that SSM performs on your managed.
@@ -30,34 +32,41 @@ def create_document(path_content: str,
     """
 
     if not any([path_content, name]):
-        raise ActivityFailed('To create a document,'
-                             'you must specify the  content and name')
+        raise ActivityFailed(
+            "To create a document," "you must specify the  content and name"
+        )
 
     try:
         with open(path_content) as open_file:
             document_content = open_file.read()
-            client = aws_client('ssm', configuration, secrets)
-            return client.create_document(Content=document_content,
-                                          Name=name,
-                                          VersionName=version_name,
-                                          DocumentType=document_type,
-                                          DocumentFormat=document_format)
+            client = aws_client("ssm", configuration, secrets)
+            return client.create_document(
+                Content=document_content,
+                Name=name,
+                VersionName=version_name,
+                DocumentType=document_type,
+                DocumentFormat=document_format,
+            )
     except ClientError as e:
         raise ActivityFailed(
             "Failed to create document '{}': '{}'".format(
-                name, str(e.response['Error']['Message'])))
+                name, str(e.response["Error"]["Message"])
+            )
+        )
 
 
-def send_command(document_name: str,
-                 targets: List[Dict[str, Any]] = None,
-                 document_version: str = None,
-                 parameters: Dict[str, Any] = None,
-                 timeout_seconds: int = None,
-                 max_concurrency: str = None,
-                 max_errors: str = None,
-                 region: str = None,
-                 configuration: Configuration = None,
-                 secrets: Secrets = None) -> AWSResponse:
+def send_command(
+    document_name: str,
+    targets: List[Dict[str, Any]] = None,
+    document_version: str = None,
+    parameters: Dict[str, Any] = None,
+    timeout_seconds: int = None,
+    max_concurrency: str = None,
+    max_errors: str = None,
+    region: str = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     Runs commands on one or more managed instances.
 
@@ -68,29 +77,34 @@ def send_command(document_name: str,
     """
 
     if not any([document_name]):
-        raise ActivityFailed('To run commands,'
-                             'you must specify the document_name')
+        raise ActivityFailed("To run commands," "you must specify the document_name")
 
     try:
-        client = aws_client('ssm', configuration, secrets)
-        return client.send_command(DocumentName=document_name,
-                                   DocumentVersion=document_version,
-                                   Targets=targets,
-                                   TimeoutSeconds=timeout_seconds,
-                                   Parameters=parameters,
-                                   MaxConcurrency=max_concurrency,
-                                   MaxErrors=max_errors)
+        client = aws_client("ssm", configuration, secrets)
+        return client.send_command(
+            DocumentName=document_name,
+            DocumentVersion=document_version,
+            Targets=targets,
+            TimeoutSeconds=timeout_seconds,
+            Parameters=parameters,
+            MaxConcurrency=max_concurrency,
+            MaxErrors=max_errors,
+        )
     except ClientError as e:
         raise ActivityFailed(
             "Failed to send command for document  '{}': '{}'".format(
-                document_name, str(e.response['Error']['Message'])))
+                document_name, str(e.response["Error"]["Message"])
+            )
+        )
 
 
-def delete_document(name: str,
-                    version_name: str = None,
-                    force: bool = True,
-                    configuration: Configuration = None,
-                    secrets: Secrets = None) -> AWSResponse:
+def delete_document(
+    name: str,
+    version_name: str = None,
+    force: bool = True,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
     """
     creates a Systems Manager (SSM) document.
 
@@ -101,16 +115,17 @@ def delete_document(name: str,
     """
 
     if not any(name):
-        raise ActivityFailed('To create a document,'
-                             'you must specify the  name')
+        raise ActivityFailed("To create a document," "you must specify the  name")
 
     try:
-        client = aws_client('ssm', configuration, secrets)
-        kwargs = {'Name': name, 'Force': force}
+        client = aws_client("ssm", configuration, secrets)
+        kwargs = {"Name": name, "Force": force}
         if version_name:
-            kwargs['VersionName'] = version_name
+            kwargs["VersionName"] = version_name
         return client.delete_document(**kwargs)
     except ClientError as e:
         raise ActivityFailed(
             "Failed to delete  document '{}': '{}'".format(
-                name, str(e.response['Error']['Message'])))
+                name, str(e.response["Error"]["Message"])
+            )
+        )

--- a/chaosaws/types.py
+++ b/chaosaws/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 __all__ = ["AWSResponse"]
 

--- a/chaosaws/utils.py
+++ b/chaosaws/utils.py
@@ -1,4 +1,3 @@
-#
 def breakup_iterable(values: list, limit: int = 50) -> list:
     for i in range(0, len(values), limit):
-        yield values[i : min(i + limit, len(values))]
+        yield values[i: min(i + limit, len(values))]

--- a/chaosaws/utils.py
+++ b/chaosaws/utils.py
@@ -1,3 +1,3 @@
 def breakup_iterable(values: list, limit: int = 50) -> list:
     for i in range(0, len(values), limit):
-        yield values[i: min(i + limit, len(values))]
+        yield values[i : min(i + limit, len(values))]

--- a/chaosaws/utils.py
+++ b/chaosaws/utils.py
@@ -1,4 +1,4 @@
 #
 def breakup_iterable(values: list, limit: int = 50) -> list:
     for i in range(0, len(values), limit):
-        yield values[i:min(i + limit, len(values))]
+        yield values[i : min(i + limit, len(values))]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def get_version_from_package() -> str:
         for line in f:
             if line.startswith("__version__"):
                 token, version = line.split(" = ", 1)
-                version = version.replace("'", "").strip()
+                version = version.replace("\"", "").strip()
                 return version
 
 

--- a/tests/asg/test_asg_actions.py
+++ b/tests/asg/test_asg_actions.py
@@ -1,270 +1,295 @@
 from unittest.mock import MagicMock, patch
-from chaoslib.exceptions import FailedActivity
-from chaosaws.asg.actions import (
-    suspend_processes, resume_processes, terminate_random_instances,
-    detach_random_instances, change_subnets, detach_random_volume,
-    attach_volume, stop_random_instances)
 
 import pytest
+from chaoslib.exceptions import FailedActivity
+
+from chaosaws.asg.actions import (
+    attach_volume,
+    change_subnets,
+    detach_random_instances,
+    detach_random_volume,
+    resume_processes,
+    stop_random_instances,
+    suspend_processes,
+    terminate_random_instances,
+)
 
 
 def test_suspend_process_no_name_or_tag():
     with pytest.raises(FailedActivity) as x:
         suspend_processes()
-    assert 'one of the following arguments are required: ' \
-           'asg_names or tags' in str(x.value)
+    assert "one of the following arguments are required: " "asg_names or tags" in str(
+        x.value
+    )
 
 
 def test_suspend_process_both_name_and_tag_one():
     with pytest.raises(FailedActivity) as x:
         suspend_processes(
-            asg_names=['AutoScalingGroup-A'],
-            tags=[{"Key": "TagKey", "Values": ["TagValues"]}])
-    assert 'only one of the following arguments are allowed: ' \
-           'asg_names/tags' in str(x.value)
+            asg_names=["AutoScalingGroup-A"],
+            tags=[{"Key": "TagKey", "Values": ["TagValues"]}],
+        )
+    assert "only one of the following arguments are allowed: " "asg_names/tags" in str(
+        x.value
+    )
 
 
 def test_suspend_process_invalid_process():
     with pytest.raises(FailedActivity) as x:
-        suspend_processes(
-            asg_names=['AutoScalingGroup-A'],
-            process_names=['Lunch'])
+        suspend_processes(asg_names=["AutoScalingGroup-A"], process_names=["Lunch"])
     assert "invalid process(es): ['Lunch'] not in" in str(x.value)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_suspend_process_asg_names(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "DesiredCapacity": 1,
-            "Instances": [{
-                "HealthStatus": "Healthy",
-                "LifecycleState": "InService"
-            }],
-            "SuspendedProcesses": []
-        }]
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+                "SuspendedProcesses": [],
+            }
+        ]
     }
     suspend_processes(asg_names=asg_names)
-    client.suspend_processes.assert_called_with(
-        AutoScalingGroupName=asg_names[0])
+    client.suspend_processes.assert_called_with(AutoScalingGroupName=asg_names[0])
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_suspend_process_asg_tags(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    client.get_paginator.return_value.paginate.return_value = [{
-        'Tags': [{
-            'ResourceId': 'AutoScalingGroup-A',
-            'ResourceType': 'auto-scaling-group',
-            'Key': 'TargetKey',
-            'Value': 'TargetValue',
-            'PropagateAtLaunch': False}]
-    }]
+    asg_names = ["AutoScalingGroup-A"]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
+                {
+                    "ResourceId": "AutoScalingGroup-A",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "TargetKey",
+                    "Value": "TargetValue",
+                    "PropagateAtLaunch": False,
+                }
+            ]
+        }
+    ]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "DesiredCapacity": 1,
-            "Instances": [{
-                "HealthStatus": "Healthy",
-                "LifecycleState": "InService"
-            }],
-            "SuspendedProcesses": []
-        }]
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+                "SuspendedProcesses": [],
+            }
+        ]
     }
-    suspend_processes(tags=[{'Key': 'TargetKey', 'Value': 'TargetValue'}])
-    client.suspend_processes.assert_called_with(
-        AutoScalingGroupName=asg_names[0])
+    suspend_processes(tags=[{"Key": "TargetKey", "Value": "TargetValue"}])
+    client.suspend_processes.assert_called_with(AutoScalingGroupName=asg_names[0])
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_suspend_process_asg_invalid_names(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": []}
+    asg_names = ["AutoScalingGroup-A"]
+    client.describe_auto_scaling_groups.return_value = {"AutoScalingGroups": []}
     with pytest.raises(FailedActivity) as x:
         suspend_processes(asg_names=asg_names, process_names=["Launch"])
-    assert 'Unable to locate ASG(s): %s' % asg_names in str(x.value)
+    assert "Unable to locate ASG(s): %s" % asg_names in str(x.value)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_suspend_process_asg_invalid_name(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A', 'AutoScalingGroup-B']
+    asg_names = ["AutoScalingGroup-A", "AutoScalingGroup-B"]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "DesiredCapacity": 1,
-            "Instances": [{
-                "HealthStatus": "Healthy",
-                "LifecycleState": "InService"
-            }],
-            "SuspendedProcesses": []
-        }]
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+                "SuspendedProcesses": [],
+            }
+        ]
     }
     with pytest.raises(FailedActivity) as x:
         suspend_processes(asg_names=asg_names, process_names=["Launch"])
-    assert 'No ASG(s) found with name(s): %s' % ([asg_names[1]]) in str(x.value)
+    assert "No ASG(s) found with name(s): %s" % ([asg_names[1]]) in str(x.value)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_suspend_process_asg_invalid_tags(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TargetKey', 'Value': 'TargetValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{'Tags': []}]
+    tags = [{"Key": "TargetKey", "Value": "TargetValue"}]
+    client.get_paginator.return_value.paginate.return_value = [{"Tags": []}]
     with pytest.raises(FailedActivity) as x:
         suspend_processes(tags=tags)
-    assert 'No ASG(s) found with matching tag(s): %s.' % tags in str(x.value)
+    assert "No ASG(s) found with matching tag(s): %s." % tags in str(x.value)
 
 
 def test_resume_process_no_name_or_tag():
     with pytest.raises(FailedActivity) as x:
         resume_processes()
-    assert 'one of the following arguments are required: ' \
-           'asg_names or tags' in str(x.value)
+    assert "one of the following arguments are required: " "asg_names or tags" in str(
+        x.value
+    )
 
 
 def test_resume_process_both_name_and_tag():
     with pytest.raises(FailedActivity) as x:
         resume_processes(
-            asg_names=['AutoScalingGroup-A'],
-            tags=[{"Key": "TagKey", "Values": ["TagValues"]}])
-    assert 'only one of the following arguments are allowed: ' \
-           'asg_names/tags' in str(x.value)
+            asg_names=["AutoScalingGroup-A"],
+            tags=[{"Key": "TagKey", "Values": ["TagValues"]}],
+        )
+    assert "only one of the following arguments are allowed: " "asg_names/tags" in str(
+        x.value
+    )
 
 
 def test_resume_process_invalid_process():
     with pytest.raises(FailedActivity) as x:
-        resume_processes(
-            asg_names=['AutoScalingGroup-A'],
-            process_names=['Lunch'])
+        resume_processes(asg_names=["AutoScalingGroup-A"], process_names=["Lunch"])
     assert "invalid process(es): ['Lunch'] not in" in str(x.value)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_resume_process_asg_names(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "DesiredCapacity": 1,
-            "Instances": [{
-                "HealthStatus": "Healthy",
-                "LifecycleState": "InService"
-            }],
-            "SuspendedProcesses": [{"ProcessName": "Launch"}]
-        }]
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+                "SuspendedProcesses": [{"ProcessName": "Launch"}],
+            }
+        ]
     }
     resume_processes(asg_names=asg_names, process_names=["Launch"])
     client.resume_processes.assert_called_with(
-        AutoScalingGroupName=asg_names[0], ScalingProcesses=["Launch"])
+        AutoScalingGroupName=asg_names[0], ScalingProcesses=["Launch"]
+    )
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_resume_process_asg_tags(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    tags = [{'Key': 'TargetKey', 'Value': 'TargetValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        'Tags': [{
-            'ResourceId': 'AutoScalingGroup-A',
-            'ResourceType': 'auto-scaling-group',
-            'Key': 'TargetKey',
-            'Value': 'TargetValue',
-            'PropagateAtLaunch': False}]
-    }]
+    asg_names = ["AutoScalingGroup-A"]
+    tags = [{"Key": "TargetKey", "Value": "TargetValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
+                {
+                    "ResourceId": "AutoScalingGroup-A",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "TargetKey",
+                    "Value": "TargetValue",
+                    "PropagateAtLaunch": False,
+                }
+            ]
+        }
+    ]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "DesiredCapacity": 1,
-            "Instances": [{
-                "HealthStatus": "Healthy",
-                "LifecycleState": "InService"
-            }],
-            "SuspendedProcesses": [{"ProcessName": "Launch"}]
-        }]
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+                "SuspendedProcesses": [{"ProcessName": "Launch"}],
+            }
+        ]
     }
     resume_processes(tags=tags, process_names=["Launch"])
     client.resume_processes.assert_called_with(
-        AutoScalingGroupName=asg_names[0], ScalingProcesses=["Launch"])
+        AutoScalingGroupName=asg_names[0], ScalingProcesses=["Launch"]
+    )
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_resume_process_asg_invalid_tags(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TargetKey', 'Value': 'TargetValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{'Tags': []}]
+    tags = [{"Key": "TargetKey", "Value": "TargetValue"}]
+    client.get_paginator.return_value.paginate.return_value = [{"Tags": []}]
     with pytest.raises(FailedActivity) as x:
         resume_processes(tags=tags)
-    assert 'No ASG(s) found with matching tag(s): %s.' % tags in str(x.value)
+    assert "No ASG(s) found with matching tag(s): %s." % tags in str(x.value)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_resume_process_asg_invalid_names(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": []}
+    asg_names = ["AutoScalingGroup-A"]
+    client.describe_auto_scaling_groups.return_value = {"AutoScalingGroups": []}
     with pytest.raises(FailedActivity) as x:
         resume_processes(asg_names=asg_names, process_names=["Launch"])
-    assert 'Unable to locate ASG(s): ' in str(x.value)
+    assert "Unable to locate ASG(s): " in str(x.value)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_resume_process_asg_invalid_name(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A', 'AutoScalingGroup-B']
+    asg_names = ["AutoScalingGroup-A", "AutoScalingGroup-B"]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "DesiredCapacity": 1,
-            "Instances": [{
-                "HealthStatus": "Healthy",
-                "LifecycleState": "InService"
-            }],
-            "SuspendedProcesses": [{"ProcessName": "Launch"}]
-        }]
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+                "SuspendedProcesses": [{"ProcessName": "Launch"}],
+            }
+        ]
     }
     with pytest.raises(FailedActivity) as x:
         resume_processes(asg_names=asg_names, process_names=["Launch"])
-    assert 'No ASG(s) found with name(s): %s' % ([asg_names[1]]) in str(x.value)
+    assert "No ASG(s) found with name(s): %s" % ([asg_names[1]]) in str(x.value)
 
 
 def test_terminate_instances_no_asgs():
     with pytest.raises(FailedActivity) as x:
         terminate_random_instances(instance_count=10)
-    assert 'one of the following arguments are required: ' \
-           'asg_names or tags' in str(x.value)
+    assert "one of the following arguments are required: " "asg_names or tags" in str(
+        x.value
+    )
 
 
 def test_terminate_instances_no_numbers():
-    asg_names = ['AutoScalingGroup-A', 'AutoScalingGroup-B']
+    asg_names = ["AutoScalingGroup-A", "AutoScalingGroup-B"]
     with pytest.raises(FailedActivity) as x:
         terminate_random_instances(asg_names)
-    assert 'Must specify one of "instance_count", ' \
-           '"instance_percent", "az"' in str(x.value)
+    assert 'Must specify one of "instance_count", ' '"instance_percent", "az"' in str(
+        x.value
+    )
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_terminate_instances_count_pass(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
@@ -273,46 +298,45 @@ def test_terminate_instances_count_pass(aws_client):
                     {
                         "InstanceId": "i-00000000000000001",
                         "AvailabilityZone": "us-east-1a",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000002",
                         "AvailabilityZone": "us-east-1b",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000003",
                         "AvailabilityZone": "us-east-1c",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
-                ]
+                ],
             }
         ]
     }
     terminate_random_instances(asg_names=asg_names, instance_count=2)
 
     instance_calls = [
-        ['i-00000000000000001', 'i-00000000000000002'],
-        ['i-00000000000000001', 'i-00000000000000003'],
-        ['i-00000000000000002', 'i-00000000000000003']
+        ["i-00000000000000001", "i-00000000000000002"],
+        ["i-00000000000000001", "i-00000000000000003"],
+        ["i-00000000000000002", "i-00000000000000003"],
     ]
 
     ex = None
     for i in instance_calls:
         try:
-            client.terminate_instances.assert_called_with(
-                InstanceIds=sorted(i))
+            client.terminate_instances.assert_called_with(InstanceIds=sorted(i))
             return True
         except AssertionError as e:
             ex = e.args
     raise AssertionError(ex)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_terminate_instances_percent_pass(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
@@ -321,43 +345,45 @@ def test_terminate_instances_percent_pass(aws_client):
                     {
                         "InstanceId": "i-00000000000000001",
                         "AvailabilityZone": "us-east-1a",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000002",
                         "AvailabilityZone": "us-east-1b",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000003",
                         "AvailabilityZone": "us-east-1c",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
-                ]
+                ],
             }
         ]
     }
     terminate_random_instances(asg_names=asg_names, instance_percent=50)
 
     instance_calls = [
-        'i-00000000000000001', 'i-00000000000000002', 'i-00000000000000003']
+        "i-00000000000000001",
+        "i-00000000000000002",
+        "i-00000000000000003",
+    ]
 
     ex = None
     for i in instance_calls:
         try:
-            client.terminate_instances.assert_called_with(
-                InstanceIds=[i])
+            client.terminate_instances.assert_called_with(InstanceIds=[i])
             return True
         except AssertionError as e:
             ex = e.args
     raise AssertionError(ex)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_terminate_instances_valid_az(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
@@ -366,32 +392,31 @@ def test_terminate_instances_valid_az(aws_client):
                     {
                         "InstanceId": "i-00000000000000001",
                         "AvailabilityZone": "us-east-1a",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000002",
                         "AvailabilityZone": "us-east-1b",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000003",
                         "AvailabilityZone": "us-east-1c",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
-                ]
+                ],
             }
         ]
     }
-    terminate_random_instances(asg_names=asg_names, az='us-east-1a')
-    client.terminate_instances.assert_called_with(
-        InstanceIds=['i-00000000000000001'])
+    terminate_random_instances(asg_names=asg_names, az="us-east-1a")
+    client.terminate_instances.assert_called_with(InstanceIds=["i-00000000000000001"])
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_terminate_instances_invalid_az(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
@@ -400,32 +425,32 @@ def test_terminate_instances_invalid_az(aws_client):
                     {
                         "InstanceId": "i-00000000000000001",
                         "AvailabilityZone": "us-east-1a",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000002",
                         "AvailabilityZone": "us-east-1b",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000003",
                         "AvailabilityZone": "us-east-1c",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
-                ]
+                ],
             }
         ]
     }
     with pytest.raises(FailedActivity) as x:
-        terminate_random_instances(asg_names=asg_names, az='us-east-1d')
-    assert 'No instances found in Availability Zone: us-east-1d' in str(x.value)
+        terminate_random_instances(asg_names=asg_names, az="us-east-1d")
+    assert "No instances found in Availability Zone: us-east-1d" in str(x.value)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_terminate_instances_invalid_count(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
@@ -434,66 +459,74 @@ def test_terminate_instances_invalid_count(aws_client):
                     {
                         "InstanceId": "i-00000000000000001",
                         "AvailabilityZone": "us-east-1a",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     }
-                ]
+                ],
             }
         ]
     }
     with pytest.raises(FailedActivity) as x:
         terminate_random_instances(asg_names=asg_names, instance_count=2)
-    assert 'Not enough healthy instances in {} to satisfy ' \
-           'termination count {} ({})'.format(asg_names[0], 2, 1) in str(x.value)
+    assert (
+        "Not enough healthy instances in {} to satisfy "
+        "termination count {} ({})".format(asg_names[0], 2, 1) in str(x.value)
+    )
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_terminate_instances_tags(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TargetKey', 'Value': 'TargetValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        'Tags': [{
-            'ResourceId': 'AutoScalingGroup-A',
-            'ResourceType': 'auto-scaling-group',
-            'Key': 'TargetKey',
-            'Value': 'TargetValue',
-            'PropagateAtLaunch': False}]
-    }]
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Instances": [
+    tags = [{"Key": "TargetKey", "Value": "TargetValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
                 {
-                    "InstanceId": "i-00000000000000001",
-                    "AvailabilityZone": "us-east-1a",
-                    "LifecycleState": "InService"
-                },
-                {
-                    "InstanceId": "i-00000000000000002",
-                    "AvailabilityZone": "us-east-1b",
-                    "LifecycleState": "InService"
-                },
-                {
-                    "InstanceId": "i-00000000000000003",
-                    "AvailabilityZone": "us-east-1c",
-                    "LifecycleState": "InService"
-                },
+                    "ResourceId": "AutoScalingGroup-A",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "TargetKey",
+                    "Value": "TargetValue",
+                    "PropagateAtLaunch": False,
+                }
             ]
-        }]
+        }
+    ]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "Instances": [
+                    {
+                        "InstanceId": "i-00000000000000001",
+                        "AvailabilityZone": "us-east-1a",
+                        "LifecycleState": "InService",
+                    },
+                    {
+                        "InstanceId": "i-00000000000000002",
+                        "AvailabilityZone": "us-east-1b",
+                        "LifecycleState": "InService",
+                    },
+                    {
+                        "InstanceId": "i-00000000000000003",
+                        "AvailabilityZone": "us-east-1c",
+                        "LifecycleState": "InService",
+                    },
+                ],
+            }
+        ]
     }
     terminate_random_instances(tags=tags, instance_count=2)
 
     instance_calls = [
-        ['i-00000000000000001', 'i-00000000000000002'],
-        ['i-00000000000000001', 'i-00000000000000003'],
-        ['i-00000000000000002', 'i-00000000000000003']
+        ["i-00000000000000001", "i-00000000000000002"],
+        ["i-00000000000000001", "i-00000000000000003"],
+        ["i-00000000000000002", "i-00000000000000003"],
     ]
 
     ex = None
     for i in instance_calls:
         try:
-            client.terminate_instances.assert_called_with(
-                InstanceIds=sorted(i))
+            client.terminate_instances.assert_called_with(InstanceIds=sorted(i))
             return True
         except AssertionError as e:
             ex = e.args
@@ -503,32 +536,35 @@ def test_terminate_instances_tags(aws_client):
 def test_detach_instance_no_name_or_tag():
     with pytest.raises(FailedActivity) as x:
         detach_random_instances()
-    assert 'one of the following arguments are required: ' \
-           'asg_names or tags' in str(x.value)
+    assert "one of the following arguments are required: " "asg_names or tags" in str(
+        x.value
+    )
 
 
 def test_detach_instance_both_name_and_tag_one():
     with pytest.raises(FailedActivity) as x:
         detach_random_instances(
-            asg_names=['AutoScalingGroup-A'],
-            tags=[{"Key": "TagKey", "Values": ["TagValues"]}])
-    assert 'only one of the following arguments are allowed: ' \
-           'asg_names/tags' in str(x.value)
+            asg_names=["AutoScalingGroup-A"],
+            tags=[{"Key": "TagKey", "Values": ["TagValues"]}],
+        )
+    assert "only one of the following arguments are allowed: " "asg_names/tags" in str(
+        x.value
+    )
 
 
 def test_detach_instance_no_count():
     with pytest.raises(FailedActivity) as x:
-        detach_random_instances(
-            asg_names=['AutoScalingGroup-A'])
-    assert 'You must specify either "instance_count" or ' \
-           '"instance_percent"' in str(x.value)
+        detach_random_instances(asg_names=["AutoScalingGroup-A"])
+    assert 'You must specify either "instance_count" or ' '"instance_percent"' in str(
+        x.value
+    )
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_detach_instances_invalid_count(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
@@ -537,28 +573,30 @@ def test_detach_instances_invalid_count(aws_client):
                     {
                         "InstanceId": "i-00000000000000001",
                         "AvailabilityZone": "us-east-1a",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000002",
                         "AvailabilityZone": "us-east-1b",
-                        "LifecycleState": "InService"
-                    }
-                ]
+                        "LifecycleState": "InService",
+                    },
+                ],
             }
         ]
     }
     with pytest.raises(FailedActivity) as x:
         detach_random_instances(asg_names, instance_count=3)
-    assert 'You are attempting to detach more instances than exist on ' \
-           'asg %s' % asg_names[0] in str(x.value)
+    assert (
+        "You are attempting to detach more instances than exist on "
+        "asg %s" % asg_names[0] in str(x.value)
+    )
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_detach_instances_count(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
@@ -567,28 +605,29 @@ def test_detach_instances_count(aws_client):
                     {
                         "InstanceId": "i-00000000000000001",
                         "AvailabilityZone": "us-east-1a",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000002",
                         "AvailabilityZone": "us-east-1b",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000003",
                         "AvailabilityZone": "us-east-1c",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
-                ]
+                ],
             }
         ]
     }
     result = detach_random_instances(asg_names, instance_count=2)
 
     instance_calls = [
-        ['i-00000000000000001', 'i-00000000000000002'],
-        ['i-00000000000000001', 'i-00000000000000003'],
-        ['i-00000000000000002', 'i-00000000000000003']]
+        ["i-00000000000000001", "i-00000000000000002"],
+        ["i-00000000000000001", "i-00000000000000003"],
+        ["i-00000000000000002", "i-00000000000000003"],
+    ]
 
     ex = None
     call_found = False
@@ -599,12 +638,12 @@ def test_detach_instances_count(aws_client):
             client.detach_instances.assert_called_with(
                 AutoScalingGroupName=asg_names[0],
                 InstanceIds=instance_ids,
-                ShouldDecrementDesiredCapacity=False)
+                ShouldDecrementDesiredCapacity=False,
+            )
             call_found = True
-            assert result['DetachingInstances'] == [{
-                'AutoScalingGroupName': asg_names[0],
-                'InstanceIds': instance_ids
-            }]
+            assert result["DetachingInstances"] == [
+                {"AutoScalingGroupName": asg_names[0], "InstanceIds": instance_ids}
+            ]
             return True
         except AssertionError as e:
             ex = str(e.args)
@@ -613,11 +652,11 @@ def test_detach_instances_count(aws_client):
     raise AssertionError(ex)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_detach_instances_percent(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
@@ -626,28 +665,29 @@ def test_detach_instances_percent(aws_client):
                     {
                         "InstanceId": "i-00000000000000001",
                         "AvailabilityZone": "us-east-1a",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000002",
                         "AvailabilityZone": "us-east-1b",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000003",
                         "AvailabilityZone": "us-east-1c",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
-                ]
+                ],
             }
         ]
     }
     detach_random_instances(asg_names, instance_percent=67)
 
     instance_calls = [
-        ['i-00000000000000001', 'i-00000000000000002'],
-        ['i-00000000000000001', 'i-00000000000000003'],
-        ['i-00000000000000002', 'i-00000000000000003']]
+        ["i-00000000000000001", "i-00000000000000002"],
+        ["i-00000000000000001", "i-00000000000000003"],
+        ["i-00000000000000002", "i-00000000000000003"],
+    ]
 
     ex = None
     for i in instance_calls:
@@ -655,349 +695,32 @@ def test_detach_instances_percent(aws_client):
             client.detach_instances.assert_called_with(
                 AutoScalingGroupName=asg_names[0],
                 InstanceIds=sorted(i),
-                ShouldDecrementDesiredCapacity=False)
+                ShouldDecrementDesiredCapacity=False,
+            )
             return True
         except AssertionError as e:
             ex = str(e.args)
     raise AssertionError(ex)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
 def test_detach_instances_tags(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TargetKey', 'Value': 'TargetValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        'Tags': [{
-            'ResourceId': 'AutoScalingGroup-A',
-            'ResourceType': 'auto-scaling-group',
-            'Key': 'TargetKey',
-            'Value': 'TargetValue',
-            'PropagateAtLaunch': False}]
-    }]
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Instances": [
+    tags = [{"Key": "TargetKey", "Value": "TargetValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
                 {
-                    "InstanceId": "i-00000000000000001",
-                    "AvailabilityZone": "us-east-1a",
-                    "LifecycleState": "InService"
-                },
-                {
-                    "InstanceId": "i-00000000000000002",
-                    "AvailabilityZone": "us-east-1b",
-                    "LifecycleState": "InService"
-                },
-                {
-                    "InstanceId": "i-00000000000000003",
-                    "AvailabilityZone": "us-east-1c",
-                    "LifecycleState": "InService"
-                },
+                    "ResourceId": "AutoScalingGroup-A",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "TargetKey",
+                    "Value": "TargetValue",
+                    "PropagateAtLaunch": False,
+                }
             ]
-        }]
-    }
-    detach_random_instances(tags=tags, instance_count=2)
-
-    instance_calls = [
-        ['i-00000000000000001', 'i-00000000000000002'],
-        ['i-00000000000000001', 'i-00000000000000003'],
-        ['i-00000000000000002', 'i-00000000000000003']
+        }
     ]
-
-    ex = None
-    for i in instance_calls:
-        try:
-            client.detach_instances.assert_called_with(
-                AutoScalingGroupName='AutoScalingGroup-A',
-                InstanceIds=sorted(i),
-                ShouldDecrementDesiredCapacity=False)
-            return True
-        except AssertionError as e:
-            ex = e.args
-    raise AssertionError(ex)
-
-
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
-def test_change_subnets_valid_names(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    params = dict(
-        asg_names=asg_names,
-        subnets=['subnet-123456789', 'subnet-23456789a'])
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "VPCZoneIdentifier": "subnet-012345678,subnet-123456789"}]}
-    change_subnets(**params)
-    client.update_auto_scaling_group.assert_called_with(
-        AutoScalingGroupName=asg_names[0],
-        VPCZoneIdentifier="subnet-123456789,subnet-23456789a")
-
-
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
-def test_change_subnets_valid_tags(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    tags = [{'Key': 'TargetKey', 'Value': 'TargetValue'}]
-    params = dict(
-        tags=tags,
-        subnets=['subnet-123456789', 'subnet-23456789a'])
-    client.get_paginator.return_value.paginate.return_value = [{
-        'Tags': [{
-            'ResourceId': 'AutoScalingGroup-A',
-            'ResourceType': 'auto-scaling-group',
-            'Key': 'TargetKey',
-            'Value': 'TargetValue'}]}]
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "VPCZoneIdentifier": "subnet-012345678,subnet-123456789"}]}
-    change_subnets(**params)
-
-    client.update_auto_scaling_group.assert_called_with(
-        AutoScalingGroupName="AutoScalingGroup-A",
-        VPCZoneIdentifier="subnet-123456789,subnet-23456789a")
-
-
-def test_change_subnets_no_subnet():
-    asg_names = ['AutoScalingGroup-A']
-    with pytest.raises(TypeError) as x:
-        change_subnets(asg_names=asg_names)
-    assert "missing 1 required positional argument: 'subnets'" in str(x.value)
-
-
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
-def test_detach_random_volume_asg_name(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Instances": [
-                {"InstanceId": "i-00000000000000001"}]}]}
-    client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'InstanceId': 'i-00000000000000001',
-                'BlockDeviceMappings': [
-                    {
-                        'DeviceName': '/dev/xvda',
-                        'Ebs': {'VolumeId': 'vol-00000001'}
-                    },
-                    {
-                        'DeviceName': '/dev/sdc',
-                        'Ebs': {'VolumeId': 'vol-00000002'}
-                    }]}]}]}
-    client.detach_volume.return_value = {
-        'Device': '/dev/sdc',
-        'InstanceId': 'i-00000000000000001',
-        'State': 'detaching',
-        'VolumeId': 'vol-00000002'}
-
-    results = detach_random_volume(asg_names=asg_names)
-
-    client.describe_auto_scaling_groups.assert_called_with(
-        AutoScalingGroupNames=asg_names)
-    client.describe_instances.assert_called_with(
-        InstanceIds=['i-00000000000000001'])
-    client.detach_volume.assert_called_with(
-        Device='/dev/sdc',
-        Force=True,
-        InstanceId='i-00000000000000001',
-        VolumeId='vol-00000002')
-    assert results[0]['Device'] == '/dev/sdc'
-
-
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
-def test_detach_random_volume_asg_tags(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    tags = [{'Key': 'TargetKey', 'Value': 'TargetValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        'Tags': [{
-            'ResourceId': 'AutoScalingGroup-A',
-            'ResourceType': 'auto-scaling-group',
-            'Key': 'TargetKey',
-            'Value': 'TargetValue',
-            'PropagateAtLaunch': False}]}]
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Instances": [
-                {"InstanceId": "i-00000000000000001"}]}]}
-    client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'InstanceId': 'i-00000000000000001',
-                'BlockDeviceMappings': [
-                    {
-                        'DeviceName': '/dev/xvda',
-                        'Ebs': {'VolumeId': 'vol-00000001'}
-                    },
-                    {
-                        'DeviceName': '/dev/sdb',
-                        'Ebs': {'VolumeId': 'vol-00000002'}
-                    }]}]}]}
-    client.detach_volume.return_value = {
-        'Device': '/dev/sdb',
-        'InstanceId': 'i-00000000000000001',
-        'State': 'detaching',
-        'VolumeId': 'vol-00000002'}
-
-    results = detach_random_volume(tags=tags)
-
-    client.describe_auto_scaling_groups.assert_called_with(
-        AutoScalingGroupNames=asg_names)
-    client.describe_instances.assert_called_with(
-        InstanceIds=['i-00000000000000001'])
-    client.detach_volume.assert_called_with(
-        Device='/dev/sdb',
-        Force=True,
-        InstanceId='i-00000000000000001',
-        VolumeId='vol-00000002')
-    assert results[0]['Device'] == '/dev/sdb'
-
-
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
-def test_detach_random_volume_asg_invalid_name(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": []}
-
-    with pytest.raises(FailedActivity) as x:
-        detach_random_volume(asg_names=asg_names)
-    assert "Unable to locate ASG(s): %s" % asg_names in str(x.value)
-
-
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
-def test_detach_random_volume_asg_invalid_tags(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    tags = [{'Key': 'TargetKey', 'Value': 'TargetValue'}]
-    client.describe_instances.return_value = {'Reservations': []}
-
-    with pytest.raises(FailedActivity) as x:
-        detach_random_volume(tags=tags)
-    assert "No ASG(s) found with matching tag(s): %s" % tags in str(x.value)
-
-
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
-def test_attach_volume_asg_name(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": asg_names[0],
-            "Instances": [
-                {"InstanceId": "i-00000000000000001"}]}]}
-
-    client.describe_volumes.return_value = {
-            'Volumes': [
-                {
-                    'VolumeId': 'vol-00000001',
-                    'Tags': [{
-                        'Key': 'ChaosToolkitDetached',
-                        'Value': 'DeviceName=/dev/sdc;InstanceId=%s;ASG=%s' % (
-                            'i-987654321fabcde', asg_names[0])}]
-                },
-                {
-                    'VolumeId': 'vol-00000002',
-                    'Tags': [{
-                        'Key': 'ChaosToolkitDetached',
-                        'Value': 'DeviceName=/dev/sdb;InstanceId='
-                                 'i-987654321fefghi'
-                    }]}]}
-
-    client.attach_volume.return_value = {
-        'DeviceName': '/dev/sdc',
-        'InstanceId': 'i-987654321fabcde',
-        'State': 'attaching',
-        'VolumeId': 'vol-00000001'}
-
-    results = attach_volume(asg_names=asg_names)
-
-    client.describe_auto_scaling_groups.assert_called_with(
-        AutoScalingGroupNames=asg_names)
-    client.describe_volumes.assert_called_with(
-        Filters=[{'Name': 'tag-key', 'Values': ['ChaosToolkitDetached']}])
-    client.attach_volume.assert_called_with(
-        Device='/dev/sdc',
-        InstanceId='i-987654321fabcde',
-        VolumeId='vol-00000001')
-    assert results[0]['DeviceName'] == '/dev/sdc'
-
-
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
-def test_attach_volume_asg_tags(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    tags = [{'Key': 'TargetKey', 'Value': 'TargetValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        'Tags': [{
-            'ResourceId': asg_names[0],
-            'ResourceType': 'auto-scaling-group',
-            'Key': 'TargetKey',
-            'Value': 'TargetValue',
-            'PropagateAtLaunch': False}]}]
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": asg_names[0],
-            "Instances": [
-                {"InstanceId": "i-00000000000000001"}]}]}
-
-    client.describe_volumes.return_value = {
-        'Volumes': [
-            {
-                'VolumeId': 'vol-00000001',
-                'Tags': [{
-                    'Key': 'ChaosToolkitDetached',
-                    'Value': 'DeviceName=/dev/sdb;InstanceId=%s;ASG=%s' % (
-                        'i-00000000000000001', asg_names[0])}]
-            },
-            {
-                'VolumeId': 'vol-00000002',
-                'Tags': [{
-                    'Key': 'ChaosToolkitDetached',
-                    'Value': 'DeviceName=/dev/sdb;InstanceId='
-                             'i-987654321fghij'
-                }]}]}
-
-    client.attach_volume.return_value = {
-        'DeviceName': '/dev/sdb',
-        'InstanceId': 'i-00000000000000001',
-        'State': 'attaching',
-        'VolumeId': 'vol-00000001'}
-
-    results = attach_volume(tags=tags)
-
-    client.describe_auto_scaling_groups.assert_called_with(
-        AutoScalingGroupNames=asg_names)
-    client.get_paginator.return_value.paginate.assert_called_with(
-        Filters=[
-            {'Name': 'key', 'Values': ['TargetKey']},
-            {'Name': 'value', 'Values': ['TargetValue']}])
-    client.describe_volumes.assert_called_with(
-        Filters=[{'Name': 'tag-key', 'Values': ['ChaosToolkitDetached']}])
-    client.attach_volume.assert_called_with(
-        Device='/dev/sdb',
-        InstanceId='i-00000000000000001',
-        VolumeId='vol-00000001')
-    assert results[0]['DeviceName'] == '/dev/sdb'
-
-
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
-def test_asg_stop_random_instance_name(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
@@ -1006,81 +729,495 @@ def test_asg_stop_random_instance_name(aws_client):
                     {
                         "InstanceId": "i-00000000000000001",
                         "AvailabilityZone": "us-east-1a",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000002",
                         "AvailabilityZone": "us-east-1b",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
                     {
                         "InstanceId": "i-00000000000000003",
                         "AvailabilityZone": "us-east-1c",
-                        "LifecycleState": "InService"
+                        "LifecycleState": "InService",
                     },
-                ]
+                ],
             }
         ]
     }
-    stop_random_instances(asg_names=asg_names, instance_percent=50)
+    detach_random_instances(tags=tags, instance_count=2)
 
     instance_calls = [
-        'i-00000000000000001', 'i-00000000000000002', 'i-00000000000000003']
+        ["i-00000000000000001", "i-00000000000000002"],
+        ["i-00000000000000001", "i-00000000000000003"],
+        ["i-00000000000000002", "i-00000000000000003"],
+    ]
 
     ex = None
     for i in instance_calls:
         try:
-            client.stop_instances.assert_called_with(
-                Force=False, InstanceIds=[i])
+            client.detach_instances.assert_called_with(
+                AutoScalingGroupName="AutoScalingGroup-A",
+                InstanceIds=sorted(i),
+                ShouldDecrementDesiredCapacity=False,
+            )
             return True
         except AssertionError as e:
             ex = e.args
     raise AssertionError(ex)
 
 
-@patch('chaosaws.asg.actions.aws_client', autospec=True)
-def test_asg_stop_random_instance_tags(aws_client):
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
+def test_change_subnets_valid_names(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TargetKey', 'Value': 'TargetValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        'Tags': [{
-            'ResourceId': 'AutoScalingGroup-A',
-            'ResourceType': 'auto-scaling-group',
-            'Key': 'TargetKey',
-            'Value': 'TargetValue',
-            'PropagateAtLaunch': False}]}]
+    asg_names = ["AutoScalingGroup-A"]
+    params = dict(asg_names=asg_names, subnets=["subnet-123456789", "subnet-23456789a"])
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Instances": [
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "VPCZoneIdentifier": "subnet-012345678,subnet-123456789",
+            }
+        ]
+    }
+    change_subnets(**params)
+    client.update_auto_scaling_group.assert_called_with(
+        AutoScalingGroupName=asg_names[0],
+        VPCZoneIdentifier="subnet-123456789,subnet-23456789a",
+    )
+
+
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
+def test_change_subnets_valid_tags(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tags = [{"Key": "TargetKey", "Value": "TargetValue"}]
+    params = dict(tags=tags, subnets=["subnet-123456789", "subnet-23456789a"])
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
                 {
-                    "InstanceId": "i-00000000000000001",
-                    "AvailabilityZone": "us-east-1a",
-                    "LifecycleState": "InService"
-                },
+                    "ResourceId": "AutoScalingGroup-A",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "TargetKey",
+                    "Value": "TargetValue",
+                }
+            ]
+        }
+    ]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "VPCZoneIdentifier": "subnet-012345678,subnet-123456789",
+            }
+        ]
+    }
+    change_subnets(**params)
+
+    client.update_auto_scaling_group.assert_called_with(
+        AutoScalingGroupName="AutoScalingGroup-A",
+        VPCZoneIdentifier="subnet-123456789,subnet-23456789a",
+    )
+
+
+def test_change_subnets_no_subnet():
+    asg_names = ["AutoScalingGroup-A"]
+    with pytest.raises(TypeError) as x:
+        change_subnets(asg_names=asg_names)
+    assert "missing 1 required positional argument: 'subnets'" in str(x.value)
+
+
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
+def test_detach_random_volume_asg_name(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    asg_names = ["AutoScalingGroup-A"]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "Instances": [{"InstanceId": "i-00000000000000001"}],
+            }
+        ]
+    }
+    client.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "InstanceId": "i-00000000000000001",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {"VolumeId": "vol-00000001"},
+                            },
+                            {
+                                "DeviceName": "/dev/sdc",
+                                "Ebs": {"VolumeId": "vol-00000002"},
+                            },
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+    client.detach_volume.return_value = {
+        "Device": "/dev/sdc",
+        "InstanceId": "i-00000000000000001",
+        "State": "detaching",
+        "VolumeId": "vol-00000002",
+    }
+
+    results = detach_random_volume(asg_names=asg_names)
+
+    client.describe_auto_scaling_groups.assert_called_with(
+        AutoScalingGroupNames=asg_names
+    )
+    client.describe_instances.assert_called_with(InstanceIds=["i-00000000000000001"])
+    client.detach_volume.assert_called_with(
+        Device="/dev/sdc",
+        Force=True,
+        InstanceId="i-00000000000000001",
+        VolumeId="vol-00000002",
+    )
+    assert results[0]["Device"] == "/dev/sdc"
+
+
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
+def test_detach_random_volume_asg_tags(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    asg_names = ["AutoScalingGroup-A"]
+    tags = [{"Key": "TargetKey", "Value": "TargetValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
                 {
-                    "InstanceId": "i-00000000000000002",
-                    "AvailabilityZone": "us-east-1b",
-                    "LifecycleState": "InService"
-                },
+                    "ResourceId": "AutoScalingGroup-A",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "TargetKey",
+                    "Value": "TargetValue",
+                    "PropagateAtLaunch": False,
+                }
+            ]
+        }
+    ]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "Instances": [{"InstanceId": "i-00000000000000001"}],
+            }
+        ]
+    }
+    client.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "InstanceId": "i-00000000000000001",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {"VolumeId": "vol-00000001"},
+                            },
+                            {
+                                "DeviceName": "/dev/sdb",
+                                "Ebs": {"VolumeId": "vol-00000002"},
+                            },
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+    client.detach_volume.return_value = {
+        "Device": "/dev/sdb",
+        "InstanceId": "i-00000000000000001",
+        "State": "detaching",
+        "VolumeId": "vol-00000002",
+    }
+
+    results = detach_random_volume(tags=tags)
+
+    client.describe_auto_scaling_groups.assert_called_with(
+        AutoScalingGroupNames=asg_names
+    )
+    client.describe_instances.assert_called_with(InstanceIds=["i-00000000000000001"])
+    client.detach_volume.assert_called_with(
+        Device="/dev/sdb",
+        Force=True,
+        InstanceId="i-00000000000000001",
+        VolumeId="vol-00000002",
+    )
+    assert results[0]["Device"] == "/dev/sdb"
+
+
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
+def test_detach_random_volume_asg_invalid_name(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    asg_names = ["AutoScalingGroup-A"]
+    client.describe_auto_scaling_groups.return_value = {"AutoScalingGroups": []}
+
+    with pytest.raises(FailedActivity) as x:
+        detach_random_volume(asg_names=asg_names)
+    assert "Unable to locate ASG(s): %s" % asg_names in str(x.value)
+
+
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
+def test_detach_random_volume_asg_invalid_tags(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tags = [{"Key": "TargetKey", "Value": "TargetValue"}]
+    client.describe_instances.return_value = {"Reservations": []}
+
+    with pytest.raises(FailedActivity) as x:
+        detach_random_volume(tags=tags)
+    assert "No ASG(s) found with matching tag(s): %s" % tags in str(x.value)
+
+
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
+def test_attach_volume_asg_name(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    asg_names = ["AutoScalingGroup-A"]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": asg_names[0],
+                "Instances": [{"InstanceId": "i-00000000000000001"}],
+            }
+        ]
+    }
+
+    client.describe_volumes.return_value = {
+        "Volumes": [
+            {
+                "VolumeId": "vol-00000001",
+                "Tags": [
+                    {
+                        "Key": "ChaosToolkitDetached",
+                        "Value": "DeviceName=/dev/sdc;InstanceId=%s;ASG=%s"
+                        % ("i-987654321fabcde", asg_names[0]),
+                    }
+                ],
+            },
+            {
+                "VolumeId": "vol-00000002",
+                "Tags": [
+                    {
+                        "Key": "ChaosToolkitDetached",
+                        "Value": "DeviceName=/dev/sdb;InstanceId=" "i-987654321fefghi",
+                    }
+                ],
+            },
+        ]
+    }
+
+    client.attach_volume.return_value = {
+        "DeviceName": "/dev/sdc",
+        "InstanceId": "i-987654321fabcde",
+        "State": "attaching",
+        "VolumeId": "vol-00000001",
+    }
+
+    results = attach_volume(asg_names=asg_names)
+
+    client.describe_auto_scaling_groups.assert_called_with(
+        AutoScalingGroupNames=asg_names
+    )
+    client.describe_volumes.assert_called_with(
+        Filters=[{"Name": "tag-key", "Values": ["ChaosToolkitDetached"]}]
+    )
+    client.attach_volume.assert_called_with(
+        Device="/dev/sdc", InstanceId="i-987654321fabcde", VolumeId="vol-00000001"
+    )
+    assert results[0]["DeviceName"] == "/dev/sdc"
+
+
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
+def test_attach_volume_asg_tags(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    asg_names = ["AutoScalingGroup-A"]
+    tags = [{"Key": "TargetKey", "Value": "TargetValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
                 {
-                    "InstanceId": "i-00000000000000003",
-                    "AvailabilityZone": "us-east-1c",
-                    "LifecycleState": "InService"
-                }]}]}
-    stop_random_instances(tags=tags, instance_count=2)
+                    "ResourceId": asg_names[0],
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "TargetKey",
+                    "Value": "TargetValue",
+                    "PropagateAtLaunch": False,
+                }
+            ]
+        }
+    ]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": asg_names[0],
+                "Instances": [{"InstanceId": "i-00000000000000001"}],
+            }
+        ]
+    }
+
+    client.describe_volumes.return_value = {
+        "Volumes": [
+            {
+                "VolumeId": "vol-00000001",
+                "Tags": [
+                    {
+                        "Key": "ChaosToolkitDetached",
+                        "Value": "DeviceName=/dev/sdb;InstanceId=%s;ASG=%s"
+                        % ("i-00000000000000001", asg_names[0]),
+                    }
+                ],
+            },
+            {
+                "VolumeId": "vol-00000002",
+                "Tags": [
+                    {
+                        "Key": "ChaosToolkitDetached",
+                        "Value": "DeviceName=/dev/sdb;InstanceId=" "i-987654321fghij",
+                    }
+                ],
+            },
+        ]
+    }
+
+    client.attach_volume.return_value = {
+        "DeviceName": "/dev/sdb",
+        "InstanceId": "i-00000000000000001",
+        "State": "attaching",
+        "VolumeId": "vol-00000001",
+    }
+
+    results = attach_volume(tags=tags)
+
+    client.describe_auto_scaling_groups.assert_called_with(
+        AutoScalingGroupNames=asg_names
+    )
+    client.get_paginator.return_value.paginate.assert_called_with(
+        Filters=[
+            {"Name": "key", "Values": ["TargetKey"]},
+            {"Name": "value", "Values": ["TargetValue"]},
+        ]
+    )
+    client.describe_volumes.assert_called_with(
+        Filters=[{"Name": "tag-key", "Values": ["ChaosToolkitDetached"]}]
+    )
+    client.attach_volume.assert_called_with(
+        Device="/dev/sdb", InstanceId="i-00000000000000001", VolumeId="vol-00000001"
+    )
+    assert results[0]["DeviceName"] == "/dev/sdb"
+
+
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
+def test_asg_stop_random_instance_name(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    asg_names = ["AutoScalingGroup-A"]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "Instances": [
+                    {
+                        "InstanceId": "i-00000000000000001",
+                        "AvailabilityZone": "us-east-1a",
+                        "LifecycleState": "InService",
+                    },
+                    {
+                        "InstanceId": "i-00000000000000002",
+                        "AvailabilityZone": "us-east-1b",
+                        "LifecycleState": "InService",
+                    },
+                    {
+                        "InstanceId": "i-00000000000000003",
+                        "AvailabilityZone": "us-east-1c",
+                        "LifecycleState": "InService",
+                    },
+                ],
+            }
+        ]
+    }
+    stop_random_instances(asg_names=asg_names, instance_percent=50)
 
     instance_calls = [
-        ['i-00000000000000001', 'i-00000000000000002'],
-        ['i-00000000000000001', 'i-00000000000000003'],
-        ['i-00000000000000002', 'i-00000000000000003']]
+        "i-00000000000000001",
+        "i-00000000000000002",
+        "i-00000000000000003",
+    ]
 
     ex = None
     for i in instance_calls:
         try:
-            client.stop_instances.assert_called_with(
-                Force=False, InstanceIds=sorted(i))
+            client.stop_instances.assert_called_with(Force=False, InstanceIds=[i])
+            return True
+        except AssertionError as e:
+            ex = e.args
+    raise AssertionError(ex)
+
+
+@patch("chaosaws.asg.actions.aws_client", autospec=True)
+def test_asg_stop_random_instance_tags(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    tags = [{"Key": "TargetKey", "Value": "TargetValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
+                {
+                    "ResourceId": "AutoScalingGroup-A",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "TargetKey",
+                    "Value": "TargetValue",
+                    "PropagateAtLaunch": False,
+                }
+            ]
+        }
+    ]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "Instances": [
+                    {
+                        "InstanceId": "i-00000000000000001",
+                        "AvailabilityZone": "us-east-1a",
+                        "LifecycleState": "InService",
+                    },
+                    {
+                        "InstanceId": "i-00000000000000002",
+                        "AvailabilityZone": "us-east-1b",
+                        "LifecycleState": "InService",
+                    },
+                    {
+                        "InstanceId": "i-00000000000000003",
+                        "AvailabilityZone": "us-east-1c",
+                        "LifecycleState": "InService",
+                    },
+                ],
+            }
+        ]
+    }
+    stop_random_instances(tags=tags, instance_count=2)
+
+    instance_calls = [
+        ["i-00000000000000001", "i-00000000000000002"],
+        ["i-00000000000000001", "i-00000000000000003"],
+        ["i-00000000000000002", "i-00000000000000003"],
+    ]
+
+    ex = None
+    for i in instance_calls:
+        try:
+            client.stop_instances.assert_called_with(Force=False, InstanceIds=sorted(i))
             return True
         except AssertionError as e:
             ex = e.args

--- a/tests/asg/test_asg_probes.py
+++ b/tests/asg/test_asg_probes.py
@@ -2,13 +2,20 @@ from sys import maxsize
 from unittest.mock import MagicMock, patch
 
 import pytest
+from chaoslib.exceptions import FailedActivity
 
 from chaosaws.asg.probes import (
-    desired_equals_healthy, desired_equals_healthy_tags, has_subnets,
-    is_scaling_in_progress, wait_desired_equals_healthy, process_is_suspended,
-    wait_desired_equals_healthy_tags, wait_desired_not_equals_healthy_tags,
-    describe_auto_scaling_groups, instance_count_by_health)
-from chaoslib.exceptions import FailedActivity
+    describe_auto_scaling_groups,
+    desired_equals_healthy,
+    desired_equals_healthy_tags,
+    has_subnets,
+    instance_count_by_health,
+    is_scaling_in_progress,
+    process_is_suspended,
+    wait_desired_equals_healthy,
+    wait_desired_equals_healthy_tags,
+    wait_desired_not_equals_healthy_tags,
+)
 
 
 def test_desired_equals_healthy_needs_asg_names():
@@ -47,993 +54,1179 @@ def test_is_scaling_in_progress():
     assert "Non-empty tags is required" in str(x.value)
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_desired_equals_healthy_true(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup1', 'AutoScalingGroup2']
+    asg_names = ["AutoScalingGroup1", "AutoScalingGroup2"]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "DesiredCapacity": 1,
-            "Instances": [{
-                "HealthStatus": "Healthy",
-                "LifecycleState": "InService"
-            }]
-        }]
+        "AutoScalingGroups": [
+            {
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+            }
+        ]
     }
     assert desired_equals_healthy(asg_names=asg_names) is True
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_desired_equals_healthy_false(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup1', 'AutoScalingGroup2']
+    asg_names = ["AutoScalingGroup1", "AutoScalingGroup2"]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "DesiredCapacity": 1,
-            "Instances": [{
-                "HealthStatus": "Unhealthy",
-                "LifecycleState": "InService"
-            }]
-        }]
+        "AutoScalingGroups": [
+            {
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                ],
+            }
+        ]
     }
     assert desired_equals_healthy(asg_names=asg_names) is False
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_desired_equals_healthy_empty(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup1', 'AutoScalingGroup2']
-    client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [
-        ]
-    }
+    asg_names = ["AutoScalingGroup1", "AutoScalingGroup2"]
+    client.describe_auto_scaling_groups.return_value = {"AutoScalingGroups": []}
     assert desired_equals_healthy(asg_names=asg_names) is False
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_wait_desired_equals_healthy_true(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup1']
+    asg_names = ["AutoScalingGroup1"]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "DesiredCapacity": 1,
-            "Instances": [{
-                "HealthStatus": "Healthy",
-                "LifecycleState": "InService"
-            }]
-        }]
+        "AutoScalingGroups": [
+            {
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+            }
+        ]
     }
-    assert wait_desired_equals_healthy(
-        asg_names=asg_names, timeout=0.1) in [0, 2]
+    assert wait_desired_equals_healthy(asg_names=asg_names, timeout=0.1) in [0, 2]
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_wait_desired_equals_healthy_timeout(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup1']
+    asg_names = ["AutoScalingGroup1"]
     client.describe_auto_scaling_groups.response = [
         {
-            "AutoScalingGroups": [{
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "Initializing"
-                }]
-            }]
+            "AutoScalingGroups": [
+                {
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "Initializing"}
+                    ],
+                }
+            ]
         }
     ]
-    assert wait_desired_equals_healthy(
-        asg_names=asg_names, timeout=0) is maxsize
+    assert wait_desired_equals_healthy(asg_names=asg_names, timeout=0) is maxsize
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_desired_equals_healthy_tags_true(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        "Tags": [{
-            "ResourceId": "AutoScalingGroup1",
-            "ResourceType": "auto-scaling-group",
-            "Key": "Application",
-            "Value": "mychaosapp"}]}]
+    tags = [{"Key": "Application", "Value": "mychaosapp"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
+                {
+                    "ResourceId": "AutoScalingGroup1",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "Application",
+                    "Value": "mychaosapp",
+                }
+            ]
+        }
+    ]
 
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
-                'AutoScalingGroupName': 'AutoScalingGroup1',
+                "AutoScalingGroupName": "AutoScalingGroup1",
                 "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Healthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'mychaosapp'
-                }]
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup1",
+                        "Key": "Application",
+                        "Value": "mychaosapp",
+                    }
+                ],
             }
         ]
     }
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup1',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Healthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'mychaosapp'
-                }]
-            },
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup2',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'NOTmychaosapp'
-                }]
-            }
-        ]},
+    client.get_paginator.return_value.paginate.return_value = [
         {
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup3',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'NOTApplication',
-                    'Value': 'mychaosapp'
-                }]
-            }]
-    }]
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup1",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "mychaosapp",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup2",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "NOTmychaosapp",
+                        }
+                    ],
+                },
+            ]
+        },
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup3",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "NOTApplication",
+                            "Value": "mychaosapp",
+                        }
+                    ],
+                }
+            ]
+        },
+    ]
     assert desired_equals_healthy_tags(tags=tags) is True
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_desired_equals_healthy_tags_false(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
-    client.describe_auto_scaling_groups.return_value = \
+    tags = [{"Key": "Application", "Value": "mychaosapp"}]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup1",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                ],
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup1",
+                        "Key": "Application",
+                        "Value": "mychaosapp",
+                    }
+                ],
+            }
+        ]
+    }
+    client.get_paginator.return_value.paginate.return_value = [
         {
             "AutoScalingGroups": [
                 {
-                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "AutoScalingGroupName": "AutoScalingGroup1",
                     "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Unhealthy",
-                        "LifecycleState": "InService"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'Application',
-                        'Value': 'mychaosapp'
-                    }]
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "mychaosapp",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup2",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "NOTmychaosapp",
+                        }
+                    ],
+                },
+            ]
+        },
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup3",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "NOTApplication",
+                            "Value": "mychaosapp",
+                        }
+                    ],
                 }
             ]
-        }
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup1',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'mychaosapp'
-                }]
-            },
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup2',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'NOTmychaosapp'
-                }]
-            }
-        ]},
-        {
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup3',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'NOTApplication',
-                    'Value': 'mychaosapp'
-                }]
-            }]
-    }]
+        },
+    ]
     assert desired_equals_healthy_tags(tags=tags) is False
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_wait_desired_equals_healthy_tags_true(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
-    client.describe_auto_scaling_groups.return_value = \
+    tags = [{"Key": "Application", "Value": "mychaosapp"}]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup1",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup1",
+                        "Key": "Application",
+                        "Value": "mychaosapp",
+                    }
+                ],
+            }
+        ]
+    }
+    client.get_paginator.return_value.paginate.return_value = [
         {
             "AutoScalingGroups": [
                 {
-                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "AutoScalingGroupName": "AutoScalingGroup1",
                     "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Healthy",
-                        "LifecycleState": "InService"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'Application',
-                        'Value': 'mychaosapp'
-                    }]
+                    "Instances": [
+                        {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "mychaosapp",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup2",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "NOTmychaosapp",
+                        }
+                    ],
+                },
+            ]
+        },
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup3",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "NOTApplication",
+                            "Value": "mychaosapp",
+                        }
+                    ],
                 }
             ]
-        }
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup1',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Healthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'mychaosapp'
-                }]
-            },
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup2',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'NOTmychaosapp'
-                }]
-            }
-        ]},
-        {
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup3',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'NOTApplication',
-                    'Value': 'mychaosapp'
-                }]
-            }]
-    }]
+        },
+    ]
     assert wait_desired_equals_healthy_tags(tags=tags, timeout=0.1) in [0, 2]
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_wait_desired_equals_healthy_tags_false(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
-    client.describe_auto_scaling_groups.return_value = \
+    tags = [{"Key": "Application", "Value": "mychaosapp"}]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup1",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                ],
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup1",
+                        "Key": "Application",
+                        "Value": "mychaosapp",
+                    }
+                ],
+            }
+        ]
+    }
+    client.get_paginator.return_value.paginate.return_value = [
         {
             "AutoScalingGroups": [
                 {
-                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "AutoScalingGroupName": "AutoScalingGroup1",
                     "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Unhealthy",
-                        "LifecycleState": "InService"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'Application',
-                        'Value': 'mychaosapp'
-                    }]
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "mychaosapp",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup2",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "NOTmychaosapp",
+                        }
+                    ],
+                },
+            ]
+        },
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup3",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "NOTApplication",
+                            "Value": "mychaosapp",
+                        }
+                    ],
                 }
             ]
-        }
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup1',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'mychaosapp'
-                }]
-            },
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup2',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'NOTmychaosapp'
-                }]
-            }
-        ]},
-        {
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup3',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'NOTApplication',
-                    'Value': 'mychaosapp'
-                }]
-            }]
-    }]
+        },
+    ]
     assert wait_desired_equals_healthy_tags(tags=tags, timeout=0) is maxsize
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_wait_desired_not_equals_healthy_tags_true(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
-    client.describe_auto_scaling_groups.return_value = \
+    tags = [{"Key": "Application", "Value": "mychaosapp"}]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup1",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                ],
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup1",
+                        "Key": "Application",
+                        "Value": "mychaosapp",
+                    }
+                ],
+            }
+        ]
+    }
+    client.get_paginator.return_value.paginate.return_value = [
         {
             "AutoScalingGroups": [
                 {
-                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "AutoScalingGroupName": "AutoScalingGroup1",
                     "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Unhealthy",
-                        "LifecycleState": "InService"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'Application',
-                        'Value': 'mychaosapp'
-                    }]
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "mychaosapp",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup2",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "NOTmychaosapp",
+                        }
+                    ],
+                },
+            ]
+        },
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup3",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "mychaosapp",
+                        }
+                    ],
                 }
             ]
-        }
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup1',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'mychaosapp'
-                }]
-            },
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup2',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'NOTmychaosapp'
-                }]
-            }
-        ]},
-        {
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup3',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'mychaosapp'
-                }]
-            }]
-    }]
-    assert wait_desired_not_equals_healthy_tags(
-        tags=tags, timeout=0.2) in [0, 2]
+        },
+    ]
+    assert wait_desired_not_equals_healthy_tags(tags=tags, timeout=0.2) in [0, 2]
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_wait_desired_not_equals_healthy_tags_false(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
-    client.describe_auto_scaling_groups.return_value = \
+    tags = [{"Key": "Application", "Value": "mychaosapp"}]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup1",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup1",
+                        "Key": "Application",
+                        "Value": "mychaosapp",
+                    }
+                ],
+            }
+        ]
+    }
+    client.get_paginator.return_value.paginate.return_value = [
         {
             "AutoScalingGroups": [
                 {
-                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "AutoScalingGroupName": "AutoScalingGroup1",
                     "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Healthy",
-                        "LifecycleState": "InService"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'Application',
-                        'Value': 'mychaosapp'
-                    }]
-                }
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "mychaosapp",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup2",
+                    "DesiredCapacity": 1,
+                    "Instances": [
+                        {"HealthStatus": "Unhealthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "NOTmychaosapp",
+                        }
+                    ],
+                },
             ]
         }
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup1',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'mychaosapp'
-                }]
-            },
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup2',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Unhealthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'NOTmychaosapp'
-                }]
-            }
-        ]
-    }]
-    assert wait_desired_not_equals_healthy_tags(
-        tags=tags, timeout=0) is maxsize
+    ]
+    assert wait_desired_not_equals_healthy_tags(tags=tags, timeout=0) is maxsize
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_is_scaling_in_progress_true(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
-    client.describe_auto_scaling_groups.return_value = \
+    tags = [{"Key": "Application", "Value": "mychaosapp"}]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup1",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "OutOfService"}
+                ],
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup1",
+                        "Key": "Application",
+                        "Value": "mychaosapp",
+                    }
+                ],
+            }
+        ]
+    }
+    client.get_paginator.return_value.paginate.return_value = [
         {
             "AutoScalingGroups": [
                 {
-                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "AutoScalingGroupName": "AutoScalingGroup1",
                     "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Healthy",
-                        "LifecycleState": "OutOfService"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'Application',
-                        'Value': 'mychaosapp'
-                    }]
+                    "Instances": [
+                        {"HealthStatus": "Healthy", "LifecycleState": "OutOfService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "mychaosapp",
+                        }
+                    ],
                 }
             ]
         }
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup1',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Healthy",
-                    "LifecycleState": "OutOfService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'mychaosapp'
-                }]
-            }
-        ]
-    }]
+    ]
     assert is_scaling_in_progress(tags=tags) is True
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_is_scaling_in_progress_false(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'Application', 'Value': 'mychaosapp'}]
-    client.describe_auto_scaling_groups.return_value = \
+    tags = [{"Key": "Application", "Value": "mychaosapp"}]
+    client.describe_auto_scaling_groups.return_value = {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup1",
+                "DesiredCapacity": 1,
+                "Instances": [
+                    {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                ],
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup1",
+                        "Key": "Application",
+                        "Value": "mychaosapp",
+                    }
+                ],
+            }
+        ]
+    }
+    client.get_paginator.return_value.paginate.return_value = [
         {
             "AutoScalingGroups": [
                 {
-                    'AutoScalingGroupName': 'AutoScalingGroup1',
+                    "AutoScalingGroupName": "AutoScalingGroup1",
                     "DesiredCapacity": 1,
-                    "Instances": [{
-                        "HealthStatus": "Healthy",
-                        "LifecycleState": "InService"
-                    }],
-                    'Tags': [{
-                        'ResourceId': 'AutoScalingGroup1',
-                        'Key': 'Application',
-                        'Value': 'mychaosapp'
-                    }]
+                    "Instances": [
+                        {"HealthStatus": "Healthy", "LifecycleState": "InService"}
+                    ],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup1",
+                            "Key": "Application",
+                            "Value": "mychaosapp",
+                        }
+                    ],
                 }
             ]
         }
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [
-            {
-                'AutoScalingGroupName': 'AutoScalingGroup1',
-                "DesiredCapacity": 1,
-                "Instances": [{
-                    "HealthStatus": "Healthy",
-                    "LifecycleState": "InService"
-                }],
-                'Tags': [{
-                    'ResourceId': 'AutoScalingGroup1',
-                    'Key': 'Application',
-                    'Value': 'mychaosapp'
-                }]
-            }
-        ]
-    }]
+    ]
     assert is_scaling_in_progress(tags=tags) is False
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_is_process_suspended_names_true(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    process_names = ['Launch']
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "SuspendedProcesses": [{
-                "ProcessName": "Launch"
-            }]}]}]
-    assert process_is_suspended(
-        asg_names=asg_names, process_names=process_names) is True
+    asg_names = ["AutoScalingGroup-A"]
+    process_names = ["Launch"]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "SuspendedProcesses": [{"ProcessName": "Launch"}],
+                }
+            ]
+        }
+    ]
+    assert (
+        process_is_suspended(asg_names=asg_names, process_names=process_names) is True
+    )
     assert client.suspend
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_is_process_suspended_names_false(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    process_names = ['Launch']
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "SuspendedProcesses": [{"ProcessName": "AZRebalance"}]}]}]
-    assert process_is_suspended(
-        asg_names=asg_names, process_names=process_names) is False
+    asg_names = ["AutoScalingGroup-A"]
+    process_names = ["Launch"]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "SuspendedProcesses": [{"ProcessName": "AZRebalance"}],
+                }
+            ]
+        }
+    ]
+    assert (
+        process_is_suspended(asg_names=asg_names, process_names=process_names) is False
+    )
     assert client.suspend
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_is_process_suspended_tags(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TestKey', 'Value': 'TestValue'}]
-    process_names = ['Launch']
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "SuspendedProcesses": ["Launch"],
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-A",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}]}]
+    tags = [{"Key": "TestKey", "Value": "TestValue"}]
+    process_names = ["Launch"]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "SuspendedProcesses": ["Launch"],
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-A",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                }
+            ]
+        }
+    ]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "SuspendedProcesses": [{
-                "ProcessName": "Launch"
-            }]}]}
-    assert process_is_suspended(
-        tags=tags, process_names=process_names) is True
-
-
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
-def test_has_subnets_names_valid(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A', 'AutoScalingGroup-B']
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-A",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}, {
-            "AutoScalingGroupName": "AutoScalingGroup-B",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-B",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}]}]
-    client.get_paginator.return_value.paginate.return_value = [{
         "AutoScalingGroups": [
             {
                 "AutoScalingGroupName": "AutoScalingGroup-A",
-                "VPCZoneIdentifier": "subnet-012345678,subnet-123456789"},
-            {
-                "AutoScalingGroupName": "AutoScalingGroup-B",
-                "VPCZoneIdentifier": "subnet-012345678,subnet-123456789"}]}]
+                "SuspendedProcesses": [{"ProcessName": "Launch"}],
+            }
+        ]
+    }
+    assert process_is_suspended(tags=tags, process_names=process_names) is True
+
+
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
+def test_has_subnets_names_valid(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    asg_names = ["AutoScalingGroup-A", "AutoScalingGroup-B"]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-A",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-B",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-B",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                },
+            ]
+        }
+    ]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "VPCZoneIdentifier": "subnet-012345678,subnet-123456789",
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-B",
+                    "VPCZoneIdentifier": "subnet-012345678,subnet-123456789",
+                },
+            ]
+        }
+    ]
     response = has_subnets(
-        subnets=['subnet-012345678', 'subnet-123456789'],
-        asg_names=asg_names)
+        subnets=["subnet-012345678", "subnet-123456789"], asg_names=asg_names
+    )
     assert response is True
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_has_subnets_tags_valid(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TestKey', 'Value': 'TestValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-A",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}, {
-            "AutoScalingGroupName": "AutoScalingGroup-B",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-B",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}]}]
+    tags = [{"Key": "TestKey", "Value": "TestValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-A",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-B",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-B",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                },
+            ]
+        }
+    ]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
                 "AutoScalingGroupName": "AutoScalingGroup-A",
                 "VPCZoneIdentifier": "subnet-012345678,subnet-123456789",
-                "Tags": [{
-                    "ResourceId": "AutoScalingGroup-A",
-                    "Key": "TestKey",
-                    "Value": "TestValue"}]
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup-A",
+                        "Key": "TestKey",
+                        "Value": "TestValue",
+                    }
+                ],
             },
             {
                 "AutoScalingGroupName": "AutoScalingGroup-B",
                 "VPCZoneIdentifier": "subnet-012345678,subnet-123456789",
-                "Tags": [{
-                    "ResourceId": "AutoScalingGroup-B",
-                    "Key": "TestKey",
-                    "Value": "TestValue"}]
-            }
-        ]}
-    response = has_subnets(
-        subnets=['subnet-012345678', 'subnet-123456789'],
-        tags=tags)
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup-B",
+                        "Key": "TestKey",
+                        "Value": "TestValue",
+                    }
+                ],
+            },
+        ]
+    }
+    response = has_subnets(subnets=["subnet-012345678", "subnet-123456789"], tags=tags)
     assert response is True
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_has_subnets_names_invalid(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A', 'AutoScalingGroup-B']
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-A",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}, {
-            "AutoScalingGroupName": "AutoScalingGroup-B",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-B",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}]}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [
-            {
-                "AutoScalingGroupName": "AutoScalingGroup-A",
-                "VPCZoneIdentifier": "subnet-012345678,subnet-123456789"},
-            {
-                "AutoScalingGroupName": "AutoScalingGroup-B",
-                "VPCZoneIdentifier": "subnet-012345678,subnet-23456789a"}]}]
+    asg_names = ["AutoScalingGroup-A", "AutoScalingGroup-B"]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-A",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-B",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-B",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                },
+            ]
+        }
+    ]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "VPCZoneIdentifier": "subnet-012345678,subnet-123456789",
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-B",
+                    "VPCZoneIdentifier": "subnet-012345678,subnet-23456789a",
+                },
+            ]
+        }
+    ]
     response = has_subnets(
-        subnets=['subnet-012345678', 'subnet-123456789'],
-        asg_names=asg_names)
+        subnets=["subnet-012345678", "subnet-123456789"], asg_names=asg_names
+    )
     assert response is False
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_has_subnets_tags_invalid(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TestKey', 'Value': 'TestValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-A",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}, {
-            "AutoScalingGroupName": "AutoScalingGroup-B",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-B",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}]}]
+    tags = [{"Key": "TestKey", "Value": "TestValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-A",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-B",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-B",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                },
+            ]
+        }
+    ]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
                 "AutoScalingGroupName": "AutoScalingGroup-A",
                 "VPCZoneIdentifier": "subnet-012345678,subnet-123456789",
-                "Tags": [{
-                    "ResourceId": "AutoScalingGroup-A",
-                    "Key": "TestKey",
-                    "Value": "TestValue"}]
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup-A",
+                        "Key": "TestKey",
+                        "Value": "TestValue",
+                    }
+                ],
             },
             {
                 "AutoScalingGroupName": "AutoScalingGroup-B",
                 "VPCZoneIdentifier": "subnet-012345678,subnet-23456789a",
-                "Tags": [{
-                    "ResourceId": "AutoScalingGroup-B",
-                    "Key": "TestKey",
-                    "Value": "TestValue"}]
-            }
-        ]}
-    response = has_subnets(
-        subnets=['subnet-012345678', 'subnet-123456789'],
-        tags=tags)
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup-B",
+                        "Key": "TestKey",
+                        "Value": "TestValue",
+                    }
+                ],
+            },
+        ]
+    }
+    response = has_subnets(subnets=["subnet-012345678", "subnet-123456789"], tags=tags)
     assert response is False
 
 
 def test_has_subnets_no_subnet():
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     with pytest.raises(TypeError) as x:
         has_subnets(asg_names=asg_names)
     assert "missing 1 required positional argument: 'subnets'" in str(x.value)
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_describe_auto_scaling_groups_names(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-A",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}]}]
+    asg_names = ["AutoScalingGroup-A"]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-A",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                }
+            ]
+        }
+    ]
     describe_auto_scaling_groups(asg_names=asg_names)
     client.get_paginator.return_value.paginate.assert_called_with(
-        AutoScalingGroupNames=asg_names)
+        AutoScalingGroupNames=asg_names
+    )
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_describe_auto_scaling_groups_tags(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TestKey', 'Value': 'TestValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-A",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}, {
-            "AutoScalingGroupName": "AutoScalingGroup-B",
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-B",
-                "Key": "TestKey",
-                "Value": "TestValue"}]}]}]
+    tags = [{"Key": "TestKey", "Value": "TestValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "AutoScalingGroups": [
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-A",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-A",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                },
+                {
+                    "AutoScalingGroupName": "AutoScalingGroup-B",
+                    "Tags": [
+                        {
+                            "ResourceId": "AutoScalingGroup-B",
+                            "Key": "TestKey",
+                            "Value": "TestValue",
+                        }
+                    ],
+                },
+            ]
+        }
+    ]
     client.describe_auto_scaling_groups.return_value = {
         "AutoScalingGroups": [
             {
                 "AutoScalingGroupName": "AutoScalingGroup-A",
                 "Instances": [],
-                "Tags": [{
-                    "ResourceId": "AutoScalingGroup-A",
-                    "Key": "TestKey",
-                    "Value": "TestValue"}]
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup-A",
+                        "Key": "TestKey",
+                        "Value": "TestValue",
+                    }
+                ],
             },
             {
                 "AutoScalingGroupName": "AutoScalingGroup-B",
                 "Instances": [],
-                "Tags": [{
-                    "ResourceId": "AutoScalingGroup-B",
-                    "Key": "TestKey",
-                    "Value": "TestValue"}]
-            }
-        ]}
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup-B",
+                        "Key": "TestKey",
+                        "Value": "TestValue",
+                    }
+                ],
+            },
+        ]
+    }
     describe_auto_scaling_groups(tags=tags)
     client.describe_auto_scaling_groups.assert_called_with(
-        AutoScalingGroupNames=["AutoScalingGroup-A", "AutoScalingGroup-B"])
+        AutoScalingGroupNames=["AutoScalingGroup-A", "AutoScalingGroup-B"]
+    )
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_instance_healthy_count_names(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Instances": [
-                {
-                    "InstanceId": "i-012345678901",
-                    "HealthStatus": "Healthy"
-                },
-                {
-                    "InstanceId": "i-012345678902",
-                    "HealthStatus": "Healthy"
-                },
-                {
-                    "InstanceId": "i-012345678903",
-                    "HealthStatus": "Unhealthy"
-                }]}]}
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "Instances": [
+                    {"InstanceId": "i-012345678901", "HealthStatus": "Healthy"},
+                    {"InstanceId": "i-012345678902", "HealthStatus": "Healthy"},
+                    {"InstanceId": "i-012345678903", "HealthStatus": "Unhealthy"},
+                ],
+            }
+        ]
+    }
     response = instance_count_by_health(asg_names)
     client.describe_auto_scaling_groups.assert_called_with(
-        AutoScalingGroupNames=asg_names)
+        AutoScalingGroupNames=asg_names
+    )
     assert response == 2
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_instance_healthy_count_tags(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TestKey', 'Value': 'TestValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        "Tags": [{
-            "ResourceId": "AutoScalingGroup-A",
-            "ResourceType": "auto-scaling-group",
-            "Key": "TestKey",
-            "Value": "TestValue"}]}]
+    tags = [{"Key": "TestKey", "Value": "TestValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
+                {
+                    "ResourceId": "AutoScalingGroup-A",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "TestKey",
+                    "Value": "TestValue",
+                }
+            ]
+        }
+    ]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Instances": [
-                {
-                    "InstanceId": "i-012345678901",
-                    "HealthStatus": "Healthy"
-                },
-                {
-                    "InstanceId": "i-012345678902",
-                    "HealthStatus": "Healthy"
-                },
-                {
-                    "InstanceId": "i-012345678903",
-                    "HealthStatus": "Unhealthy"
-                }],
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-A",
-                "Key": "TestKey",
-                "Value": "TestValue"}]
-        }]}
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "Instances": [
+                    {"InstanceId": "i-012345678901", "HealthStatus": "Healthy"},
+                    {"InstanceId": "i-012345678902", "HealthStatus": "Healthy"},
+                    {"InstanceId": "i-012345678903", "HealthStatus": "Unhealthy"},
+                ],
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup-A",
+                        "Key": "TestKey",
+                        "Value": "TestValue",
+                    }
+                ],
+            }
+        ]
+    }
     response = instance_count_by_health(tags=tags)
     client.get_paginator.return_value.paginate.assert_called_with(
-        Filters=[{'Name': 'TestKey', 'Values': ['TestValue']}])
+        Filters=[{"Name": "TestKey", "Values": ["TestValue"]}]
+    )
     client.describe_auto_scaling_groups.assert_called_with(
-        AutoScalingGroupNames=["AutoScalingGroup-A"])
+        AutoScalingGroupNames=["AutoScalingGroup-A"]
+    )
     assert response == 2
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_instance_unhealthy_count_names(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    asg_names = ['AutoScalingGroup-A']
+    asg_names = ["AutoScalingGroup-A"]
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Instances": [
-                {
-                    "InstanceId": "i-012345678901",
-                    "HealthStatus": "Healthy"
-                },
-                {
-                    "InstanceId": "i-012345678902",
-                    "HealthStatus": "Healthy"
-                },
-                {
-                    "InstanceId": "i-012345678903",
-                    "HealthStatus": "Unhealthy"
-                }
-            ]}]}
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "Instances": [
+                    {"InstanceId": "i-012345678901", "HealthStatus": "Healthy"},
+                    {"InstanceId": "i-012345678902", "HealthStatus": "Healthy"},
+                    {"InstanceId": "i-012345678903", "HealthStatus": "Unhealthy"},
+                ],
+            }
+        ]
+    }
     response = instance_count_by_health(asg_names, count_healthy=False)
     client.describe_auto_scaling_groups.assert_called_with(
-        AutoScalingGroupNames=asg_names)
+        AutoScalingGroupNames=asg_names
+    )
     assert response == 1
 
 
-@patch('chaosaws.asg.probes.aws_client', autospec=True)
+@patch("chaosaws.asg.probes.aws_client", autospec=True)
 def test_instance_unhealthy_count_tags(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tags = [{'Key': 'TestKey', 'Value': 'TestValue'}]
-    client.get_paginator.return_value.paginate.return_value = [{
-        "Tags": [{
-            "ResourceId": "AutoScalingGroup-A",
-            "ResourceType": "auto-scaling-group",
-            "Key": "TestKey",
-            "Value": "TestValue"}]}]
+    tags = [{"Key": "TestKey", "Value": "TestValue"}]
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Tags": [
+                {
+                    "ResourceId": "AutoScalingGroup-A",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "TestKey",
+                    "Value": "TestValue",
+                }
+            ]
+        }
+    ]
 
     client.describe_auto_scaling_groups.return_value = {
-        "AutoScalingGroups": [{
-            "AutoScalingGroupName": "AutoScalingGroup-A",
-            "Instances": [
-                {
-                    "InstanceId": "i-012345678901",
-                    "HealthStatus": "Healthy"
-                },
-                {
-                    "InstanceId": "i-012345678902",
-                    "HealthStatus": "Healthy"
-                },
-                {
-                    "InstanceId": "i-012345678903",
-                    "HealthStatus": "Unhealthy"
-                }],
-            "Tags": [{
-                "ResourceId": "AutoScalingGroup-A",
-                "Key": "TestKey",
-                "Value": "TestValue"}]
-        }]}
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupName": "AutoScalingGroup-A",
+                "Instances": [
+                    {"InstanceId": "i-012345678901", "HealthStatus": "Healthy"},
+                    {"InstanceId": "i-012345678902", "HealthStatus": "Healthy"},
+                    {"InstanceId": "i-012345678903", "HealthStatus": "Unhealthy"},
+                ],
+                "Tags": [
+                    {
+                        "ResourceId": "AutoScalingGroup-A",
+                        "Key": "TestKey",
+                        "Value": "TestValue",
+                    }
+                ],
+            }
+        ]
+    }
     response = instance_count_by_health(tags=tags, count_healthy=False)
     client.get_paginator.return_value.paginate.assert_called_with(
-        Filters=[{'Name': 'TestKey', 'Values': ['TestValue']}])
+        Filters=[{"Name": "TestKey", "Values": ["TestValue"]}]
+    )
     client.describe_auto_scaling_groups.assert_called_with(
-        AutoScalingGroupNames=["AutoScalingGroup-A"])
+        AutoScalingGroupNames=["AutoScalingGroup-A"]
+    )
     assert response == 1

--- a/tests/awslambda/test_awslambda_actions.py
+++ b/tests/awslambda/test_awslambda_actions.py
@@ -1,246 +1,253 @@
 import json
+import os
 from base64 import b64encode
 from unittest.mock import MagicMock, patch
-import os
 
 import pytest
-from chaoslib.exceptions import FailedActivity
 from botocore.exceptions import ClientError
+from chaoslib.exceptions import FailedActivity
 
 from chaosaws.awslambda.actions import (
-    delete_function_concurrency, invoke_function, put_function_concurrency,
-    put_function_memory_size, put_function_timeout, delete_event_source_mapping,
-    toggle_event_source_mapping_state
+    delete_event_source_mapping,
+    delete_function_concurrency,
+    invoke_function,
+    put_function_concurrency,
+    put_function_memory_size,
+    put_function_timeout,
+    toggle_event_source_mapping_state,
 )
 
 
 def mock_client_error(operation_name: str):
-    return ClientError(operation_name=operation_name, error_response={
-        'Error': {'Message': 'Test Error'}})
+    return ClientError(
+        operation_name=operation_name,
+        error_response={"Error": {"Message": "Test Error"}},
+    )
 
 
 def read_in_test_data(filename):
     module_path = os.path.dirname(os.path.abspath(__file__))
-    test_path = os.path.join(module_path, 'test_data', filename)
-    with open(test_path, 'r') as fh:
+    test_path = os.path.join(module_path, "test_data", filename)
+    with open(test_path, "r") as fh:
         test_data = json.loads(fh.read())
     return test_data
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_put_function_concurrency(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    lambda_function_name = 'my-lambda-function'
+    lambda_function_name = "my-lambda-function"
     concurrency = 0
     put_function_concurrency(lambda_function_name, concurrency)
     client.put_function_concurrency.assert_called_with(
-        FunctionName=lambda_function_name,
-        ReservedConcurrentExecutions=concurrency)
+        FunctionName=lambda_function_name, ReservedConcurrentExecutions=concurrency
+    )
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_put_function_concurrency_empty_string(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    lambda_function_name = ''
+    lambda_function_name = ""
     concurrency = 0
     with pytest.raises(FailedActivity):
         put_function_concurrency(lambda_function_name, concurrency)
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_put_function_concurrency_failedactivity(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    lambda_function_name = 'my-lambda-function'
+    lambda_function_name = "my-lambda-function"
     concurrency = 0
 
-    with patch.object(client, 'put_function_concurrency', FailedActivity):
+    with patch.object(client, "put_function_concurrency", FailedActivity):
         with pytest.raises(Exception):
             put_function_concurrency(lambda_function_name, concurrency)
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_delete_function_concurrency(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    lambda_function_name = 'my-lambda-function'
+    lambda_function_name = "my-lambda-function"
     delete_function_concurrency(lambda_function_name)
     client.delete_function_concurrency.assert_called_with(
-        FunctionName=lambda_function_name)
-
-
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
-def test_aws_lambda_invoke_no_args(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    mock_payload = {'some': 'response'}
-    mock_response = {'Payload': MagicMock()}
-    mock_response['Payload'].read.return_value = json.dumps(
-        mock_payload).encode()
-    client.invoke.return_value = mock_response
-    lambda_function_name = 'my-lambda-function'
-
-    response = invoke_function(lambda_function_name)
-
-    assert response['Payload'] == mock_payload
-    client.invoke.assert_called_with(
-        FunctionName=lambda_function_name,
-        InvocationType='RequestResponse',
-        LogType='None'
+        FunctionName=lambda_function_name
     )
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
+def test_aws_lambda_invoke_no_args(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    mock_payload = {"some": "response"}
+    mock_response = {"Payload": MagicMock()}
+    mock_response["Payload"].read.return_value = json.dumps(mock_payload).encode()
+    client.invoke.return_value = mock_response
+    lambda_function_name = "my-lambda-function"
+
+    response = invoke_function(lambda_function_name)
+
+    assert response["Payload"] == mock_payload
+    client.invoke.assert_called_with(
+        FunctionName=lambda_function_name,
+        InvocationType="RequestResponse",
+        LogType="None",
+    )
+
+
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_invoke_with_args(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    mock_payload = {'some': 'response'}
-    mock_response = {'Payload': MagicMock()}
-    mock_response['Payload'].read.return_value = json.dumps(
-        mock_payload).encode()
+    mock_payload = {"some": "response"}
+    mock_response = {"Payload": MagicMock()}
+    mock_response["Payload"].read.return_value = json.dumps(mock_payload).encode()
     client.invoke.return_value = mock_response
-    lambda_function_name = 'my-lambda-function'
-    function_arguments = {'some': 'argument'}
-    invocation_type = 'Event'
-    client_context = {'some': 'context'}
-    qualifier = '$LATEST'
+    lambda_function_name = "my-lambda-function"
+    function_arguments = {"some": "argument"}
+    invocation_type = "Event"
+    client_context = {"some": "context"}
+    qualifier = "$LATEST"
 
-    invoke_function(function_name=lambda_function_name,
-                    function_arguments=function_arguments,
-                    invocation_type=invocation_type,
-                    client_context=client_context,
-                    qualifier=qualifier)
+    invoke_function(
+        function_name=lambda_function_name,
+        function_arguments=function_arguments,
+        invocation_type=invocation_type,
+        client_context=client_context,
+        qualifier=qualifier,
+    )
 
     client.invoke.assert_called_with(
         FunctionName=lambda_function_name,
         InvocationType=invocation_type,
-        LogType='None',
+        LogType="None",
         Payload=json.dumps(function_arguments),
         ClientContext=b64encode(json.dumps(client_context).encode()).decode(),
-        Qualifier=qualifier
+        Qualifier=qualifier,
     )
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_invoke_failed(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.invoke.side_effect = Exception('Some Exception')
-    lambda_function_name = 'my-lambda-function'
+    client.invoke.side_effect = Exception("Some Exception")
+    lambda_function_name = "my-lambda-function"
     with pytest.raises(FailedActivity):
         invoke_function(lambda_function_name)
     client.invoke.assert_called_with(
         FunctionName=lambda_function_name,
-        InvocationType='RequestResponse',
-        LogType='None'
+        InvocationType="RequestResponse",
+        LogType="None",
     )
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_invoke_empty_response_payload(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    mock_response = {'Payload': MagicMock()}
-    mock_response['Payload'].read.return_value = b''
+    mock_response = {"Payload": MagicMock()}
+    mock_response["Payload"].read.return_value = b""
     client.invoke.return_value = mock_response
-    lambda_function_name = 'my-lambda-function'
+    lambda_function_name = "my-lambda-function"
 
-    response = invoke_function(lambda_function_name,
-                               invocation_type='Event')
+    response = invoke_function(lambda_function_name, invocation_type="Event")
 
-    assert response['Payload'] == ''
+    assert response["Payload"] == ""
     client.invoke.assert_called_with(
-        FunctionName=lambda_function_name,
-        InvocationType='Event',
-        LogType='None'
+        FunctionName=lambda_function_name, InvocationType="Event", LogType="None"
     )
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_put_function_timeout(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    lambda_function_name = 'my-lambda-function'
+    lambda_function_name = "my-lambda-function"
     timeout = 3
     put_function_timeout(lambda_function_name, timeout)
     client.update_function_configuration.assert_called_with(
-        FunctionName=lambda_function_name,
-        Timeout=timeout)
+        FunctionName=lambda_function_name, Timeout=timeout
+    )
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_put_function_memory_size(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    lambda_function_name = 'my-lambda-function'
+    lambda_function_name = "my-lambda-function"
     memory_size = 512
     put_function_memory_size(lambda_function_name, memory_size)
     client.update_function_configuration.assert_called_with(
-        FunctionName=lambda_function_name,
-        MemorySize=memory_size)
+        FunctionName=lambda_function_name, MemorySize=memory_size
+    )
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_delete_event_source_mapping(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.delete_event_source_mapping.return_value = read_in_test_data(
-        'delete_event_source_mapping.json')
-    uuid = '6b08c7db-a0f5-404d-ae73-b116d9125b0e'
+        "delete_event_source_mapping.json"
+    )
+    uuid = "6b08c7db-a0f5-404d-ae73-b116d9125b0e"
     response = delete_event_source_mapping(event_uuid=uuid)
-    assert response['State'] == 'Deleting'
+    assert response["State"] == "Deleting"
     client.delete_event_source_mapping.assert_called_with(UUID=uuid)
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_delete_event_source_mapping_exception(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.delete_event_source_mapping.side_effect = mock_client_error(
-        'delete_event_source_mapping')
+        "delete_event_source_mapping"
+    )
 
     with pytest.raises(FailedActivity) as x:
-        uuid = '6b08c7db-a0f5-404d-ae73-b116d9125b0e'
+        uuid = "6b08c7db-a0f5-404d-ae73-b116d9125b0e"
         delete_event_source_mapping(event_uuid=uuid)
-    assert 'Test Error' in str(x)
+    assert "Test Error" in str(x)
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_toggle_event_source_mapping_enable(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.update_event_source_mapping.return_value = read_in_test_data(
-        'update_event_source_mapping_enable.json')
-    uuid = '6b08c7db-a0f5-404d-ae73-b116d9125b0e'
+        "update_event_source_mapping_enable.json"
+    )
+    uuid = "6b08c7db-a0f5-404d-ae73-b116d9125b0e"
     response = toggle_event_source_mapping_state(event_uuid=uuid, enabled=True)
-    assert response['State'] == 'Enabling'
-    client.update_event_source_mapping.assert_called_with(
-        UUID=uuid, Enabled=True)
+    assert response["State"] == "Enabling"
+    client.update_event_source_mapping.assert_called_with(UUID=uuid, Enabled=True)
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_toggle_event_source_mapping_disable(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.update_event_source_mapping.return_value = read_in_test_data(
-        'update_event_source_mapping_disable.json')
-    uuid = '6b08c7db-a0f5-404d-ae73-b116d9125b0e'
+        "update_event_source_mapping_disable.json"
+    )
+    uuid = "6b08c7db-a0f5-404d-ae73-b116d9125b0e"
     response = toggle_event_source_mapping_state(event_uuid=uuid, enabled=False)
-    assert response['State'] == 'Disabling'
-    client.update_event_source_mapping.assert_called_with(
-        UUID=uuid, Enabled=False)
+    assert response["State"] == "Disabling"
+    client.update_event_source_mapping.assert_called_with(UUID=uuid, Enabled=False)
 
 
-@patch('chaosaws.awslambda.actions.aws_client', autospec=True)
+@patch("chaosaws.awslambda.actions.aws_client", autospec=True)
 def test_aws_lambda_toggle_event_source_mapping_exception(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.update_event_source_mapping.side_effect = mock_client_error(
-        'update_event_source_mapping')
+        "update_event_source_mapping"
+    )
 
     with pytest.raises(FailedActivity) as x:
-        uuid = '6b08c7db-a0f5-404d-ae73-b116d9125b0e'
+        uuid = "6b08c7db-a0f5-404d-ae73-b116d9125b0e"
         toggle_event_source_mapping_state(uuid, False)
-    assert 'Test Error' in str(x)
+    assert "Test Error" in str(x)

--- a/tests/awslambda/test_awslambda_probes.py
+++ b/tests/awslambda/test_awslambda_probes.py
@@ -3,44 +3,47 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-from chaoslib.exceptions import FailedActivity
 from botocore.exceptions import ClientError
+from chaoslib.exceptions import FailedActivity
 
 from chaosaws.awslambda.probes import (
-    get_function_concurrency, get_function_memory_size, get_function_timeout,
-    list_event_source_mapping)
+    get_function_concurrency,
+    get_function_memory_size,
+    get_function_timeout,
+    list_event_source_mapping,
+)
 
 
 def mock_client_error(operation_name: str):
-    return ClientError(operation_name=operation_name, error_response={
-        'Error': {'Message': 'Test Error'}})
+    return ClientError(
+        operation_name=operation_name,
+        error_response={"Error": {"Message": "Test Error"}},
+    )
 
 
 def read_in_test_data(filename):
     module_path = os.path.dirname(os.path.abspath(__file__))
-    test_path = os.path.join(module_path, 'test_data', filename)
-    with open(test_path, 'r') as fh:
+    test_path = os.path.join(module_path, "test_data", filename)
+    with open(test_path, "r") as fh:
         test_data = json.loads(fh.read())
     return test_data
 
 
-@patch('chaosaws.awslambda.probes.aws_client', autospec=True)
+@patch("chaosaws.awslambda.probes.aws_client", autospec=True)
 def test_aws_lambda_get_function_concurrency(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    lambda_function_name = 'my-lambda-function'
+    lambda_function_name = "my-lambda-function"
     get_function_concurrency(lambda_function_name)
     client.get_function.assert_called_with(FunctionName=lambda_function_name)
 
 
-@patch('chaosaws.awslambda.probes.aws_client', autospec=True)
+@patch("chaosaws.awslambda.probes.aws_client", autospec=True)
 def test_aws_lambda_get_function_timeout(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.get_function_configuration.return_value = {
-        'Timeout': 3
-    }
-    lambda_function_name = 'my-lambda-function'
+    client.get_function_configuration.return_value = {"Timeout": 3}
+    lambda_function_name = "my-lambda-function"
     response = get_function_timeout(lambda_function_name)
     assert response == 3
     client.get_function_configuration.assert_called_with(
@@ -48,14 +51,12 @@ def test_aws_lambda_get_function_timeout(aws_client):
     )
 
 
-@patch('chaosaws.awslambda.probes.aws_client', autospec=True)
+@patch("chaosaws.awslambda.probes.aws_client", autospec=True)
 def test_aws_lambda_get_function_memory_size(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.get_function_configuration.return_value = {
-        'MemorySize': 1024
-    }
-    lambda_function_name = 'my-lambda-function'
+    client.get_function_configuration.return_value = {"MemorySize": 1024}
+    lambda_function_name = "my-lambda-function"
     response = get_function_memory_size(lambda_function_name)
     assert response == 1024
     client.get_function_configuration.assert_called_with(
@@ -63,34 +64,35 @@ def test_aws_lambda_get_function_memory_size(aws_client):
     )
 
 
-@patch('chaosaws.awslambda.probes.aws_client', autospec=True)
+@patch("chaosaws.awslambda.probes.aws_client", autospec=True)
 def test_aws_lambda_list_event_source_mappings(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.list_event_source_mappings.return_value = read_in_test_data(
-        'list_event_source_mapping.json')
+        "list_event_source_mapping.json"
+    )
 
-    function_name = 'GenericLambdaFunction'
+    function_name = "GenericLambdaFunction"
     response = list_event_source_mapping(function_name=function_name)
-    assert response['EventSourceMappings']
-    client.list_event_source_mappings.assert_called_with(
-        FunctionName=function_name)
+    assert response["EventSourceMappings"]
+    client.list_event_source_mappings.assert_called_with(FunctionName=function_name)
 
 
 def test_aws_lambda_list_event_source_mappings_no_parameter():
     with pytest.raises(FailedActivity) as x:
         list_event_source_mapping()
-    assert 'must specify at least one of' in str(x)
+    assert "must specify at least one of" in str(x)
 
 
-@patch('chaosaws.awslambda.probes.aws_client', autospec=True)
+@patch("chaosaws.awslambda.probes.aws_client", autospec=True)
 def test_aws_lambda_list_event_source_mappings_exception(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.list_event_source_mappings.side_effect = mock_client_error(
-        'list_event_source_mappings')
+        "list_event_source_mappings"
+    )
 
     with pytest.raises(FailedActivity) as x:
-        function_name = 'GenericLambdaFunction'
+        function_name = "GenericLambdaFunction"
         list_event_source_mapping(function_name=function_name)
     assert "Test Error" in str(x)

--- a/tests/cloudwatch/test_cloudwatch_actions.py
+++ b/tests/cloudwatch/test_cloudwatch_actions.py
@@ -6,120 +6,126 @@ from botocore.exceptions import ClientError
 from chaoslib.exceptions import FailedActivity
 
 from chaosaws.cloudwatch.actions import (
-    put_rule, put_rule_targets, disable_rule, enable_rule, delete_rule,
-    remove_rule_targets, put_metric_data
+    delete_rule,
+    disable_rule,
+    enable_rule,
+    put_metric_data,
+    put_rule,
+    put_rule_targets,
+    remove_rule_targets,
 )
 
 
 def mock_client_error(*args, **kwargs):
     return ClientError(
-        operation_name=kwargs['op'],
-        error_response={'Error': {
-            'Code': kwargs['Code'],
-            'Message': kwargs['Message']
-        }}
+        operation_name=kwargs["op"],
+        error_response={
+            "Error": {"Code": kwargs["Code"], "Message": kwargs["Message"]}
+        },
     )
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_cloudwatch_put_rule(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    rule_name = 'my-rule'
-    schedule_expression = 'rate(5 minutes)'
-    state = 'ENABLED'
-    description = 'My 5 minute rule'
-    role_arn = 'iam:role:for:my:rule'
-    put_rule(rule_name,
-             schedule_expression=schedule_expression,
-             state=state,
-             description=description,
-             role_arn=role_arn)
+    rule_name = "my-rule"
+    schedule_expression = "rate(5 minutes)"
+    state = "ENABLED"
+    description = "My 5 minute rule"
+    role_arn = "iam:role:for:my:rule"
+    put_rule(
+        rule_name,
+        schedule_expression=schedule_expression,
+        state=state,
+        description=description,
+        role_arn=role_arn,
+    )
     client.put_rule.assert_called_with(
         Name=rule_name,
         ScheduleExpression=schedule_expression,
         State=state,
         Description=description,
-        RoleArn=role_arn)
+        RoleArn=role_arn,
+    )
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_cloudwatch_put_rule_targets(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    rule_name = 'my-rule'
+    rule_name = "my-rule"
     targets = [
         {
-            'Id': '1234',
-            'Arn': 'arn:aws:lambda:eu-central-1:'
-                   '101010101010:function:MyFunction'
+            "Id": "1234",
+            "Arn": "arn:aws:lambda:eu-central-1:" "101010101010:function:MyFunction",
         }
     ]
     put_rule_targets(rule_name, targets)
     client.put_targets.assert_called_with(Rule=rule_name, Targets=targets)
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_cloudwatch_disable_rule(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    rule_name = 'my-rule'
+    rule_name = "my-rule"
     disable_rule(rule_name)
     client.disable_rule.assert_called_with(Name=rule_name)
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_cloudwatch_enable_rule(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    rule_name = 'my-rule'
+    rule_name = "my-rule"
     enable_rule(rule_name)
     client.enable_rule.assert_called_with(Name=rule_name)
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_cloudwatch_delete_rule(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    rule_name = 'my-rule'
+    rule_name = "my-rule"
     delete_rule(rule_name)
     client.delete_rule.assert_called_with(Name=rule_name)
     client.remove_targets.assert_not_called()
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_cloudwatch_delete_rule_force(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    target_ids = ['1', '2', '3']
+    target_ids = ["1", "2", "3"]
     client.list_targets_by_rule.return_value = {
-        'Targets': [{'Id': t} for t in target_ids]
+        "Targets": [{"Id": t} for t in target_ids]
     }
-    rule_name = 'my-rule'
+    rule_name = "my-rule"
     delete_rule(rule_name, force=True)
     client.delete_rule.assert_called_with(Name=rule_name)
     client.list_targets_by_rule.assert_called_with(Rule=rule_name)
     client.remove_targets.assert_called_with(Rule=rule_name, Ids=target_ids)
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_cloudwatch_remove_rule_targets(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    rule_name = 'my-rule'
-    target_ids = ['1', '2', '3']
+    rule_name = "my-rule"
+    target_ids = ["1", "2", "3"]
     remove_rule_targets(rule_name, target_ids)
     client.remove_targets.assert_called_with(Rule=rule_name, Ids=target_ids)
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_cloudwatch_remove_rule_targets_all(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    rule_name = 'my-rule'
-    target_ids = ['1', '2', '3']
+    rule_name = "my-rule"
+    target_ids = ["1", "2", "3"]
     client.list_targets_by_rule.return_value = {
-        'Targets': [{'Id': t} for t in target_ids]
+        "Targets": [{"Id": t} for t in target_ids]
     }
     remove_rule_targets(rule_name, target_ids=None)
     client.remove_targets.assert_called_with(Rule=rule_name, Ids=target_ids)
@@ -127,7 +133,7 @@ def test_cloudwatch_remove_rule_targets_all(aws_client):
     client.remove_targets.assert_called_with(Rule=rule_name, Ids=target_ids)
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_put_metric_data_valid_single_datapoint(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -136,55 +142,51 @@ def test_put_metric_data_valid_single_datapoint(aws_client):
     time_stamp_2 = datetime.today()
 
     put_metric_data(
-        namespace='TestMetricNamespace',
+        namespace="TestMetricNamespace",
         metric_data=[
             {
-                'MetricName': 'MemoryUtilization',
-                'Dimensions': [
-                    {'Name': 'InstanceId', 'Value': 'i-000000000000'}],
-                'Timestamp': time_stamp_1,
-                'Value': 85.568945236,
-                'Unit': 'Percent',
-                'StorageResolution': 60
+                "MetricName": "MemoryUtilization",
+                "Dimensions": [{"Name": "InstanceId", "Value": "i-000000000000"}],
+                "Timestamp": time_stamp_1,
+                "Value": 85.568945236,
+                "Unit": "Percent",
+                "StorageResolution": 60,
             },
             {
-                'MetricName': 'MemoryUtilization',
-                'Dimensions': [
-                    {'Name': 'InstanceId', 'Value': 'i-000000000000'}],
-                'Timestamp': time_stamp_2,
-                'Value': 89.6854,
-                'Unit': 'Percent',
-                'StorageResolution': 60
-            }
-        ]
+                "MetricName": "MemoryUtilization",
+                "Dimensions": [{"Name": "InstanceId", "Value": "i-000000000000"}],
+                "Timestamp": time_stamp_2,
+                "Value": 89.6854,
+                "Unit": "Percent",
+                "StorageResolution": 60,
+            },
+        ],
     )
 
     client.put_metric_data.assert_called_with(
-        Namespace='TestMetricNamespace',
+        Namespace="TestMetricNamespace",
         MetricData=[
             {
-                'MetricName': 'MemoryUtilization',
-                'Dimensions': [
-                    {'Name': 'InstanceId', 'Value': 'i-000000000000'}],
-                'Timestamp': time_stamp_1,
-                'Value': 85.568945236,
-                'Unit': 'Percent',
-                'StorageResolution': 60
+                "MetricName": "MemoryUtilization",
+                "Dimensions": [{"Name": "InstanceId", "Value": "i-000000000000"}],
+                "Timestamp": time_stamp_1,
+                "Value": 85.568945236,
+                "Unit": "Percent",
+                "StorageResolution": 60,
             },
             {
-                'MetricName': 'MemoryUtilization',
-                'Dimensions': [
-                    {'Name': 'InstanceId', 'Value': 'i-000000000000'}],
-                'Timestamp': time_stamp_2,
-                'Value': 89.6854,
-                'Unit': 'Percent',
-                'StorageResolution': 60
-            }
-        ]
+                "MetricName": "MemoryUtilization",
+                "Dimensions": [{"Name": "InstanceId", "Value": "i-000000000000"}],
+                "Timestamp": time_stamp_2,
+                "Value": 89.6854,
+                "Unit": "Percent",
+                "StorageResolution": 60,
+            },
+        ],
     )
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_put_metric_data_valid_multi_datapoints(aws_client):
     time_stamp = datetime.today()
     client = MagicMock()
@@ -192,59 +194,59 @@ def test_put_metric_data_valid_multi_datapoints(aws_client):
     client.put_metric_data.return_value = None
 
     put_metric_data(
-        namespace='TestMetricNamespace',
-        metric_data=[{
-            'MetricName': 'MemoryUtilization',
-            'Dimensions': [{'Name': 'InstanceId', 'Value': 'i-000000000000'}],
-            'Timestamp': time_stamp,
-            'Values': [5.5, 10.2, 6.5],
-            'Counts': [1, 3, 2.6],
-            'Unit': 'Percent',
-            'StorageResolution': 60
-        }]
+        namespace="TestMetricNamespace",
+        metric_data=[
+            {
+                "MetricName": "MemoryUtilization",
+                "Dimensions": [{"Name": "InstanceId", "Value": "i-000000000000"}],
+                "Timestamp": time_stamp,
+                "Values": [5.5, 10.2, 6.5],
+                "Counts": [1, 3, 2.6],
+                "Unit": "Percent",
+                "StorageResolution": 60,
+            }
+        ],
     )
 
     client.put_metric_data.assert_called_with(
-        Namespace='TestMetricNamespace',
+        Namespace="TestMetricNamespace",
         MetricData=[
             {
-                'MetricName': 'MemoryUtilization',
-                'Dimensions': [
-                    {'Name': 'InstanceId', 'Value': 'i-000000000000'}],
-                'Timestamp': time_stamp,
-                'Values': [5.5, 10.2, 6.5],
-                'Counts': [1, 3, 2.6],
-                'Unit': 'Percent',
-                'StorageResolution': 60
+                "MetricName": "MemoryUtilization",
+                "Dimensions": [{"Name": "InstanceId", "Value": "i-000000000000"}],
+                "Timestamp": time_stamp,
+                "Values": [5.5, 10.2, 6.5],
+                "Counts": [1, 3, 2.6],
+                "Unit": "Percent",
+                "StorageResolution": 60,
             }
-        ]
+        ],
     )
 
 
-@patch('chaosaws.cloudwatch.actions.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.actions.aws_client", autospec=True)
 def test_put_metric_data_invalid_parameter(aws_client):
     time_stamp = datetime.today()
     client = MagicMock()
     aws_client.return_value = client
     client.put_metric_data.side_effect = mock_client_error(
-        op='PutMetricData',
-        Code='InvalidParameterValueException',
-        Message='An error occurred when calling PutMetricData'
+        op="PutMetricData",
+        Code="InvalidParameterValueException",
+        Message="An error occurred when calling PutMetricData",
     )
 
     with pytest.raises(FailedActivity) as x:
         put_metric_data(
-            namespace='TestMetricNamespace',
+            namespace="TestMetricNamespace",
             metric_data=[
                 {
-                    'MetricName': 'MemoryUtilization',
-                    'Dimensions': [
-                        {'Name': 'InstanceId', 'Value': 'i-000000000000'}],
-                    'Timestamp': time_stamp,
-                    'Value': 85.568945236,
-                    'Unit': 'InvalidUnit',
-                    'StorageResolution': 60
+                    "MetricName": "MemoryUtilization",
+                    "Dimensions": [{"Name": "InstanceId", "Value": "i-000000000000"}],
+                    "Timestamp": time_stamp,
+                    "Value": 85.568945236,
+                    "Unit": "InvalidUnit",
+                    "StorageResolution": 60,
                 }
-            ]
+            ],
         )
-    assert 'An error occurred when calling PutMetricData' in str(x)
+    assert "An error occurred when calling PutMetricData" in str(x)

--- a/tests/cloudwatch/test_cloudwatch_probes.py
+++ b/tests/cloudwatch/test_cloudwatch_probes.py
@@ -7,10 +7,13 @@ import pytest
 from chaoslib.exceptions import FailedActivity
 
 from chaosaws.cloudwatch.probes import (
-    get_alarm_state_value, get_metric_statistics, get_metric_data)
+    get_alarm_state_value,
+    get_metric_data,
+    get_metric_statistics,
+)
 
 module_path = os.path.dirname(os.path.abspath(__file__))
-date_format = '%a, %d %b %Y %H:%M'
+date_format = "%a, %d %b %Y %H:%M"
 
 
 def datetime_parser(json_data: dict):
@@ -22,119 +25,114 @@ def datetime_parser(json_data: dict):
     return json_data
 
 
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
 def test_cloudwatch_get_alarm_state_value_ok(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alarm_name = 'my-alarm'
+    alarm_name = "my-alarm"
     client.describe_alarms.return_value = {
-        'MetricAlarms': [
-            {
-                'AlarmName': alarm_name,
-                'StateValue': 'OK'
-            }
-        ]
+        "MetricAlarms": [{"AlarmName": alarm_name, "StateValue": "OK"}]
     }
     result = get_alarm_state_value(alarm_name)
-    assert result == 'OK'
+    assert result == "OK"
     client.describe_alarms.assert_called_with(AlarmNames=[alarm_name])
 
 
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
 def test_cloudwatch_get_alarm_state_value_not_found(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alarm_name = 'my-alarm'
-    client.describe_alarms.return_value = {
-        'MetricAlarms': []
-    }
+    alarm_name = "my-alarm"
+    client.describe_alarms.return_value = {"MetricAlarms": []}
     with pytest.raises(FailedActivity):
         get_alarm_state_value(alarm_name)
     client.describe_alarms.assert_called_with(AlarmNames=[alarm_name])
 
 
-@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
-def test_cloudwatch_get_metric_statistics_ok(aws_client,
-                                             mock_datetime):
+@patch("chaosaws.cloudwatch.probes.datetime", autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
+def test_cloudwatch_get_metric_statistics_ok(aws_client, mock_datetime):
     client = MagicMock()
     aws_client.return_value = client
-    mock_datetime.utcnow.return_value = datetime(2015, 1, 1, 15, 15,
-                                                 tzinfo=timezone.utc)
+    mock_datetime.utcnow.return_value = datetime(
+        2015, 1, 1, 15, 15, tzinfo=timezone.utc
+    )
 
-    namespace = 'AWS/Lambda'
-    metric_name = 'Invocations'
-    dimension_name = 'FunctionName'
-    dimension_value = 'MyFunction'
+    namespace = "AWS/Lambda"
+    metric_name = "Invocations"
+    dimension_name = "FunctionName"
+    dimension_value = "MyFunction"
     duration = 120
     offset = 60
-    statistic = 'Sum'
+    statistic = "Sum"
     extended_statistic = None
-    unit = 'Count'
-    client.get_metric_statistics.return_value = {
-        'Datapoints': [{statistic: 4753.0}]
-    }
+    unit = "Count"
+    client.get_metric_statistics.return_value = {"Datapoints": [{statistic: 4753.0}]}
 
-    result = get_metric_statistics(namespace=namespace,
-                                   metric_name=metric_name,
-                                   dimension_name=dimension_name,
-                                   dimension_value=dimension_value,
-                                   duration=duration,
-                                   offset=offset,
-                                   statistic=statistic,
-                                   extended_statistic=extended_statistic,
-                                   unit=unit)
+    result = get_metric_statistics(
+        namespace=namespace,
+        metric_name=metric_name,
+        dimension_name=dimension_name,
+        dimension_value=dimension_value,
+        duration=duration,
+        offset=offset,
+        statistic=statistic,
+        extended_statistic=extended_statistic,
+        unit=unit,
+    )
 
     assert result == 4753.0
     client.get_metric_statistics.assert_called_with(
         Namespace=namespace,
         MetricName=metric_name,
-        Dimensions=[{'Name': dimension_name, 'Value': dimension_value}],
+        Dimensions=[{"Name": dimension_name, "Value": dimension_value}],
         Period=duration,
         StartTime=datetime(2015, 1, 1, 15, 12, tzinfo=timezone.utc),
         EndTime=datetime(2015, 1, 1, 15, 14, tzinfo=timezone.utc),
         Statistics=[statistic],
-        Unit=unit
+        Unit=unit,
     )
 
 
-@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
-def test_cloudwatch_get_metric_statistics_extended_ok(aws_client,
-                                                      mock_datetime):
+@patch("chaosaws.cloudwatch.probes.datetime", autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
+def test_cloudwatch_get_metric_statistics_extended_ok(aws_client, mock_datetime):
     client = MagicMock()
     aws_client.return_value = client
-    mock_datetime.utcnow.return_value = datetime(2015, 1, 1, 15, 15,
-                                                 tzinfo=timezone.utc)
+    mock_datetime.utcnow.return_value = datetime(
+        2015, 1, 1, 15, 15, tzinfo=timezone.utc
+    )
 
-    namespace = 'AWS/Lambda'
-    metric_name = 'Invocations'
-    dimension_name = 'FunctionName'
-    dimension_value = 'MyFunction'
+    namespace = "AWS/Lambda"
+    metric_name = "Invocations"
+    dimension_name = "FunctionName"
+    dimension_value = "MyFunction"
     duration = 120
     offset = 60
     statistic = None
-    extended_statistic = 'p99'
+    extended_statistic = "p99"
     client.get_metric_statistics.return_value = {
-        'Datapoints': [{'ExtendedStatistics': {extended_statistic: 4753.0}}]
+        "Datapoints": [{"ExtendedStatistics": {extended_statistic: 4753.0}}]
     }
     unit = None
 
-    result = get_metric_statistics(namespace=namespace,
-                                   metric_name=metric_name,
-                                   dimension_name=dimension_name,
-                                   dimension_value=dimension_value,
-                                   duration=duration,
-                                   offset=offset,
-                                   statistic=statistic,
-                                   extended_statistic=extended_statistic,
-                                   unit=unit)
+    result = get_metric_statistics(
+        namespace=namespace,
+        metric_name=metric_name,
+        dimension_name=dimension_name,
+        dimension_value=dimension_value,
+        duration=duration,
+        offset=offset,
+        statistic=statistic,
+        extended_statistic=extended_statistic,
+        unit=unit,
+    )
 
     assert result == 4753.0
     client.get_metric_statistics.assert_called_with(
         Namespace=namespace,
         MetricName=metric_name,
-        Dimensions=[{'Name': dimension_name, 'Value': dimension_value}],
+        Dimensions=[{"Name": dimension_name, "Value": dimension_value}],
         Period=duration,
         StartTime=datetime(2015, 1, 1, 15, 12, tzinfo=timezone.utc),
         EndTime=datetime(2015, 1, 1, 15, 14, tzinfo=timezone.utc),
@@ -142,307 +140,322 @@ def test_cloudwatch_get_metric_statistics_extended_ok(aws_client,
     )
 
 
-@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
-def test_cloudwatch_get_metric_statistics_no_datapoints(
-        aws_client, mock_datetime):
+@patch("chaosaws.cloudwatch.probes.datetime", autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
+def test_cloudwatch_get_metric_statistics_no_datapoints(aws_client, mock_datetime):
     client = MagicMock()
     aws_client.return_value = client
-    mock_datetime.utcnow.return_value = datetime(2015, 1, 1, 15, 15,
-                                                 tzinfo=timezone.utc)
+    mock_datetime.utcnow.return_value = datetime(
+        2015, 1, 1, 15, 15, tzinfo=timezone.utc
+    )
 
-    namespace = 'AWS/Lambda'
-    metric_name = 'Invocations'
-    dimension_name = 'FunctionName'
-    dimension_value = 'MyFunction'
+    namespace = "AWS/Lambda"
+    metric_name = "Invocations"
+    dimension_name = "FunctionName"
+    dimension_value = "MyFunction"
     duration = 120
     offset = 60
-    statistic = 'Sum'
+    statistic = "Sum"
     extended_statistic = None
-    unit = 'Count'
-    client.get_metric_statistics.return_value = {
-        'Datapoints': []
-    }
+    unit = "Count"
+    client.get_metric_statistics.return_value = {"Datapoints": []}
 
     response = get_metric_statistics(
-        namespace=namespace, metric_name=metric_name,
-        dimension_name=dimension_name, dimension_value=dimension_value,
-        duration=duration, offset=offset, statistic=statistic,
-        extended_statistic=extended_statistic, unit=unit)
+        namespace=namespace,
+        metric_name=metric_name,
+        dimension_name=dimension_name,
+        dimension_value=dimension_value,
+        duration=duration,
+        offset=offset,
+        statistic=statistic,
+        extended_statistic=extended_statistic,
+        unit=unit,
+    )
 
     assert response == 0
 
     client.get_metric_statistics.assert_called_with(
         Namespace=namespace,
         MetricName=metric_name,
-        Dimensions=[{'Name': dimension_name, 'Value': dimension_value}],
+        Dimensions=[{"Name": dimension_name, "Value": dimension_value}],
         Period=duration,
         StartTime=datetime(2015, 1, 1, 15, 12, tzinfo=timezone.utc),
         EndTime=datetime(2015, 1, 1, 15, 14, tzinfo=timezone.utc),
         Statistics=[statistic],
-        Unit=unit
+        Unit=unit,
     )
 
 
-@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
-def test_cloudwatch_get_metric_statistics_bad_response(
-        aws_client, mock_datetime):
+@patch("chaosaws.cloudwatch.probes.datetime", autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
+def test_cloudwatch_get_metric_statistics_bad_response(aws_client, mock_datetime):
     client = MagicMock()
     aws_client.return_value = client
-    mock_datetime.utcnow.return_value = datetime(2015, 1, 1, 15, 15,
-                                                 tzinfo=timezone.utc)
+    mock_datetime.utcnow.return_value = datetime(
+        2015, 1, 1, 15, 15, tzinfo=timezone.utc
+    )
 
-    namespace = 'AWS/Lambda'
-    metric_name = 'Invocations'
-    dimension_name = 'FunctionName'
-    dimension_value = 'MyFunction'
+    namespace = "AWS/Lambda"
+    metric_name = "Invocations"
+    dimension_name = "FunctionName"
+    dimension_value = "MyFunction"
     duration = 120
     offset = 60
-    statistic = 'Sum'
+    statistic = "Sum"
     extended_statistic = None
-    unit = 'Count'
-    client.get_metric_statistics.return_value = {
-        'Datapoints': [{'some': 'value'}]
-    }
+    unit = "Count"
+    client.get_metric_statistics.return_value = {"Datapoints": [{"some": "value"}]}
 
     with pytest.raises(FailedActivity):
-        get_metric_statistics(namespace=namespace, metric_name=metric_name,
-                              dimension_name=dimension_name,
-                              dimension_value=dimension_value,
-                              duration=duration, offset=offset,
-                              statistic=statistic,
-                              extended_statistic=extended_statistic, unit=unit)
+        get_metric_statistics(
+            namespace=namespace,
+            metric_name=metric_name,
+            dimension_name=dimension_name,
+            dimension_value=dimension_value,
+            duration=duration,
+            offset=offset,
+            statistic=statistic,
+            extended_statistic=extended_statistic,
+            unit=unit,
+        )
 
     client.get_metric_statistics.assert_called_with(
         Namespace=namespace,
         MetricName=metric_name,
-        Dimensions=[{'Name': dimension_name, 'Value': dimension_value}],
+        Dimensions=[{"Name": dimension_name, "Value": dimension_value}],
         Period=duration,
         StartTime=datetime(2015, 1, 1, 15, 12, tzinfo=timezone.utc),
         EndTime=datetime(2015, 1, 1, 15, 14, tzinfo=timezone.utc),
         Statistics=[statistic],
-        Unit=unit
+        Unit=unit,
     )
 
 
-@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.probes.datetime", autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
 def test_get_cloudwatch_data_average(m_client, m_datetime):
-    with open(os.path.join(
-            module_path, 'data', 'cloudwatch_data_full.json'), 'r') as fh:
+    with open(
+        os.path.join(module_path, "data", "cloudwatch_data_full.json"), "r"
+    ) as fh:
         response_data = json.loads(fh.read(), object_hook=datetime_parser)
     client = MagicMock()
     m_client.return_value = client
     client.get_metric_data.return_value = response_data
-    m_datetime.utcnow.return_value = datetime(
-        2020, 1, 1, 17, 00, tzinfo=timezone.utc)
+    m_datetime.utcnow.return_value = datetime(2020, 1, 1, 17, 00, tzinfo=timezone.utc)
 
     args = {
-        'namespace': 'AWS/ApplicationELB',
-        'metric_name': 'ActiveConnectionCount',
-        'dimension_name': 'LoadBalancer',
-        'dimension_value': 'app/my_test_alb/0000000000000000',
-        'period': 60,
-        'duration': 300,
-        'statistic': 'Average',
-        'unit': 'Count'
+        "namespace": "AWS/ApplicationELB",
+        "metric_name": "ActiveConnectionCount",
+        "dimension_name": "LoadBalancer",
+        "dimension_value": "app/my_test_alb/0000000000000000",
+        "period": 60,
+        "duration": 300,
+        "statistic": "Average",
+        "unit": "Count",
     }
     response = get_metric_data(**args)
     client.get_metric_data.assert_called_with(
         MetricDataQueries=[
             {
-                'Id': 'm1',
-                'MetricStat': {
-                    'Metric': {
-                        'Namespace': 'AWS/ApplicationELB',
-                        'MetricName': 'ActiveConnectionCount',
-                        'Dimensions': [{
-                            'Name': 'LoadBalancer',
-                            'Value': 'app/my_test_alb/0000000000000000'
-                        }]
+                "Id": "m1",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/ApplicationELB",
+                        "MetricName": "ActiveConnectionCount",
+                        "Dimensions": [
+                            {
+                                "Name": "LoadBalancer",
+                                "Value": "app/my_test_alb/0000000000000000",
+                            }
+                        ],
                     },
-                    'Period': 60,
-                    'Stat': 'Average',
-                    'Unit': 'Count',
+                    "Period": 60,
+                    "Stat": "Average",
+                    "Unit": "Count",
                 },
-                'Label': 'ActiveConnectionCount',
+                "Label": "ActiveConnectionCount",
             },
         ],
         StartTime=datetime(2020, 1, 1, 16, 55, tzinfo=timezone.utc),
-        EndTime=datetime(2020, 1, 1, 17, 0, tzinfo=timezone.utc)
+        EndTime=datetime(2020, 1, 1, 17, 0, tzinfo=timezone.utc),
     )
     assert response == 7.53
 
 
-@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.probes.datetime", autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
 def test_get_cloudwatch_data_minimum(m_client, m_datetime):
-    with open(os.path.join(
-            module_path, 'data', 'cloudwatch_data_full.json'), 'r') as fh:
+    with open(
+        os.path.join(module_path, "data", "cloudwatch_data_full.json"), "r"
+    ) as fh:
         response_data = json.loads(fh.read(), object_hook=datetime_parser)
     client = MagicMock()
     m_client.return_value = client
     client.get_metric_data.return_value = response_data
-    m_datetime.utcnow.return_value = datetime(
-        2020, 1, 1, 17, 00, tzinfo=timezone.utc)
+    m_datetime.utcnow.return_value = datetime(2020, 1, 1, 17, 00, tzinfo=timezone.utc)
 
     args = {
-        'namespace': 'AWS/ApplicationELB',
-        'metric_name': 'ActiveConnectionCount',
-        'dimension_name': 'LoadBalancer',
-        'dimension_value': 'app/my_test_alb/0000000000000000',
-        'period': 60,
-        'duration': 300,
-        'statistic': 'Minimum',
-        'unit': 'Count'
+        "namespace": "AWS/ApplicationELB",
+        "metric_name": "ActiveConnectionCount",
+        "dimension_name": "LoadBalancer",
+        "dimension_value": "app/my_test_alb/0000000000000000",
+        "period": 60,
+        "duration": 300,
+        "statistic": "Minimum",
+        "unit": "Count",
     }
     response = get_metric_data(**args)
     client.get_metric_data.assert_called_with(
         MetricDataQueries=[
             {
-                'Id': 'm1',
-                'MetricStat': {
-                    'Metric': {
-                        'Namespace': 'AWS/ApplicationELB',
-                        'MetricName': 'ActiveConnectionCount',
-                        'Dimensions': [{
-                            'Name': 'LoadBalancer',
-                            'Value': 'app/my_test_alb/0000000000000000'
-                        }]
+                "Id": "m1",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/ApplicationELB",
+                        "MetricName": "ActiveConnectionCount",
+                        "Dimensions": [
+                            {
+                                "Name": "LoadBalancer",
+                                "Value": "app/my_test_alb/0000000000000000",
+                            }
+                        ],
                     },
-                    'Period': 60,
-                    'Stat': 'Minimum',
-                    'Unit': 'Count',
+                    "Period": 60,
+                    "Stat": "Minimum",
+                    "Unit": "Count",
                 },
-                'Label': 'ActiveConnectionCount',
+                "Label": "ActiveConnectionCount",
             },
         ],
         StartTime=datetime(2020, 1, 1, 16, 55, tzinfo=timezone.utc),
-        EndTime=datetime(2020, 1, 1, 17, 0, tzinfo=timezone.utc)
+        EndTime=datetime(2020, 1, 1, 17, 0, tzinfo=timezone.utc),
     )
     assert response == 5.0
 
 
-@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.probes.datetime", autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
 def test_get_cloudwatch_data_maximum(m_client, m_datetime):
-    with open(os.path.join(
-            module_path, 'data', 'cloudwatch_data_full.json'), 'r') as fh:
+    with open(
+        os.path.join(module_path, "data", "cloudwatch_data_full.json"), "r"
+    ) as fh:
         response_data = json.loads(fh.read(), object_hook=datetime_parser)
     client = MagicMock()
     m_client.return_value = client
     client.get_metric_data.return_value = response_data
-    m_datetime.utcnow.return_value = datetime(
-        2020, 1, 1, 17, 00, tzinfo=timezone.utc)
+    m_datetime.utcnow.return_value = datetime(2020, 1, 1, 17, 00, tzinfo=timezone.utc)
 
     args = {
-        'namespace': 'AWS/ApplicationELB',
-        'metric_name': 'ActiveConnectionCount',
-        'dimension_name': 'LoadBalancer',
-        'dimension_value': 'app/my_test_alb/0000000000000000',
-        'period': 60,
-        'duration': 300,
-        'statistic': 'Maximum',
-        'unit': 'Count'
+        "namespace": "AWS/ApplicationELB",
+        "metric_name": "ActiveConnectionCount",
+        "dimension_name": "LoadBalancer",
+        "dimension_value": "app/my_test_alb/0000000000000000",
+        "period": 60,
+        "duration": 300,
+        "statistic": "Maximum",
+        "unit": "Count",
     }
     response = get_metric_data(**args)
     client.get_metric_data.assert_called_with(
         MetricDataQueries=[
             {
-                'Id': 'm1',
-                'MetricStat': {
-                    'Metric': {
-                        'Namespace': 'AWS/ApplicationELB',
-                        'MetricName': 'ActiveConnectionCount',
-                        'Dimensions': [{
-                            'Name': 'LoadBalancer',
-                            'Value': 'app/my_test_alb/0000000000000000'
-                        }]
+                "Id": "m1",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/ApplicationELB",
+                        "MetricName": "ActiveConnectionCount",
+                        "Dimensions": [
+                            {
+                                "Name": "LoadBalancer",
+                                "Value": "app/my_test_alb/0000000000000000",
+                            }
+                        ],
                     },
-                    'Period': 60,
-                    'Stat': 'Maximum',
-                    'Unit': 'Count',
+                    "Period": 60,
+                    "Stat": "Maximum",
+                    "Unit": "Count",
                 },
-                'Label': 'ActiveConnectionCount',
+                "Label": "ActiveConnectionCount",
             },
         ],
         StartTime=datetime(2020, 1, 1, 16, 55, tzinfo=timezone.utc),
-        EndTime=datetime(2020, 1, 1, 17, 0, tzinfo=timezone.utc)
+        EndTime=datetime(2020, 1, 1, 17, 0, tzinfo=timezone.utc),
     )
     assert response == 10.33
 
 
-@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.probes.datetime", autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
 def test_get_cloudwatch_data_sum(m_client, m_datetime):
-    with open(os.path.join(
-            module_path, 'data', 'cloudwatch_data_full.json'), 'r') as fh:
+    with open(
+        os.path.join(module_path, "data", "cloudwatch_data_full.json"), "r"
+    ) as fh:
         response_data = json.loads(fh.read(), object_hook=datetime_parser)
     client = MagicMock()
     m_client.return_value = client
     client.get_metric_data.return_value = response_data
-    m_datetime.utcnow.return_value = datetime(
-        2020, 1, 1, 17, 00, tzinfo=timezone.utc)
+    m_datetime.utcnow.return_value = datetime(2020, 1, 1, 17, 00, tzinfo=timezone.utc)
 
     args = {
-        'namespace': 'AWS/ApplicationELB',
-        'metric_name': 'ActiveConnectionCount',
-        'dimension_name': 'LoadBalancer',
-        'dimension_value': 'app/my_test_alb/0000000000000000',
-        'period': 60,
-        'duration': 300,
-        'statistic': 'Sum',
-        'unit': 'Count'
+        "namespace": "AWS/ApplicationELB",
+        "metric_name": "ActiveConnectionCount",
+        "dimension_name": "LoadBalancer",
+        "dimension_value": "app/my_test_alb/0000000000000000",
+        "period": 60,
+        "duration": 300,
+        "statistic": "Sum",
+        "unit": "Count",
     }
     response = get_metric_data(**args)
     client.get_metric_data.assert_called_with(
         MetricDataQueries=[
             {
-                'Id': 'm1',
-                'MetricStat': {
-                    'Metric': {
-                        'Namespace': 'AWS/ApplicationELB',
-                        'MetricName': 'ActiveConnectionCount',
-                        'Dimensions': [{
-                            'Name': 'LoadBalancer',
-                            'Value': 'app/my_test_alb/0000000000000000'
-                        }]
+                "Id": "m1",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/ApplicationELB",
+                        "MetricName": "ActiveConnectionCount",
+                        "Dimensions": [
+                            {
+                                "Name": "LoadBalancer",
+                                "Value": "app/my_test_alb/0000000000000000",
+                            }
+                        ],
                     },
-                    'Period': 60,
-                    'Stat': 'Sum',
-                    'Unit': 'Count',
+                    "Period": 60,
+                    "Stat": "Sum",
+                    "Unit": "Count",
                 },
-                'Label': 'ActiveConnectionCount',
+                "Label": "ActiveConnectionCount",
             },
         ],
         StartTime=datetime(2020, 1, 1, 16, 55, tzinfo=timezone.utc),
-        EndTime=datetime(2020, 1, 1, 17, 0, tzinfo=timezone.utc)
+        EndTime=datetime(2020, 1, 1, 17, 0, tzinfo=timezone.utc),
     )
     assert response == 37.67
 
 
-@patch('chaosaws.cloudwatch.probes.datetime', autospec=True)
-@patch('chaosaws.cloudwatch.probes.aws_client', autospec=True)
+@patch("chaosaws.cloudwatch.probes.datetime", autospec=True)
+@patch("chaosaws.cloudwatch.probes.aws_client", autospec=True)
 def test_get_cloudwatch_data_no_results(m_client, m_datetime):
-    with open(os.path.join(
-            module_path, 'data', 'cloudwatch_data_none.json'), 'r') as fh:
+    with open(
+        os.path.join(module_path, "data", "cloudwatch_data_none.json"), "r"
+    ) as fh:
         response_data = json.loads(fh.read(), object_hook=datetime_parser)
     client = MagicMock()
     m_client.return_value = client
     client.get_metric_data.return_value = response_data
-    m_datetime.utcnow.return_value = datetime(
-        2020, 1, 1, 17, 00, tzinfo=timezone.utc)
+    m_datetime.utcnow.return_value = datetime(2020, 1, 1, 17, 00, tzinfo=timezone.utc)
 
     args = {
-        'namespace': 'AWS/ApplicationELB',
-        'metric_name': 'HTTPCode_ELB_504_Count',
-        'dimension_name': 'LoadBalancer',
-        'dimension_value': 'app/my_test_alb/0000000000000000',
-        'period': 60,
-        'duration': 300,
-        'statistic': 'Average',
-        'unit': 'Count'
+        "namespace": "AWS/ApplicationELB",
+        "metric_name": "HTTPCode_ELB_504_Count",
+        "dimension_name": "LoadBalancer",
+        "dimension_value": "app/my_test_alb/0000000000000000",
+        "period": 60,
+        "duration": 300,
+        "statistic": "Average",
+        "unit": "Count",
     }
 
     response = get_metric_data(**args)
@@ -451,23 +464,25 @@ def test_get_cloudwatch_data_no_results(m_client, m_datetime):
     client.get_metric_data.assert_called_with(
         MetricDataQueries=[
             {
-                'Id': 'm1',
-                'MetricStat': {
-                    'Metric': {
-                        'Namespace': 'AWS/ApplicationELB',
-                        'MetricName': 'HTTPCode_ELB_504_Count',
-                        'Dimensions': [{
-                            'Name': 'LoadBalancer',
-                            'Value': 'app/my_test_alb/0000000000000000'
-                        }]
+                "Id": "m1",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "AWS/ApplicationELB",
+                        "MetricName": "HTTPCode_ELB_504_Count",
+                        "Dimensions": [
+                            {
+                                "Name": "LoadBalancer",
+                                "Value": "app/my_test_alb/0000000000000000",
+                            }
+                        ],
                     },
-                    'Period': 60,
-                    'Stat': 'Average',
-                    'Unit': 'Count',
+                    "Period": 60,
+                    "Stat": "Average",
+                    "Unit": "Count",
                 },
-                'Label': 'HTTPCode_ELB_504_Count',
+                "Label": "HTTPCode_ELB_504_Count",
             },
         ],
         StartTime=datetime(2020, 1, 1, 16, 55, tzinfo=timezone.utc),
-        EndTime=datetime(2020, 1, 1, 17, 0, tzinfo=timezone.utc)
+        EndTime=datetime(2020, 1, 1, 17, 0, tzinfo=timezone.utc),
     )

--- a/tests/cloudwatch/test_cloudwatch_probes.py
+++ b/tests/cloudwatch/test_cloudwatch_probes.py
@@ -20,7 +20,7 @@ def datetime_parser(json_data: dict):
     for k, v in json_data.items():
         try:
             json_data[k] = datetime.strptime(v, datetime)
-        except:
+        except Exception:
             pass
     return json_data
 

--- a/tests/ec2/test_ec2_actions.py
+++ b/tests/ec2/test_ec2_actions.py
@@ -2,260 +2,259 @@ from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from chaosaws.ec2.actions import (
-    stop_instance, stop_instances, terminate_instance, terminate_instances,
-    start_instances, restart_instances, detach_random_volume, attach_volume,
-    authorize_security_group_ingress, revoke_security_group_ingress)
-
 from chaoslib.exceptions import FailedActivity
 
+from chaosaws.ec2.actions import (
+    attach_volume,
+    authorize_security_group_ingress,
+    detach_random_volume,
+    restart_instances,
+    revoke_security_group_ingress,
+    start_instances,
+    stop_instance,
+    stop_instances,
+    terminate_instance,
+    terminate_instances,
+)
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_id = "i-1234567890abcdef0"
     client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'InstanceId': inst_id,
-                'InstanceLifecycle': 'normal'}]}]}
+        "Reservations": [
+            {"Instances": [{"InstanceId": inst_id, "InstanceLifecycle": "normal"}]}
+        ]
+    }
     stop_instance(inst_id)
-    client.stop_instances.assert_called_with(
-        InstanceIds=[inst_id], Force=False)
+    client.stop_instances.assert_called_with(InstanceIds=[inst_id], Force=False)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_spot_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_id = "i-1234567890abcdef0"
-    spot_request_id = 'sir-abcdef01'
+    spot_request_id = "sir-abcdef01"
     client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'InstanceId': inst_id,
-                'InstanceLifecycle': 'spot',
-                'SpotInstanceRequestId': spot_request_id}]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "InstanceId": inst_id,
+                        "InstanceLifecycle": "spot",
+                        "SpotInstanceRequestId": spot_request_id,
+                    }
+                ]
+            }
+        ]
+    }
     stop_instance(inst_id)
     client.cancel_spot_instance_requests.assert_called_with(
-        SpotInstanceRequestIds=[spot_request_id])
-    client.terminate_instances.assert_called_with(
-        InstanceIds=[inst_id])
+        SpotInstanceRequestIds=[spot_request_id]
+    )
+    client.terminate_instances.assert_called_with(InstanceIds=[inst_id])
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_instance_can_be_forced(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_id = "i-1234567890abcdef0"
     client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'InstanceId': inst_id,
-                'InstanceLifecycle': 'normal'}]}]}
+        "Reservations": [
+            {"Instances": [{"InstanceId": inst_id, "InstanceLifecycle": "normal"}]}
+        ]
+    }
     stop_instance(inst_id, force=True)
-    client.stop_instances.assert_called_with(
-        InstanceIds=[inst_id], Force=True)
+    client.stop_instances.assert_called_with(InstanceIds=[inst_id], Force=True)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_spot_instance_can_be_forced(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_id = "i-1234567890abcdef0"
-    spot_request_id = 'sir-abcdef01'
+    spot_request_id = "sir-abcdef01"
     client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'InstanceId': inst_id,
-                'InstanceLifecycle': 'spot',
-                'SpotInstanceRequestId': spot_request_id}]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "InstanceId": inst_id,
+                        "InstanceLifecycle": "spot",
+                        "SpotInstanceRequestId": spot_request_id,
+                    }
+                ]
+            }
+        ]
+    }
     stop_instance(inst_id, force=True)
     client.cancel_spot_instance_requests.assert_called_with(
-        SpotInstanceRequestIds=[spot_request_id])
-    client.terminate_instances.assert_called_with(
-        InstanceIds=[inst_id])
+        SpotInstanceRequestIds=[spot_request_id]
+    )
+    client.terminate_instances.assert_called_with(InstanceIds=[inst_id])
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_ids = ["i-1234567890abcdef0", "i-987654321fedcba"]
-    spot_request_id = 'sir-abcdef01'
+    spot_request_id = "sir-abcdef01"
     client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [
-                {
-                    'InstanceId': inst_ids[0],
-                    'InstanceLifecycle': 'normal'
-                },
-                {
-                    'InstanceId': inst_ids[1],
-                    'InstanceLifecycle': 'spot',
-                    'SpotInstanceRequestId': spot_request_id
-                }]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": inst_ids[0], "InstanceLifecycle": "normal"},
+                    {
+                        "InstanceId": inst_ids[1],
+                        "InstanceLifecycle": "spot",
+                        "SpotInstanceRequestId": spot_request_id,
+                    },
+                ]
+            }
+        ]
+    }
     stop_instances(inst_ids)
-    client.stop_instances.assert_called_with(
-        InstanceIds=[inst_ids[0]], Force=False)
+    client.stop_instances.assert_called_with(InstanceIds=[inst_ids[0]], Force=False)
     client.cancel_spot_instance_requests.assert_called_with(
-        SpotInstanceRequestIds=[spot_request_id])
-    client.terminate_instances.assert_called_with(
-        InstanceIds=[inst_ids[1]])
+        SpotInstanceRequestIds=[spot_request_id]
+    )
+    client.terminate_instances.assert_called_with(InstanceIds=[inst_ids[1]])
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_random_instance_in_az(aws_client):
     client = MagicMock()
     aws_client.return_value = client
 
     inst_id = "i-987654321fedcba"
     client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'InstanceId': inst_id,
-                'InstanceLifecycle': 'normal'}]
-        }]}
+        "Reservations": [
+            {"Instances": [{"InstanceId": inst_id, "InstanceLifecycle": "normal"}]}
+        ]
+    }
 
     stop_instance(az="us-west-1")
-    client.stop_instances.assert_called_with(
-        InstanceIds=[inst_id], Force=False)
+    client.stop_instances.assert_called_with(InstanceIds=[inst_id], Force=False)
 
 
 def test_stop_random_needs_instance_id_or_az():
     with pytest.raises(FailedActivity) as x:
         stop_instance()
-    assert "stop an EC2 instance, you must specify either the instance id," \
-           " an AZ to pick a random instance from, or a set of filters." in \
-           str(x.value)
+    assert (
+        "stop an EC2 instance, you must specify either the instance id,"
+        " an AZ to pick a random instance from, or a set of filters." in str(x.value)
+    )
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_all_instances_in_az(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_1_id = "i-987654321fedcba"
     inst_2_id = "i-123456789abcdef"
-    spot_request_id = 'sir-abcdef01'
+    spot_request_id = "sir-abcdef01"
     client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [
-                {
-                    'InstanceId': inst_1_id,
-                    'InstanceLifecycle': 'normal'
-                },
-                {
-                    'InstanceId': inst_2_id,
-                    'InstanceLifecycle': 'spot',
-                    'SpotInstanceRequestId': spot_request_id
-                }
-            ]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": inst_1_id, "InstanceLifecycle": "normal"},
+                    {
+                        "InstanceId": inst_2_id,
+                        "InstanceLifecycle": "spot",
+                        "SpotInstanceRequestId": spot_request_id,
+                    },
+                ]
+            }
+        ]
+    }
 
     stop_instances(az="us-west-1")
-    client.stop_instances.assert_called_with(
-        InstanceIds=[inst_1_id], Force=False)
+    client.stop_instances.assert_called_with(InstanceIds=[inst_1_id], Force=False)
     client.cancel_spot_instance_requests.assert_called_with(
-        SpotInstanceRequestIds=[spot_request_id])
-    client.terminate_instances.assert_called_with(
-        InstanceIds=[inst_2_id])
+        SpotInstanceRequestIds=[spot_request_id]
+    )
+    client.terminate_instances.assert_called_with(InstanceIds=[inst_2_id])
 
 
 def test_stop_all_instances_needs_instance_id_or_az():
     with pytest.raises(FailedActivity) as x:
         stop_instances()
-    assert "To stop EC2 instances, you must specify either the instance ids," \
-           " an AZ to pick random instances from, or a set of filters." in \
-           str(x.value)
+    assert (
+        "To stop EC2 instances, you must specify either the instance ids,"
+        " an AZ to pick random instances from, or a set of filters." in str(x.value)
+    )
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_all_instances_may_not_have_any_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.describe_instances.return_value = {'Reservations':
-                                              [{'Instances': []}]}
+    client.describe_instances.return_value = {"Reservations": [{"Instances": []}]}
 
     with pytest.raises(FailedActivity) as x:
         stop_instances(az="us-west-1")
     assert "No instances in availability zone: us-west-1" in str(x.value)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_instance_by_specific_filters(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_1_id = "i-987654321fedcba"
     client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'InstanceId': inst_1_id,
-                'InstanceLifecycle': 'normal'}]
-        }]}
+        "Reservations": [
+            {"Instances": [{"InstanceId": inst_1_id, "InstanceLifecycle": "normal"}]}
+        ]
+    }
 
     filters = [
         {
-            'Name': 'instance-state-name',
-            'Values': ['running'],
+            "Name": "instance-state-name",
+            "Values": ["running"],
         },
-        {
-            'Name': 'tag-key',
-            'Values': ['eksctl.cluster.k8s.io/v1alpha1/cluster-name']
-        },
-        {
-            'Name': 'tag-value',
-            'Values': ['chaos-cluster']
-        },
-        {
-            'Name': 'tag-key',
-            'Values': ['kubernetes.io/cluster/chaos-cluster']
-        },
-        {
-            'Name': 'tag-value',
-            'Values': ['owned']
-        }
+        {"Name": "tag-key", "Values": ["eksctl.cluster.k8s.io/v1alpha1/cluster-name"]},
+        {"Name": "tag-value", "Values": ["chaos-cluster"]},
+        {"Name": "tag-key", "Values": ["kubernetes.io/cluster/chaos-cluster"]},
+        {"Name": "tag-value", "Values": ["owned"]},
     ]
 
-    stop_instances(filters=filters, az='us-west-2')
+    stop_instances(filters=filters, az="us-west-2")
 
     called_filters = deepcopy(filters)
-    called_filters.append(
-        {'Name': 'availability-zone', 'Values': ['us-west-2']})
+    called_filters.append({"Name": "availability-zone", "Values": ["us-west-2"]})
     client.describe_instances.assert_called_with(Filters=called_filters)
-    client.stop_instances.assert_called_with(
-        InstanceIds=[inst_1_id], Force=False)
+    client.stop_instances.assert_called_with(InstanceIds=[inst_1_id], Force=False)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_instance_with_no_lifecycle(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_id = "i-1234567890abcdef0"
     client.describe_instances.return_value = {
-        'Reservations':
-        [{'Instances': [{'InstanceId': inst_id}]}]
+        "Reservations": [{"Instances": [{"InstanceId": inst_id}]}]
     }
     stop_instance(inst_id)
-    client.stop_instances.assert_called_with(
-        InstanceIds=[inst_id], Force=False)
+    client.stop_instances.assert_called_with(InstanceIds=[inst_id], Force=False)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_stop_normal_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_id = "i-1234567890abcdef0"
     client.describe_instances.return_value = {
-        'Reservations':
-        [{'Instances': [{
-            'InstanceId': inst_id,
-            'InstanceLifecycle': 'normal'
-        }]}]
+        "Reservations": [
+            {"Instances": [{"InstanceId": inst_id, "InstanceLifecycle": "normal"}]}
+        ]
     }
     stop_instance(inst_id)
-    client.stop_instances.assert_called_with(
-        InstanceIds=[inst_id], Force=False)
+    client.stop_instances.assert_called_with(InstanceIds=[inst_id], Force=False)
 
 
 ###
@@ -264,86 +263,101 @@ def test_stop_normal_instance(aws_client):
 def test_terminate_instance_no_values():
     with pytest.raises(FailedActivity) as x:
         terminate_instance()
-    assert 'To terminate an EC2, you must specify the instance-id, ' \
-           'an Availability Zone, or provide a set of filters' in str(x.value)
+    assert (
+        "To terminate an EC2, you must specify the instance-id, "
+        "an Availability Zone, or provide a set of filters" in str(x.value)
+    )
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_terminate_instance_az_no_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    az = 'us-west-2'
-    client.describe_instances.return_value = {
-        'Reservations': [{'Instances': []}]}
-    filters = [{'Name': 'availability-zone', 'Values': ['us-west-2']}]
+    az = "us-west-2"
+    client.describe_instances.return_value = {"Reservations": [{"Instances": []}]}
+    filters = [{"Name": "availability-zone", "Values": ["us-west-2"]}]
     with pytest.raises(FailedActivity) as x:
         terminate_instance(az=az)
     assert "No instances found matching filters: %s" % filters in str(x.value)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_terminate_normal_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_id = "i-1234567890abcdef0"
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [{
-            'InstanceId': inst_id, 'InstanceLifecycle': 'normal'}]}]}
+        "Reservations": [
+            {"Instances": [{"InstanceId": inst_id, "InstanceLifecycle": "normal"}]}
+        ]
+    }
     terminate_instance(inst_id)
     client.terminate_instances.assert_called_with(InstanceIds=[inst_id])
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_terminate_spot_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_id = "i-1234567890abcdef0"
-    spot_request_id = 'sir-abcdef01'
+    spot_request_id = "sir-abcdef01"
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [{
-            'InstanceId': inst_id, 'InstanceLifecycle': 'spot',
-            'SpotInstanceRequestId': spot_request_id}]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "InstanceId": inst_id,
+                        "InstanceLifecycle": "spot",
+                        "SpotInstanceRequestId": spot_request_id,
+                    }
+                ]
+            }
+        ]
+    }
     terminate_instance(inst_id)
     client.cancel_spot_instance_requests.assert_called_with(
-        SpotInstanceRequestIds=[spot_request_id])
+        SpotInstanceRequestIds=[spot_request_id]
+    )
     client.terminate_instances.assert_called_with(InstanceIds=[inst_id])
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_terminate_random_az_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_id = "i-987654321fedcba"
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [{
-            'InstanceId': inst_id, 'InstanceLifecycle': 'normal'}]}]}
+        "Reservations": [
+            {"Instances": [{"InstanceId": inst_id, "InstanceLifecycle": "normal"}]}
+        ]
+    }
 
     terminate_instance(az="us-west-1")
     client.terminate_instances.assert_called_with(InstanceIds=[inst_id])
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_terminate_instance_by_filters(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     inst_1_id = "i-987654321fedcba"
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [{
-            'InstanceId': inst_1_id, 'InstanceLifecycle': 'normal'}]}]}
+        "Reservations": [
+            {"Instances": [{"InstanceId": inst_1_id, "InstanceLifecycle": "normal"}]}
+        ]
+    }
 
     filters = [
-        {'Name': 'instance-state-name', 'Values': ['running']},
-        {'Name': 'tag-value', 'Values': ['chaos-cluster']},
-        {'Name': 'tag-key', 'Values': ['kubernetes.io/cluster/chaos-cluster']},
-        {'Name': 'tag-value', 'Values': ['owned']},
-        {'Name': 'tag-key',
-         'Values': ['eksctl.cluster.k8s.io/v1alpha1/cluster-name']},
+        {"Name": "instance-state-name", "Values": ["running"]},
+        {"Name": "tag-value", "Values": ["chaos-cluster"]},
+        {"Name": "tag-key", "Values": ["kubernetes.io/cluster/chaos-cluster"]},
+        {"Name": "tag-value", "Values": ["owned"]},
+        {"Name": "tag-key", "Values": ["eksctl.cluster.k8s.io/v1alpha1/cluster-name"]},
     ]
-    terminate_instance(filters=filters, az='us-west-2')
+    terminate_instance(filters=filters, az="us-west-2")
 
     called_filters = deepcopy(filters)
-    called_filters.append(
-        {'Name': 'availability-zone', 'Values': ['us-west-2']})
+    called_filters.append({"Name": "availability-zone", "Values": ["us-west-2"]})
     client.describe_instances.assert_called_with(Filters=called_filters)
     client.terminate_instances.assert_called_with(InstanceIds=[inst_1_id])
 
@@ -354,553 +368,636 @@ def test_terminate_instance_by_filters(aws_client):
 def test_terminate_instances_no_values():
     with pytest.raises(FailedActivity) as x:
         terminate_instances()
-    assert 'To terminate instances, you must specify the instance-id, an ' \
-           'Availability Zone, or provide a set of filters' in str(x.value)
+    assert (
+        "To terminate instances, you must specify the instance-id, an "
+        "Availability Zone, or provide a set of filters" in str(x.value)
+    )
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_terminate_instances_az_no_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    az = 'us-west-2'
-    filters = [{'Name': 'availability-zone', 'Values': ['us-west-2']}]
-    client.describe_instances.return_value = {
-        'Reservations': [{'Instances': []}]}
+    az = "us-west-2"
+    filters = [{"Name": "availability-zone", "Values": ["us-west-2"]}]
+    client.describe_instances.return_value = {"Reservations": [{"Instances": []}]}
 
     with pytest.raises(FailedActivity) as x:
         terminate_instances(az=az)
     assert "No instances found matching filters: %s" % filters in str(x.value)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_terminate_normal_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    instance_ids = ["i-987654321fedcba", "i-392024ac3252ecb"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
-            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
-        ]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": instance_ids[0], "InstanceLifecycle": "normal"},
+                    {"InstanceId": instance_ids[1], "InstanceLifecycle": "normal"},
+                ]
+            }
+        ]
+    }
     terminate_instances(instance_ids)
     client.terminate_instances.assert_called_with(InstanceIds=instance_ids)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_terminate_spot_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
-    spot_ids = ['sir-abcdef01', 'sir-fedcba10']
+    instance_ids = ["i-987654321fedcba", "i-392024ac3252ecb"]
+    spot_ids = ["sir-abcdef01", "sir-fedcba10"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0],
-             'InstanceLifecycle': 'spot',
-             'SpotInstanceRequestId': spot_ids[0]},
-            {'InstanceId': instance_ids[1],
-             'InstanceLifecycle': 'spot',
-             'SpotInstanceRequestId': spot_ids[1]},
-        ]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "InstanceId": instance_ids[0],
+                        "InstanceLifecycle": "spot",
+                        "SpotInstanceRequestId": spot_ids[0],
+                    },
+                    {
+                        "InstanceId": instance_ids[1],
+                        "InstanceLifecycle": "spot",
+                        "SpotInstanceRequestId": spot_ids[1],
+                    },
+                ]
+            }
+        ]
+    }
     terminate_instances(instance_ids)
     client.cancel_spot_instance_requests.assert_called_with(
-        SpotInstanceRequestIds=spot_ids)
+        SpotInstanceRequestIds=spot_ids
+    )
     client.terminate_instances.assert_called_with(InstanceIds=instance_ids)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_terminate_random_az_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    instance_ids = ["i-987654321fedcba", "i-392024ac3252ecb"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
-            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
-        ]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": instance_ids[0], "InstanceLifecycle": "normal"},
+                    {"InstanceId": instance_ids[1], "InstanceLifecycle": "normal"},
+                ]
+            }
+        ]
+    }
 
     terminate_instances(az="us-west-1")
     client.terminate_instances.assert_called_with(InstanceIds=instance_ids)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_terminate_instances_by_filters(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    instance_ids = ["i-987654321fedcba", "i-392024ac3252ecb"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
-            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
-        ]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": instance_ids[0], "InstanceLifecycle": "normal"},
+                    {"InstanceId": instance_ids[1], "InstanceLifecycle": "normal"},
+                ]
+            }
+        ]
+    }
 
     filters = [
-        {'Name': 'instance-state-name', 'Values': ['running']},
-        {'Name': 'tag-value', 'Values': ['chaos-cluster']},
-        {'Name': 'tag-key', 'Values': ['kubernetes.io/cluster/chaos-cluster']},
-        {'Name': 'tag-value', 'Values': ['owned']},
-        {'Name': 'tag-key',
-         'Values': ['eksctl.cluster.k8s.io/v1alpha1/cluster-name']},
+        {"Name": "instance-state-name", "Values": ["running"]},
+        {"Name": "tag-value", "Values": ["chaos-cluster"]},
+        {"Name": "tag-key", "Values": ["kubernetes.io/cluster/chaos-cluster"]},
+        {"Name": "tag-value", "Values": ["owned"]},
+        {"Name": "tag-key", "Values": ["eksctl.cluster.k8s.io/v1alpha1/cluster-name"]},
     ]
-    terminate_instances(filters=filters, az='us-west-2')
+    terminate_instances(filters=filters, az="us-west-2")
 
     called_filters = deepcopy(filters)
-    called_filters.append(
-        {'Name': 'availability-zone', 'Values': ['us-west-2']})
+    called_filters.append({"Name": "availability-zone", "Values": ["us-west-2"]})
     client.describe_instances.assert_called_with(Filters=called_filters)
     client.terminate_instances.assert_called_with(InstanceIds=instance_ids)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_start_instances_by_id(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    instance_ids = ["i-987654321fedcba", "i-392024ac3252ecb"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
-            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
-        ]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": instance_ids[0], "InstanceLifecycle": "normal"},
+                    {"InstanceId": instance_ids[1], "InstanceLifecycle": "normal"},
+                ]
+            }
+        ]
+    }
     start_instances(instance_ids=instance_ids)
     client.describe_instances.assert_called_with(InstanceIds=instance_ids)
     client.start_instances.assert_called_with(InstanceIds=instance_ids)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_start_instances_by_filter(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-abcdef123456789']
+    instance_ids = ["i-987654321fedcba", "i-abcdef123456789"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
-            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
-        ]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": instance_ids[0], "InstanceLifecycle": "normal"},
+                    {"InstanceId": instance_ids[1], "InstanceLifecycle": "normal"},
+                ]
+            }
+        ]
+    }
 
     filters = [
-        {'Name': 'instance-state-name', 'Values': ['running']},
-        {'Name': 'tag-value', 'Values': ['chaos-cluster']},
-        {'Name': 'tag-key', 'Values': ['kubernetes.io/cluster/chaos-cluster']},
-        {'Name': 'tag-value', 'Values': ['owned']},
-        {'Name': 'tag-key',
-         'Values': ['eksctl.cluster.k8s.io/v1alpha1/cluster-name']},
+        {"Name": "instance-state-name", "Values": ["running"]},
+        {"Name": "tag-value", "Values": ["chaos-cluster"]},
+        {"Name": "tag-key", "Values": ["kubernetes.io/cluster/chaos-cluster"]},
+        {"Name": "tag-value", "Values": ["owned"]},
+        {"Name": "tag-key", "Values": ["eksctl.cluster.k8s.io/v1alpha1/cluster-name"]},
     ]
-    start_instances(filters=filters, az='us-west-2')
+    start_instances(filters=filters, az="us-west-2")
 
     called_filters = deepcopy(filters)
-    called_filters.append(
-        {'Name': 'availability-zone', 'Values': ['us-west-2']})
+    called_filters.append({"Name": "availability-zone", "Values": ["us-west-2"]})
     client.describe_instances.assert_called_with(Filters=called_filters)
     client.start_instances.assert_called_with(InstanceIds=instance_ids)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_start_instances_by_az(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-abcdef123456789']
+    instance_ids = ["i-987654321fedcba", "i-abcdef123456789"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
-            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
-        ]}]}
-    start_instances(az='us-west-2')
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": instance_ids[0], "InstanceLifecycle": "normal"},
+                    {"InstanceId": instance_ids[1], "InstanceLifecycle": "normal"},
+                ]
+            }
+        ]
+    }
+    start_instances(az="us-west-2")
 
-    az_filter = [{'Name': 'availability-zone', 'Values': ['us-west-2']}]
+    az_filter = [{"Name": "availability-zone", "Values": ["us-west-2"]}]
     client.describe_instances.assert_called_with(Filters=az_filter)
     client.start_instances.assert_called_with(InstanceIds=instance_ids)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_restart_instances_by_id(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    instance_ids = ["i-987654321fedcba", "i-392024ac3252ecb"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
-            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
-        ]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": instance_ids[0], "InstanceLifecycle": "normal"},
+                    {"InstanceId": instance_ids[1], "InstanceLifecycle": "normal"},
+                ]
+            }
+        ]
+    }
     restart_instances(instance_ids=instance_ids)
     client.describe_instances.assert_called_with(InstanceIds=instance_ids)
     client.reboot_instances.assert_called_with(InstanceIds=instance_ids)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_restart_instances_by_filter(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-abcdef123456789']
+    instance_ids = ["i-987654321fedcba", "i-abcdef123456789"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
-            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
-        ]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": instance_ids[0], "InstanceLifecycle": "normal"},
+                    {"InstanceId": instance_ids[1], "InstanceLifecycle": "normal"},
+                ]
+            }
+        ]
+    }
 
     filters = [
-        {'Name': 'instance-state-name', 'Values': ['running']},
-        {'Name': 'tag-value', 'Values': ['chaos-cluster']},
-        {'Name': 'tag-key', 'Values': ['kubernetes.io/cluster/chaos-cluster']},
-        {'Name': 'tag-value', 'Values': ['owned']},
-        {'Name': 'tag-key',
-         'Values': ['eksctl.cluster.k8s.io/v1alpha1/cluster-name']},
+        {"Name": "instance-state-name", "Values": ["running"]},
+        {"Name": "tag-value", "Values": ["chaos-cluster"]},
+        {"Name": "tag-key", "Values": ["kubernetes.io/cluster/chaos-cluster"]},
+        {"Name": "tag-value", "Values": ["owned"]},
+        {"Name": "tag-key", "Values": ["eksctl.cluster.k8s.io/v1alpha1/cluster-name"]},
     ]
-    restart_instances(filters=filters, az='us-west-2')
+    restart_instances(filters=filters, az="us-west-2")
 
     called_filters = deepcopy(filters)
-    called_filters.append(
-        {'Name': 'availability-zone', 'Values': ['us-west-2']})
+    called_filters.append({"Name": "availability-zone", "Values": ["us-west-2"]})
     client.describe_instances.assert_called_with(Filters=called_filters)
     client.reboot_instances.assert_called_with(InstanceIds=instance_ids)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_restart_instances_by_az(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-abcdef123456789']
+    instance_ids = ["i-987654321fedcba", "i-abcdef123456789"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0], 'InstanceLifecycle': 'normal'},
-            {'InstanceId': instance_ids[1], 'InstanceLifecycle': 'normal'},
-        ]}]}
-    restart_instances(az='us-west-2')
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": instance_ids[0], "InstanceLifecycle": "normal"},
+                    {"InstanceId": instance_ids[1], "InstanceLifecycle": "normal"},
+                ]
+            }
+        ]
+    }
+    restart_instances(az="us-west-2")
 
-    az_filter = [{'Name': 'availability-zone', 'Values': ['us-west-2']}]
+    az_filter = [{"Name": "availability-zone", "Values": ["us-west-2"]}]
     client.describe_instances.assert_called_with(Filters=az_filter)
     client.reboot_instances.assert_called_with(InstanceIds=instance_ids)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_detach_random_volume_ec2_id(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba']
+    instance_ids = ["i-987654321fedcba"]
     client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'InstanceId': 'i-987654321fedcba',
-                'BlockDeviceMappings': [
+        "Reservations": [
+            {
+                "Instances": [
                     {
-                        'DeviceName': '/dev/xvda',
-                        'Ebs': {'VolumeId': 'vol-00000001'}
-                    },
-                    {
-                        'DeviceName': '/dev/sdc',
-                        'Ebs': {'VolumeId': 'vol-00000002'}
-                    }]}]}]}
+                        "InstanceId": "i-987654321fedcba",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {"VolumeId": "vol-00000001"},
+                            },
+                            {
+                                "DeviceName": "/dev/sdc",
+                                "Ebs": {"VolumeId": "vol-00000002"},
+                            },
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
     client.detach_volume.return_value = {
-        'Device': '/dev/sdc',
-        'InstanceId': 'i-987654321fedcba',
-        'State': 'detaching',
-        'VolumeId': 'vol-00000002'}
+        "Device": "/dev/sdc",
+        "InstanceId": "i-987654321fedcba",
+        "State": "detaching",
+        "VolumeId": "vol-00000002",
+    }
 
     results = detach_random_volume(instance_ids=instance_ids)
 
-    client.describe_instances.assert_called_with(
-        InstanceIds=['i-987654321fedcba'])
+    client.describe_instances.assert_called_with(InstanceIds=["i-987654321fedcba"])
     client.detach_volume.assert_called_with(
-        Device='/dev/sdc',
+        Device="/dev/sdc",
         Force=True,
-        InstanceId='i-987654321fedcba',
-        VolumeId='vol-00000002')
-    assert results[0]['Device'] == '/dev/sdc'
+        InstanceId="i-987654321fedcba",
+        VolumeId="vol-00000002",
+    )
+    assert results[0]["Device"] == "/dev/sdc"
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_detach_random_volume_ec2_filter(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    filters = [{
-        'Name': 'block-device-mapping.device-name',
-        'Values': ['/dev/sdb']}]
+    filters = [{"Name": "block-device-mapping.device-name", "Values": ["/dev/sdb"]}]
     client.describe_instances.return_value = {
-        'Reservations': [{
-            'Instances': [{
-                'InstanceId': 'i-987654321fedcba',
-                'BlockDeviceMappings': [
+        "Reservations": [
+            {
+                "Instances": [
                     {
-                        'DeviceName': '/dev/xvda',
-                        'Ebs': {'VolumeId': 'vol-00000001'}
-                    },
-                    {
-                        'DeviceName': '/dev/sdb',
-                        'Ebs': {'VolumeId': 'vol-00000002'}
-                    }]}]}]}
+                        "InstanceId": "i-987654321fedcba",
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda",
+                                "Ebs": {"VolumeId": "vol-00000001"},
+                            },
+                            {
+                                "DeviceName": "/dev/sdb",
+                                "Ebs": {"VolumeId": "vol-00000002"},
+                            },
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
     client.detach_volume.return_value = {
-        'Device': '/dev/sdb',
-        'InstanceId': 'i-987654321fedcba',
-        'State': 'detaching',
-        'VolumeId': 'vol-00000002'}
+        "Device": "/dev/sdb",
+        "InstanceId": "i-987654321fedcba",
+        "State": "detaching",
+        "VolumeId": "vol-00000002",
+    }
 
     results = detach_random_volume(filters=filters)
 
-    client.describe_instances.assert_called_with(
-        Filters=filters)
+    client.describe_instances.assert_called_with(Filters=filters)
     client.detach_volume.assert_called_with(
-        Device='/dev/sdb',
+        Device="/dev/sdb",
         Force=True,
-        InstanceId='i-987654321fedcba',
-        VolumeId='vol-00000002')
-    assert results[0]['Device'] == '/dev/sdb'
+        InstanceId="i-987654321fedcba",
+        VolumeId="vol-00000002",
+    )
+    assert results[0]["Device"] == "/dev/sdb"
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_detach_random_volume_ec2_invalid_id(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba']
-    client.describe_instances.return_value = {'Reservations': []}
+    instance_ids = ["i-987654321fedcba"]
+    client.describe_instances.return_value = {"Reservations": []}
 
     with pytest.raises(FailedActivity) as x:
         detach_random_volume(instance_ids=instance_ids)
-    assert "no instances found matching: {'InstanceIds': %s}" % (
-        instance_ids) in str(x.value)
+    assert "no instances found matching: {'InstanceIds': %s}" % (instance_ids) in str(
+        x.value
+    )
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_detach_random_volume_ec2_invalid_filters(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    filters = [{
-        'Name': 'block-device-mapping.device-name',
-        'Values': ['/dev/sdb']}]
-    client.describe_instances.return_value = {'Reservations': []}
+    filters = [{"Name": "block-device-mapping.device-name", "Values": ["/dev/sdb"]}]
+    client.describe_instances.return_value = {"Reservations": []}
 
     with pytest.raises(FailedActivity) as x:
         detach_random_volume(filters=filters)
-    assert 'block-device-mapping.device-name' in str(x.value)
-    assert '/dev/sdb' in str(x.value)
+    assert "block-device-mapping.device-name" in str(x.value)
+    assert "/dev/sdb" in str(x.value)
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_attach_volume_ec2_id(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba']
+    instance_ids = ["i-987654321fedcba"]
     client.describe_instances.return_value = {
-            'Reservations': [
-                {'Instances': [{'InstanceId': 'i-987654321fedcba'}]}]}
+        "Reservations": [{"Instances": [{"InstanceId": "i-987654321fedcba"}]}]
+    }
 
-    client.get_paginator.return_value.paginate.return_value = [{
-            'Volumes': [
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Volumes": [
                 {
-                    'VolumeId': 'vol-00000001',
-                    'Tags': [{
-                        'Key': 'ChaosToolkitDetached',
-                        'Value': 'DeviceName=/dev/sdc;InstanceId=%s' % (
-                            instance_ids[0])}]
+                    "VolumeId": "vol-00000001",
+                    "Tags": [
+                        {
+                            "Key": "ChaosToolkitDetached",
+                            "Value": "DeviceName=/dev/sdc;InstanceId=%s"
+                            % (instance_ids[0]),
+                        }
+                    ],
                 },
                 {
-                    'VolumeId': 'vol-00000002',
-                    'Tags': [{
-                        'Key': 'ChaosToolkitDetached',
-                        'Value': 'DeviceName=/dev/sdb;InstanceId='
-                                 'i-987654321fabcde'
-                    }]}]}]
+                    "VolumeId": "vol-00000002",
+                    "Tags": [
+                        {
+                            "Key": "ChaosToolkitDetached",
+                            "Value": "DeviceName=/dev/sdb;InstanceId="
+                            "i-987654321fabcde",
+                        }
+                    ],
+                },
+            ]
+        }
+    ]
 
     client.attach_volume.return_value = {
-        'DeviceName': '/dev/sdc',
-        'InstanceId': instance_ids[0],
-        'State': 'attaching',
-        'VolumeId': 'vol-00000001'}
+        "DeviceName": "/dev/sdc",
+        "InstanceId": instance_ids[0],
+        "State": "attaching",
+        "VolumeId": "vol-00000001",
+    }
 
     results = attach_volume(instance_ids=instance_ids)
 
     client.describe_instances.assert_called_with(InstanceIds=instance_ids)
-    client.get_paginator.return_value.paginate.assert_called_with(Filters=[{
-        'Name': 'tag-key', 'Values': ['ChaosToolkitDetached']}])
+    client.get_paginator.return_value.paginate.assert_called_with(
+        Filters=[{"Name": "tag-key", "Values": ["ChaosToolkitDetached"]}]
+    )
     client.attach_volume.assert_called_with(
-        Device='/dev/sdc',
-        InstanceId=instance_ids[0],
-        VolumeId='vol-00000001')
-    assert results[0]['DeviceName'] == '/dev/sdc'
+        Device="/dev/sdc", InstanceId=instance_ids[0], VolumeId="vol-00000001"
+    )
+    assert results[0]["DeviceName"] == "/dev/sdc"
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_attach_volume_ec2_filter(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba']
-    filters = [{'Name': 'instance-state-name', 'Values': ['running']}]
+    instance_ids = ["i-987654321fedcba"]
+    filters = [{"Name": "instance-state-name", "Values": ["running"]}]
     client.describe_instances.return_value = {
-            'Reservations': [
-                {'Instances': [{
-                    'InstanceId': 'i-987654321fedcba',
-                    'State': {
-                        'Code': 16,
-                        'Name': 'running'
-                    }}]}]}
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "InstanceId": "i-987654321fedcba",
+                        "State": {"Code": 16, "Name": "running"},
+                    }
+                ]
+            }
+        ]
+    }
 
-    client.get_paginator.return_value.paginate.return_value = [{
-            'Volumes': [
+    client.get_paginator.return_value.paginate.return_value = [
+        {
+            "Volumes": [
                 {
-                    'VolumeId': 'vol-00000001',
-                    'Tags': [{
-                        'Key': 'ChaosToolkitDetached',
-                        'Value': 'DeviceName=/dev/sdb;InstanceId=%s' % (
-                            instance_ids[0])}]
+                    "VolumeId": "vol-00000001",
+                    "Tags": [
+                        {
+                            "Key": "ChaosToolkitDetached",
+                            "Value": "DeviceName=/dev/sdb;InstanceId=%s"
+                            % (instance_ids[0]),
+                        }
+                    ],
                 },
                 {
-                    'VolumeId': 'vol-00000002',
-                    'Tags': [{
-                        'Key': 'ChaosToolkitDetached',
-                        'Value': 'DeviceName=/dev/sdb;InstanceId='
-                                 'i-987654321fabcde'
-                    }]}]}]
+                    "VolumeId": "vol-00000002",
+                    "Tags": [
+                        {
+                            "Key": "ChaosToolkitDetached",
+                            "Value": "DeviceName=/dev/sdb;InstanceId="
+                            "i-987654321fabcde",
+                        }
+                    ],
+                },
+            ]
+        }
+    ]
 
     client.attach_volume.return_value = {
-        'DeviceName': '/dev/sdb',
-        'InstanceId': instance_ids[0],
-        'State': 'attaching',
-        'VolumeId': 'vol-00000001'}
+        "DeviceName": "/dev/sdb",
+        "InstanceId": instance_ids[0],
+        "State": "attaching",
+        "VolumeId": "vol-00000001",
+    }
 
     results = attach_volume(filters=filters)
 
     client.describe_instances.assert_called_with(Filters=filters)
-    client.get_paginator.return_value.paginate.assert_called_with(Filters=[{
-        'Name': 'tag-key', 'Values': ['ChaosToolkitDetached']}])
+    client.get_paginator.return_value.paginate.assert_called_with(
+        Filters=[{"Name": "tag-key", "Values": ["ChaosToolkitDetached"]}]
+    )
     client.attach_volume.assert_called_with(
-        Device='/dev/sdb',
-        InstanceId=instance_ids[0],
-        VolumeId='vol-00000001')
-    assert results[0]['DeviceName'] == '/dev/sdb'
+        Device="/dev/sdb", InstanceId=instance_ids[0], VolumeId="vol-00000001"
+    )
+    assert results[0]["DeviceName"] == "/dev/sdb"
 
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
 def test_authorize_security_group_ingress_with_ingress_security_group(aws_client):
-    #arrange
+    # arrange
     client = MagicMock()
     aws_client.return_value = client
-    requested_security_group_id='sg-123456789abc'
-    ingress_security_group_id='sg-123456789cba'
-    ip_protocol='tcp'
-    from_port=0
-    to_port=80
-    #act
+    requested_security_group_id = "sg-123456789abc"
+    ingress_security_group_id = "sg-123456789cba"
+    ip_protocol = "tcp"
+    from_port = 0
+    to_port = 80
+    # act
     authorize_security_group_ingress(
         requested_security_group_id=requested_security_group_id,
         ip_protocol=ip_protocol,
         from_port=from_port,
         to_port=to_port,
-        ingress_security_group_id=ingress_security_group_id
+        ingress_security_group_id=ingress_security_group_id,
     )
-    #assert
+    # assert
     client.authorize_security_group_ingress.assert_called_with(
         GroupId=requested_security_group_id,
         IpPermissions=[
             {
-                'IpProtocol': ip_protocol,
-                'FromPort': from_port,
-                'ToPort': to_port,
-                'IpRanges': [{}],
-                'UserIdGroupPairs': [
-                    {
-                        'GroupId': ingress_security_group_id
-                    }
-                ]
+                "IpProtocol": ip_protocol,
+                "FromPort": from_port,
+                "ToPort": to_port,
+                "IpRanges": [{}],
+                "UserIdGroupPairs": [{"GroupId": ingress_security_group_id}],
             }
-        ]
+        ],
     )
-    
-    
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
-def test_authorize_security_group_ingress_with_cidr_ip(aws_client):
-    #arrange
-    client = MagicMock()
-    aws_client.return_value = client
-    requested_security_group_id='sg-123456789abc'
-    cidr_ip='0.0.0.0/0'
-    ip_protocol='tcp'
-    from_port=0
-    to_port=80
-    #act
-    authorize_security_group_ingress(
-        requested_security_group_id=requested_security_group_id,
-        ip_protocol=ip_protocol,
-        from_port=from_port,
-        to_port=to_port,
-        cidr_ip=cidr_ip
-    )
-    #assert
-    client.authorize_security_group_ingress.assert_called_with(
-        GroupId=requested_security_group_id,
-        IpPermissions=[
-            {
-                'IpProtocol': ip_protocol,
-                'FromPort': from_port,
-                'ToPort': to_port,
-                'IpRanges': [{'CidrIp': cidr_ip}],
-                'UserIdGroupPairs': [{}]
-            }
-        ]
-    )
-    
-    
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
-def test_revoke_security_group_ingress_with_ingress_security_group(aws_client):
-    #arrange
-    client = MagicMock()
-    aws_client.return_value = client
-    requested_security_group_id='sg-123456789abc'
-    ingress_security_group_id='sg-123456789cba'
-    ip_protocol='tcp'
-    from_port=0
-    to_port=80
-    #act
-    revoke_security_group_ingress(
-        requested_security_group_id=requested_security_group_id,
-        ip_protocol=ip_protocol,
-        from_port=from_port,
-        to_port=to_port,
-        ingress_security_group_id=ingress_security_group_id
-    )
-    #assert
-    client.revoke_security_group_ingress.assert_called_with(
-        GroupId=requested_security_group_id,
-        IpPermissions=[
-            {
-                'IpProtocol': ip_protocol,
-                'FromPort': from_port,
-                'ToPort': to_port,
-                'IpRanges': [{}],
-                'UserIdGroupPairs': [
-                    {
-                        'GroupId': ingress_security_group_id
-                    }
-                ]
-            }
-        ]
-    )
-    
 
-@patch('chaosaws.ec2.actions.aws_client', autospec=True)
-def test_revoke_security_group_ingress_with_cidr_ip(aws_client):
-    #arrange
+
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
+def test_authorize_security_group_ingress_with_cidr_ip(aws_client):
+    # arrange
     client = MagicMock()
     aws_client.return_value = client
-    requested_security_group_id='sg-123456789abc'
-    cidr_ip='0.0.0.0/0'
-    ip_protocol='tcp'
-    from_port=0
-    to_port=80
-    #act
+    requested_security_group_id = "sg-123456789abc"
+    cidr_ip = "0.0.0.0/0"
+    ip_protocol = "tcp"
+    from_port = 0
+    to_port = 80
+    # act
+    authorize_security_group_ingress(
+        requested_security_group_id=requested_security_group_id,
+        ip_protocol=ip_protocol,
+        from_port=from_port,
+        to_port=to_port,
+        cidr_ip=cidr_ip,
+    )
+    # assert
+    client.authorize_security_group_ingress.assert_called_with(
+        GroupId=requested_security_group_id,
+        IpPermissions=[
+            {
+                "IpProtocol": ip_protocol,
+                "FromPort": from_port,
+                "ToPort": to_port,
+                "IpRanges": [{"CidrIp": cidr_ip}],
+                "UserIdGroupPairs": [{}],
+            }
+        ],
+    )
+
+
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
+def test_revoke_security_group_ingress_with_ingress_security_group(aws_client):
+    # arrange
+    client = MagicMock()
+    aws_client.return_value = client
+    requested_security_group_id = "sg-123456789abc"
+    ingress_security_group_id = "sg-123456789cba"
+    ip_protocol = "tcp"
+    from_port = 0
+    to_port = 80
+    # act
     revoke_security_group_ingress(
         requested_security_group_id=requested_security_group_id,
         ip_protocol=ip_protocol,
         from_port=from_port,
         to_port=to_port,
-        cidr_ip=cidr_ip
+        ingress_security_group_id=ingress_security_group_id,
     )
-    #assert
+    # assert
     client.revoke_security_group_ingress.assert_called_with(
         GroupId=requested_security_group_id,
         IpPermissions=[
             {
-                'IpProtocol': ip_protocol,
-                'FromPort': from_port,
-                'ToPort': to_port,
-                'IpRanges': [{'CidrIp': cidr_ip}],
-                'UserIdGroupPairs': [{}]
+                "IpProtocol": ip_protocol,
+                "FromPort": from_port,
+                "ToPort": to_port,
+                "IpRanges": [{}],
+                "UserIdGroupPairs": [{"GroupId": ingress_security_group_id}],
             }
-        ]
+        ],
+    )
+
+
+@patch("chaosaws.ec2.actions.aws_client", autospec=True)
+def test_revoke_security_group_ingress_with_cidr_ip(aws_client):
+    # arrange
+    client = MagicMock()
+    aws_client.return_value = client
+    requested_security_group_id = "sg-123456789abc"
+    cidr_ip = "0.0.0.0/0"
+    ip_protocol = "tcp"
+    from_port = 0
+    to_port = 80
+    # act
+    revoke_security_group_ingress(
+        requested_security_group_id=requested_security_group_id,
+        ip_protocol=ip_protocol,
+        from_port=from_port,
+        to_port=to_port,
+        cidr_ip=cidr_ip,
+    )
+    # assert
+    client.revoke_security_group_ingress.assert_called_with(
+        GroupId=requested_security_group_id,
+        IpPermissions=[
+            {
+                "IpProtocol": ip_protocol,
+                "FromPort": from_port,
+                "ToPort": to_port,
+                "IpRanges": [{"CidrIp": cidr_ip}],
+                "UserIdGroupPairs": [{}],
+            }
+        ],
     )

--- a/tests/ec2/test_ec2_probes.py
+++ b/tests/ec2/test_ec2_probes.py
@@ -1,76 +1,86 @@
-import pytest
-
 from unittest.mock import MagicMock, patch
 
-from chaosaws.ec2.probes import (
-    describe_instances, count_instances, instance_state)
+import pytest
 from chaoslib.exceptions import FailedActivity
 
+from chaosaws.ec2.probes import count_instances, describe_instances, instance_state
 
-@patch('chaosaws.ec2.probes.aws_client', autospec=True)
+
+@patch("chaosaws.ec2.probes.aws_client", autospec=True)
 def test_describe_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    filters = [{'Name': 'availability-zone', 'Values': ["us-west-1"]}]
+    filters = [{"Name": "availability-zone", "Values": ["us-west-1"]}]
     describe_instances(filters)
     client.describe_instances.assert_called_with(Filters=filters)
 
 
-@patch('chaosaws.ec2.probes.aws_client', autospec=True)
+@patch("chaosaws.ec2.probes.aws_client", autospec=True)
 def test_count_instances(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    filters = [{'Name': 'availability-zone', 'Values': ["us-west-1"]}]
+    filters = [{"Name": "availability-zone", "Values": ["us-west-1"]}]
     count_instances(filters)
     client.describe_instances.assert_called_with(Filters=filters)
 
 
-@patch('chaosaws.ec2.probes.aws_client', autospec=True)
+@patch("chaosaws.ec2.probes.aws_client", autospec=True)
 def test_instance_state_no_state(aws_client):
-    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    instance_ids = ["i-987654321fedcba", "i-392024ac3252ecb"]
     with pytest.raises(TypeError) as x:
         instance_state(instance_ids=instance_ids)
     assert "missing 1 required positional argument: 'state'" in str(x.value)
 
 
-@patch('chaosaws.ec2.probes.aws_client', autospec=True)
+@patch("chaosaws.ec2.probes.aws_client", autospec=True)
 def test_instance_state_no_query(aws_client):
-    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    instance_ids = ["i-987654321fedcba", "i-392024ac3252ecb"]
     with pytest.raises(FailedActivity) as x:
-        instance_state(state='running')
-    assert 'Probe "instance_state" missing required parameter ' \
-           '"instance_ids" or "filters"' in str(x.value)
+        instance_state(state="running")
+    assert (
+        'Probe "instance_state" missing required parameter '
+        '"instance_ids" or "filters"' in str(x.value)
+    )
 
 
-@patch('chaosaws.ec2.probes.aws_client', autospec=True)
+@patch("chaosaws.ec2.probes.aws_client", autospec=True)
 def test_instance_state(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    instance_ids = ['i-987654321fedcba', 'i-392024ac3252ecb']
+    instance_ids = ["i-987654321fedcba", "i-392024ac3252ecb"]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': instance_ids[0], 'State': {'Name': 'running'}},
-            {'InstanceId': instance_ids[1], 'State': {'Name': 'running'}},
-        ]}]}
-    results = instance_state(
-        state='running',
-        instance_ids=instance_ids)
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": instance_ids[0], "State": {"Name": "running"}},
+                    {"InstanceId": instance_ids[1], "State": {"Name": "running"}},
+                ]
+            }
+        ]
+    }
+    results = instance_state(state="running", instance_ids=instance_ids)
     client.describe_instances.assert_called_with(InstanceIds=instance_ids)
     assert results
 
 
-@patch('chaosaws.ec2.probes.aws_client', autospec=True)
+@patch("chaosaws.ec2.probes.aws_client", autospec=True)
 def test_instance_state_filters(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    filters = [{'Name': 'instance-type', 'Values': ['t2.large']}]
+    filters = [{"Name": "instance-type", "Values": ["t2.large"]}]
     client.describe_instances.return_value = {
-        'Reservations': [{'Instances': [
-            {'InstanceId': 'i-987654321fedcba',
-             'State': {'Name': 'running'},
-             'InstanceType': 't2.large'}]}]}
-    results = instance_state(
-        state='running',
-        filters=filters)
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "InstanceId": "i-987654321fedcba",
+                        "State": {"Name": "running"},
+                        "InstanceType": "t2.large",
+                    }
+                ]
+            }
+        ]
+    }
+    results = instance_state(state="running", filters=filters)
     client.describe_instances.assert_called_with(Filters=filters)
     assert results

--- a/tests/ec2/test_ec2_probes.py
+++ b/tests/ec2/test_ec2_probes.py
@@ -34,7 +34,6 @@ def test_instance_state_no_state(aws_client):
 
 @patch("chaosaws.ec2.probes.aws_client", autospec=True)
 def test_instance_state_no_query(aws_client):
-    instance_ids = ["i-987654321fedcba", "i-392024ac3252ecb"]
     with pytest.raises(FailedActivity) as x:
         instance_state(state="running")
     assert (

--- a/tests/ecs/test_ecs_actions.py
+++ b/tests/ecs/test_ecs_actions.py
@@ -7,46 +7,52 @@ from botocore.exceptions import ClientError
 from chaoslib.exceptions import FailedActivity
 
 from chaosaws.ecs.actions import (
-    delete_cluster, delete_service, deregister_container_instance, stop_task,
-    stop_random_tasks, set_service_placement_strategy, update_desired_count,
-    set_service_deployment_configuration, tag_resource, untag_resource,
-    update_container_instances_state
+    delete_cluster,
+    delete_service,
+    deregister_container_instance,
+    set_service_deployment_configuration,
+    set_service_placement_strategy,
+    stop_random_tasks,
+    stop_task,
+    tag_resource,
+    untag_resource,
+    update_container_instances_state,
+    update_desired_count,
 )
 
-data_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+data_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 
 def read_configs(filename):
     config = os.path.join(data_path, filename)
-    with open(config, 'r') as fh:
+    with open(config, "r") as fh:
         return loads(fh.read())
 
 
 def mock_client_error(*args, **kwargs):
     return ClientError(
-        operation_name=kwargs['op'],
-        error_response={'Error': {
-            'Code': kwargs['Code'],
-            'Message': kwargs['Message']
-        }}
+        operation_name=kwargs["op"],
+        error_response={
+            "Error": {"Code": kwargs["Code"], "Message": kwargs["Message"]}
+        },
     )
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_stop_random_tasks_no_count_or_percent(aws_client):
     with pytest.raises(FailedActivity) as x:
-        stop_random_tasks(cluster='ecs-cluster')
+        stop_random_tasks(cluster="ecs-cluster")
     assert 'Must specify one of "task_count", "task_percent"' in str(x.value)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_stop_random_tasks_both_count_and_percent(aws_client):
     with pytest.raises(FailedActivity) as x:
-        stop_random_tasks(cluster='ecs-cluster', task_count=1, task_percent=1)
+        stop_random_tasks(cluster="ecs-cluster", task_count=1, task_percent=1)
     assert 'Must specify one of "task_count", "task_percent"' in str(x.value)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_stop_random_tasks_count_too_high(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -54,18 +60,28 @@ def test_stop_random_tasks_count_too_high(aws_client):
     task_count = 3
     reason = "unit-test"
     client.list_tasks.side_effect = [
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"], 'nextToken': 'token0'},
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"], 'nextToken': None}
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+            ],
+            "nextToken": "token0",
+        },
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+            ],
+            "nextToken": None,
+        },
     ]
 
     with pytest.raises(FailedActivity) as x:
         stop_random_tasks(cluster=cluster, task_count=task_count, reason=reason)
-    assert 'Not enough running tasks in ecs-cluster to satisfy stop count 3 (2)' in str(x.value)
+    assert "Not enough running tasks in ecs-cluster to satisfy stop count 3 (2)" in str(
+        x.value
+    )
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_stop_random_tasks_count_no_service(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -73,18 +89,35 @@ def test_stop_random_tasks_count_no_service(aws_client):
     task_count = 2
     reason = "unit-test"
     client.list_tasks.side_effect = [
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"], 'nextToken': 'token0'},
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"], 'nextToken': None}
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+            ],
+            "nextToken": "token0",
+        },
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+            ],
+            "nextToken": None,
+        },
     ]
     stop_random_tasks(cluster=cluster, task_count=task_count, reason=reason)
 
     assert client.stop_task.call_count == 2
-    client.stop_task.assert_any_call(cluster=cluster, task="arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da", reason=reason)
-    client.stop_task.assert_any_call(cluster=cluster, task="arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk", reason=reason)
+    client.stop_task.assert_any_call(
+        cluster=cluster,
+        task="arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da",
+        reason=reason,
+    )
+    client.stop_task.assert_any_call(
+        cluster=cluster,
+        task="arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk",
+        reason=reason,
+    )
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_stop_random_tasks_percent_no_service(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -92,27 +125,38 @@ def test_stop_random_tasks_percent_no_service(aws_client):
     task_percent = 50
     reason = "unit-test"
     client.list_tasks.side_effect = [
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"], 'nextToken': 'token0'},
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"], 'nextToken': None}
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+            ],
+            "nextToken": "token0",
+        },
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+            ],
+            "nextToken": None,
+        },
     ]
     stop_random_tasks(cluster=cluster, task_percent=task_percent, reason=reason)
 
     assert client.stop_task.call_count == 1
-    task_calls = ["arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da", "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"]
+    task_calls = [
+        "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da",
+        "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk",
+    ]
 
     ex = None
     for i in task_calls:
         try:
-            client.stop_task.assert_called_with(
-                cluster=cluster, reason=reason, task=i)
+            client.stop_task.assert_called_with(cluster=cluster, reason=reason, task=i)
             return True
         except AssertionError as e:
             ex = e.args
     raise AssertionError(ex)
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_stop_random_tasks_percent_yes_service(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -121,27 +165,40 @@ def test_stop_random_tasks_percent_yes_service(aws_client):
     reason = "unit-test"
     service = "ecs-service"
     client.list_tasks.side_effect = [
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"], 'nextToken': 'token0'},
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"], 'nextToken': None}
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+            ],
+            "nextToken": "token0",
+        },
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+            ],
+            "nextToken": None,
+        },
     ]
-    stop_random_tasks(cluster=cluster, service=service, task_percent=task_percent, reason=reason)
+    stop_random_tasks(
+        cluster=cluster, service=service, task_percent=task_percent, reason=reason
+    )
 
     assert client.stop_task.call_count == 1
-    task_calls = ["arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da", "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"]
+    task_calls = [
+        "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da",
+        "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk",
+    ]
 
     ex = None
     for i in task_calls:
         try:
-            client.stop_task.assert_called_with(
-                cluster=cluster, reason=reason, task=i)
+            client.stop_task.assert_called_with(cluster=cluster, reason=reason, task=i)
             return True
         except AssertionError as e:
             ex = e.args
     raise AssertionError(ex)
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_stop_random_tasks_count_yes_service(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -150,18 +207,37 @@ def test_stop_random_tasks_count_yes_service(aws_client):
     reason = "unit-test"
     service = "ecs-service"
     client.list_tasks.side_effect = [
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"], 'nextToken': 'token0'},
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"], 'nextToken': None}
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+            ],
+            "nextToken": "token0",
+        },
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+            ],
+            "nextToken": None,
+        },
     ]
-    stop_random_tasks(cluster=cluster, service=service, task_count=task_count, reason=reason)
+    stop_random_tasks(
+        cluster=cluster, service=service, task_count=task_count, reason=reason
+    )
 
     assert client.stop_task.call_count == 2
-    client.stop_task.assert_any_call(cluster=cluster, task="arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da", reason=reason)
-    client.stop_task.assert_any_call(cluster=cluster, task="arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk", reason=reason)
+    client.stop_task.assert_any_call(
+        cluster=cluster,
+        task="arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da",
+        reason=reason,
+    )
+    client.stop_task.assert_any_call(
+        cluster=cluster,
+        task="arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk",
+        reason=reason,
+    )
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_stop_task(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -169,11 +245,10 @@ def test_stop_task(aws_client):
     task_id = "16fd2706-8baf-433b-82eb-8c7fada847da"
     reason = "unit test"
     stop_task(cluster=cluster, task_id=task_id, reason=reason)
-    client.stop_task.assert_called_with(
-        cluster=cluster, task=task_id, reason=reason)
+    client.stop_task.assert_called_with(cluster=cluster, task=task_id, reason=reason)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_stop_tasks(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -181,19 +256,29 @@ def test_stop_tasks(aws_client):
     service = "arn:aws:ecs:us-east-1:012345678910:service/my-http-service"
     reason = "unit test"
     client.list_tasks.side_effect = [
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"], 'nextToken': 'token0'},
-        {'taskArns': [
-            "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"], 'nextToken': None}
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+            ],
+            "nextToken": "token0",
+        },
+        {
+            "taskArns": [
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+            ],
+            "nextToken": None,
+        },
     ]
     stop_task(cluster=cluster, service=service, reason=reason)
 
     args, kwargs = client.stop_task.call_args
-    assert kwargs["task"] in ("16fd2706-8baf-433b-82eb-8c7fada847da",
-                              "84th9568-3tth-55g1-35ki-4o9amby245lk")
+    assert kwargs["task"] in (
+        "16fd2706-8baf-433b-82eb-8c7fada847da",
+        "84th9568-3tth-55g1-35ki-4o9amby245lk",
+    )
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_delete_service(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -202,15 +287,15 @@ def test_delete_service(aws_client):
 
     delete_service(cluster=cluster, service=svc1)
     client.update_service.assert_called_with(
-        cluster=cluster, service=svc1, desiredCount=0,
-        deploymentConfiguration={
-            'maximumPercent': 100,
-            'minimumHealthyPercent': 0
-        })
+        cluster=cluster,
+        service=svc1,
+        desiredCount=0,
+        deploymentConfiguration={"maximumPercent": 100, "minimumHealthyPercent": 0},
+    )
     client.delete_service.assert_called_with(cluster=cluster, service=svc1)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_delete_services(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -220,17 +305,17 @@ def test_delete_services(aws_client):
     svc2 = "arn:aws:ecs:us-east-1:012345678910:service/my-db-service"
 
     client.list_services.side_effect = [
-        {'serviceArns': [svc1], 'nextToken': 'token0'},
-        {'serviceArns': [svc2], 'nextToken': None}
+        {"serviceArns": [svc1], "nextToken": "token0"},
+        {"serviceArns": [svc2], "nextToken": None},
     ]
 
     delete_service(cluster=cluster)
     client.update_service.assert_called_with(
-        cluster=cluster, service=ANY, desiredCount=0,
-        deploymentConfiguration={
-            'maximumPercent': 100,
-            'minimumHealthyPercent': 0
-        })
+        cluster=cluster,
+        service=ANY,
+        desiredCount=0,
+        deploymentConfiguration={"maximumPercent": 100, "minimumHealthyPercent": 0},
+    )
     args, kwargs = client.update_service.call_args
     assert kwargs["service"] in ("my-http-service", "my-db-service")
 
@@ -239,7 +324,7 @@ def test_delete_services(aws_client):
     assert kwargs["service"] in ("my-http-service", "my-db-service")
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_delete_filtered_service(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -249,23 +334,22 @@ def test_delete_filtered_service(aws_client):
     svc2 = "arn:aws:ecs:us-east-1:012345678910:service/my-db-service"
 
     client.list_services.side_effect = [
-        {'serviceArns': [svc1], 'nextToken': 'token0'},
-        {'serviceArns': [svc2], 'nextToken': None}
+        {"serviceArns": [svc1], "nextToken": "token0"},
+        {"serviceArns": [svc2], "nextToken": None},
     ]
 
     delete_service(cluster=cluster, service_pattern="my-db")
     client.update_service.assert_called_with(
-        cluster=cluster, service="my-db-service", desiredCount=0,
-        deploymentConfiguration={
-            'maximumPercent': 100,
-            'minimumHealthyPercent': 0
-        })
+        cluster=cluster,
+        service="my-db-service",
+        desiredCount=0,
+        deploymentConfiguration={"maximumPercent": 100, "minimumHealthyPercent": 0},
+    )
 
-    client.delete_service.assert_called_with(
-        cluster=cluster, service="my-db-service")
+    client.delete_service.assert_called_with(cluster=cluster, service="my-db-service")
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_delete_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -275,7 +359,7 @@ def test_delete_cluster(aws_client):
     client.delete_cluster.assert_called_with(cluster=cluster)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_deregister_container_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -284,335 +368,334 @@ def test_deregister_container_instance(aws_client):
 
     deregister_container_instance(cluster=cluster, instance_id=inst)
     client.deregister_container_instance.assert_called_with(
-        cluster=cluster, containerInstance=inst, force=False)
+        cluster=cluster, containerInstance=inst, force=False
+    )
 
 
 def test_no_arguments_error():
     with pytest.raises(TypeError) as x:
         update_desired_count()
-    assert 'missing 3 required positional arguments' in str(x.value)
+    assert "missing 3 required positional arguments" in str(x.value)
 
 
 def test_missing_cluster_argument_error():
     with pytest.raises(TypeError) as x:
-        update_desired_count(service='my_service', desired_count=1)
+        update_desired_count(service="my_service", desired_count=1)
     assert "required positional argument: 'cluster'" in str(x.value)
 
 
 def test_missing_count_argument_error():
     with pytest.raises(TypeError) as x:
-        update_desired_count(
-            cluster='my_cluster', service='my_service')
+        update_desired_count(cluster="my_cluster", service="my_service")
     assert "required positional argument: 'desired_count'" in str(x.value)
 
 
 def test_missing_service_argument_error():
     with pytest.raises(TypeError) as x:
-        update_desired_count(
-            cluster='my_cluster', desired_count=0)
+        update_desired_count(cluster="my_cluster", desired_count=0)
     assert "required positional argument: 'service'" in str(x.value)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_update_desired_service_count(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    cluster = 'my_cluster'
-    service = 'my_service'
+    cluster = "my_cluster"
+    service = "my_service"
 
     client.describe_clusters = MagicMock(
         return_value={
-            'clusters': [{
-                'clusterArn': 'arn:aws:ecs:us-east-1::cluster/my_cluster',
-                'clusterName': 'my_cluster'
-            }]
+            "clusters": [
+                {
+                    "clusterArn": "arn:aws:ecs:us-east-1::cluster/my_cluster",
+                    "clusterName": "my_cluster",
+                }
+            ]
         }
     )
     client.describe_services = MagicMock(
         return_value={
-            'services': [{
-                'serviceArn': 'arn:aws:ecs:us-east-1::service/my_service',
-                'serviceName': 'my_service'
-            }]
+            "services": [
+                {
+                    "serviceArn": "arn:aws:ecs:us-east-1::service/my_service",
+                    "serviceName": "my_service",
+                }
+            ]
         }
     )
     client.update_service = MagicMock(
         return_value={
-            'service': {
-                'serviceArn': 'arn:aws:ecs:us-east-1::service/my_service',
-                'serviceName': 'my_service',
-                'desiredCount': 1
+            "service": {
+                "serviceArn": "arn:aws:ecs:us-east-1::service/my_service",
+                "serviceName": "my_service",
+                "desiredCount": 1,
             }
         }
     )
-    update_desired_count(
-        cluster=cluster, service=service, desired_count=1)
+    update_desired_count(cluster=cluster, service=service, desired_count=1)
     client.describe_clusters.assert_called_with(clusters=[cluster])
     client.update_service.assert_called_with(
-        cluster=cluster, service=service, desiredCount=1)
+        cluster=cluster, service=service, desiredCount=1
+    )
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_set_service_placement_strategy(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.describe_clusters.return_value = read_configs(
-        'describe_clusters_1.json')
-    client.describe_services.return_value = read_configs(
-        'describe_services_1.json')
-    client.update_service.return_value = read_configs('update_service_1.json')
+    client.describe_clusters.return_value = read_configs("describe_clusters_1.json")
+    client.describe_services.return_value = read_configs("describe_services_1.json")
+    client.update_service.return_value = read_configs("update_service_1.json")
 
     params = {
-        'cluster': 'MyTestEcsCluster',
-        'service': 'MyTestEcsService',
-        'placement_type': 'random'
+        "cluster": "MyTestEcsCluster",
+        "service": "MyTestEcsService",
+        "placement_type": "random",
     }
     set_service_placement_strategy(**params)
     client.update_service.assert_called_with(
-        cluster='MyTestEcsCluster',
-        service='MyTestEcsService',
-        placementStrategy=[{'type': 'random'}])
+        cluster="MyTestEcsCluster",
+        service="MyTestEcsService",
+        placementStrategy=[{"type": "random"}],
+    )
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_set_service_placement_strategy_invalid_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.describe_clusters.return_value = {'clusters': []}
+    client.describe_clusters.return_value = {"clusters": []}
 
     params = {
-        'cluster': 'MyInvalidCluster',
-        'service': 'MyTestEcsService',
-        'placement_type': 'random'
+        "cluster": "MyInvalidCluster",
+        "service": "MyTestEcsService",
+        "placement_type": "random",
     }
     with pytest.raises(FailedActivity) as e:
         set_service_placement_strategy(**params)
-    assert 'unable to locate cluster: MyInvalidCluster' in str(e)
+    assert "unable to locate cluster: MyInvalidCluster" in str(e)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_set_service_placement_strategy_invalid_service(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.describe_clusters.return_value = read_configs(
-        'describe_clusters_1.json')
-    client.describe_services.return_value = {'services': []}
+    client.describe_clusters.return_value = read_configs("describe_clusters_1.json")
+    client.describe_services.return_value = {"services": []}
 
     params = {
-        'cluster': 'MyTestEcsCluster',
-        'service': 'MyInvalidService',
-        'placement_type': 'random'
+        "cluster": "MyTestEcsCluster",
+        "service": "MyInvalidService",
+        "placement_type": "random",
     }
     with pytest.raises(FailedActivity) as e:
         set_service_placement_strategy(**params)
-    assert 'unable to locate service: MyInvalidService' in str(e)
+    assert "unable to locate service: MyInvalidService" in str(e)
 
 
 def test_set_service_placement_strategy_invalid_param_1():
     params = {
-        'cluster': 'MyTestEcsCluster',
-        'service': 'MyTestEcsService',
-        'placement_type': 'spread'
+        "cluster": "MyTestEcsCluster",
+        "service": "MyTestEcsService",
+        "placement_type": "spread",
     }
     with pytest.raises(FailedActivity) as e:
         set_service_placement_strategy(**params)
     assert '"placement_field" is required when using' in str(e)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_set_service_placement_strategy_invalid_param_2(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.describe_clusters.return_value = read_configs(
-        'describe_clusters_1.json')
-    client.describe_services.return_value = read_configs(
-        'describe_services_1.json')
+    client.describe_clusters.return_value = read_configs("describe_clusters_1.json")
+    client.describe_services.return_value = read_configs("describe_services_1.json")
 
     params = {
-        'op': 'UpdateService',
-        'Code': 'InvalidParameterException',
-        'Message': 'An error occurred (InvalidParameterException)'
+        "op": "UpdateService",
+        "Code": "InvalidParameterException",
+        "Message": "An error occurred (InvalidParameterException)",
     }
     client.update_service.side_effect = mock_client_error(**params)
 
     params = {
-        'cluster': 'MyTestEcsCluster',
-        'service': 'MyTestEcsService',
-        'placement_type': 'xrandom'
+        "cluster": "MyTestEcsCluster",
+        "service": "MyTestEcsService",
+        "placement_type": "xrandom",
     }
     with pytest.raises(FailedActivity) as e:
         set_service_placement_strategy(**params)
-    assert 'An error occurred (InvalidParameterException)' in str(e)
+    assert "An error occurred (InvalidParameterException)" in str(e)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_set_service_deployment_configuration(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.describe_clusters.return_value = read_configs(
-        'describe_clusters_1.json')
-    client.describe_services.return_value = read_configs(
-        'describe_services_1.json')
-    client.update_service.return_value = read_configs('update_service_2.json')
+    client.describe_clusters.return_value = read_configs("describe_clusters_1.json")
+    client.describe_services.return_value = read_configs("describe_services_1.json")
+    client.update_service.return_value = read_configs("update_service_2.json")
 
     params = {
-        'cluster': 'MyTestEcsCluster',
-        'service': 'MyTestEcsService',
-        'maximum_percent': 300,
-        'minimum_healthy_percent': 50
+        "cluster": "MyTestEcsCluster",
+        "service": "MyTestEcsService",
+        "maximum_percent": 300,
+        "minimum_healthy_percent": 50,
     }
     set_service_deployment_configuration(**params)
     client.update_service.assert_called_with(
-        cluster='MyTestEcsCluster',
-        service='MyTestEcsService',
-        deploymentConfiguration={
-            'maximumPercent': 300,
-            'minimumHealthyPercent': 50
-        })
+        cluster="MyTestEcsCluster",
+        service="MyTestEcsService",
+        deploymentConfiguration={"maximumPercent": 300, "minimumHealthyPercent": 50},
+    )
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_set_service_deployment_configuration_invalid_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.describe_clusters.return_value = {'clusters': []}
+    client.describe_clusters.return_value = {"clusters": []}
 
     params = {
-        'cluster': 'MyInvalidCluster',
-        'service': 'MyTestEcsService',
-        'maximum_percent': 100
+        "cluster": "MyInvalidCluster",
+        "service": "MyTestEcsService",
+        "maximum_percent": 100,
     }
     with pytest.raises(FailedActivity) as e:
         set_service_deployment_configuration(**params)
-    assert 'unable to locate cluster: MyInvalidCluster' in str(e)
+    assert "unable to locate cluster: MyInvalidCluster" in str(e)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_set_service_deployment_configuration_invalid_service(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    client.describe_clusters.return_value = read_configs(
-        'describe_clusters_1.json')
-    client.describe_services.return_value = {'services': []}
+    client.describe_clusters.return_value = read_configs("describe_clusters_1.json")
+    client.describe_services.return_value = {"services": []}
 
     params = {
-        'cluster': 'MyTestEcsCluster',
-        'service': 'MyInvalidService',
-        'maximum_percent': 100
+        "cluster": "MyTestEcsCluster",
+        "service": "MyInvalidService",
+        "maximum_percent": 100,
     }
     with pytest.raises(FailedActivity) as e:
         set_service_deployment_configuration(**params)
-    assert 'unable to locate service: MyInvalidService' in str(e)
+    assert "unable to locate service: MyInvalidService" in str(e)
 
 
 def test_set_service_deployment_configuration_invalid_minimum():
     params = {
-        'cluster': 'MyTestEcsCluster',
-        'service': 'MyTestEcsService',
-        'maximum_percent': 50,
-        'minimum_healthy_percent': 100
+        "cluster": "MyTestEcsCluster",
+        "service": "MyTestEcsService",
+        "maximum_percent": 50,
+        "minimum_healthy_percent": 100,
     }
     with pytest.raises(FailedActivity) as e:
         set_service_deployment_configuration(**params)
-    assert 'minimum_healthy_percent cannot be larger' in str(e)
+    assert "minimum_healthy_percent cannot be larger" in str(e)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_tag_resource(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.tag_resource.return_value = {}
 
-    arn = 'arn:aws:ecs:us-east-1:012345678910:cluster/MyTestEcsCluster'
-    tags = [{'key': 'Name', 'value': 'MyTestEcsCluster'}]
+    arn = "arn:aws:ecs:us-east-1:012345678910:cluster/MyTestEcsCluster"
+    tags = [{"key": "Name", "value": "MyTestEcsCluster"}]
     tag_resource(tags, arn)
     client.tag_resource.assert_called_with(resourceArn=arn, tags=tags)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_tag_resource_not_found(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.tag_resource.side_effect = mock_client_error(
-        op='TagResource',
-        Code='ClusterNotFoundException',
-        Message='An error occurred (ClusterNotFoundException) when calling the '
-                'TagResource operation: Cluster not found.'
+        op="TagResource",
+        Code="ClusterNotFoundException",
+        Message="An error occurred (ClusterNotFoundException) when calling the "
+        "TagResource operation: Cluster not found.",
     )
 
-    arn = 'arn:aws:ecs:us-east-1:012345678910:service/MyTestEcsCluster1/'
-    tags = [{'key': 'Name', 'value': 'MyTestEcsCluster'}]
+    arn = "arn:aws:ecs:us-east-1:012345678910:service/MyTestEcsCluster1/"
+    tags = [{"key": "Name", "value": "MyTestEcsCluster"}]
     with pytest.raises(FailedActivity) as e:
         tag_resource(tags, arn)
-    assert 'Cluster not found' in str(e)
+    assert "Cluster not found" in str(e)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_untag_resource(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.untag_resource.return_value = {}
 
-    arn = 'arn:aws:ecs:us-east-1:012345678910:service/MyTestEcsCluster/' \
-          'MyTestEcsService'
-    tag_keys = ['Purpose']
+    arn = (
+        "arn:aws:ecs:us-east-1:012345678910:service/MyTestEcsCluster/"
+        "MyTestEcsService"
+    )
+    tag_keys = ["Purpose"]
     untag_resource(tag_keys, arn)
     client.untag_resource.assert_called_with(resourceArn=arn, tagKeys=tag_keys)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_untag_resource_not_found(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.untag_resource.side_effect = mock_client_error(
-        op='UntagResource',
-        Code='ClusterNotFoundException',
-        Message='An error occurred (ClusterNotFoundException) when calling the '
-                'UntagResource operation: Cluster not found.'
+        op="UntagResource",
+        Code="ClusterNotFoundException",
+        Message="An error occurred (ClusterNotFoundException) when calling the "
+        "UntagResource operation: Cluster not found.",
     )
 
-    arn = 'arn:aws:ecs:us-east-1:012345678910:service/MyTestEcsCluster1/' \
-          'MyTestEcsService'
-    tag_keys = ['Purpose']
+    arn = (
+        "arn:aws:ecs:us-east-1:012345678910:service/MyTestEcsCluster1/"
+        "MyTestEcsService"
+    )
+    tag_keys = ["Purpose"]
     with pytest.raises(FailedActivity) as e:
         untag_resource(tag_keys, arn)
-    assert 'Cluster not found' in str(e)
+    assert "Cluster not found" in str(e)
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_update_container_instance_state(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.update_container_instance_state.return_value = read_configs(
-        'update_container_instance_state_1.json')
+        "update_container_instance_state_1.json"
+    )
 
-    arns = ['arn:aws:ecs:us-east-1:123456789012:container-instance/'
-            'a1b2c3d4-5678-90ab-cdef-11111']
+    arns = [
+        "arn:aws:ecs:us-east-1:123456789012:container-instance/"
+        "a1b2c3d4-5678-90ab-cdef-11111"
+    ]
 
     update_container_instances_state(
-        cluster='MyTestEcsCluster',
-        container_instances=arns,
-        status='DRAINING')
+        cluster="MyTestEcsCluster", container_instances=arns, status="DRAINING"
+    )
 
     client.update_container_instance_state.assert_called_with(
-        cluster='MyTestEcsCluster',
-        containerInstances=arns,
-        status='DRAINING')
+        cluster="MyTestEcsCluster", containerInstances=arns, status="DRAINING"
+    )
 
 
-@patch('chaosaws.ecs.actions.aws_client', autospec=True)
+@patch("chaosaws.ecs.actions.aws_client", autospec=True)
 def test_update_container_instance_state_invalid_status(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.update_container_instance_state.side_effect = mock_client_error(
-        op='UpdateContainerInstanceState',
-        Code='InvalidParameterException',
-        Message='Container instances status should be one of [ACTIVE,DRAINING]'
+        op="UpdateContainerInstanceState",
+        Code="InvalidParameterException",
+        Message="Container instances status should be one of [ACTIVE,DRAINING]",
     )
     with pytest.raises(FailedActivity) as e:
         update_container_instances_state(
-            cluster='MyTestEcsCluster',
-            container_instances=[
-                'arn:aws:ecs:us-east-1:x:container-instance/z'],
-            status='INVALID')
-    assert 'ACTIVE,DRAINING' in str(e)
+            cluster="MyTestEcsCluster",
+            container_instances=["arn:aws:ecs:us-east-1:x:container-instance/z"],
+            status="INVALID",
+        )
+    assert "ACTIVE,DRAINING" in str(e)

--- a/tests/ecs/test_ecs_actions.py
+++ b/tests/ecs/test_ecs_actions.py
@@ -62,13 +62,13 @@ def test_stop_random_tasks_count_too_high(aws_client):
     client.list_tasks.side_effect = [
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"  # Noqa
             ],
             "nextToken": "token0",
         },
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"  # Noqa
             ],
             "nextToken": None,
         },
@@ -91,13 +91,13 @@ def test_stop_random_tasks_count_no_service(aws_client):
     client.list_tasks.side_effect = [
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"  # Noqa
             ],
             "nextToken": "token0",
         },
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"  # Noqa
             ],
             "nextToken": None,
         },
@@ -107,12 +107,12 @@ def test_stop_random_tasks_count_no_service(aws_client):
     assert client.stop_task.call_count == 2
     client.stop_task.assert_any_call(
         cluster=cluster,
-        task="arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da",
+        task="arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da",  # Noqa
         reason=reason,
     )
     client.stop_task.assert_any_call(
         cluster=cluster,
-        task="arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk",
+        task="arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk",  # Noqa
         reason=reason,
     )
 
@@ -127,13 +127,13 @@ def test_stop_random_tasks_percent_no_service(aws_client):
     client.list_tasks.side_effect = [
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"  # Noqa
             ],
             "nextToken": "token0",
         },
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"  # Noqa
             ],
             "nextToken": None,
         },
@@ -167,13 +167,13 @@ def test_stop_random_tasks_percent_yes_service(aws_client):
     client.list_tasks.side_effect = [
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"  # Noqa
             ],
             "nextToken": "token0",
         },
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"  # Noqa
             ],
             "nextToken": None,
         },
@@ -209,13 +209,13 @@ def test_stop_random_tasks_count_yes_service(aws_client):
     client.list_tasks.side_effect = [
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"  # Noqa
             ],
             "nextToken": "token0",
         },
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"  # Noqa
             ],
             "nextToken": None,
         },
@@ -227,12 +227,12 @@ def test_stop_random_tasks_count_yes_service(aws_client):
     assert client.stop_task.call_count == 2
     client.stop_task.assert_any_call(
         cluster=cluster,
-        task="arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da",
+        task="arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da",  # Noqa
         reason=reason,
     )
     client.stop_task.assert_any_call(
         cluster=cluster,
-        task="arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk",
+        task="arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk",  # Noqa
         reason=reason,
     )
 
@@ -258,13 +258,13 @@ def test_stop_tasks(aws_client):
     client.list_tasks.side_effect = [
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"
+                "arn:aws:ecs:us-east-1:012345678910:task/16fd2706-8baf-433b-82eb-8c7fada847da"  # Noqa
             ],
             "nextToken": "token0",
         },
         {
             "taskArns": [
-                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"
+                "arn:aws:ecs:us-east-1:012345678910:task/84th9568-3tth-55g1-35ki-4o9amby245lk"  # Noqa
             ],
             "nextToken": None,
         },

--- a/tests/ecs/test_ecs_probes.py
+++ b/tests/ecs/test_ecs_probes.py
@@ -4,184 +4,180 @@ import pytest
 from chaoslib.exceptions import FailedActivity
 
 from chaosaws.ecs.probes import (
-    service_is_deploying, describe_cluster, describe_service, describe_tasks,
-    are_all_desired_tasks_running)
+    are_all_desired_tasks_running,
+    describe_cluster,
+    describe_service,
+    describe_tasks,
+    service_is_deploying,
+)
 
 
-@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+@patch("chaosaws.ecs.probes.aws_client", autospec=True)
 def test_ecs_service_is_not_deploying(aws_client):
     client = MagicMock()
-    client.describe_services = MagicMock(return_value={
-        'services': [{
-            'deployments': [
-                {"status": "PRIMARY"}
-            ]
-        }]
-    })
+    client.describe_services = MagicMock(
+        return_value={"services": [{"deployments": [{"status": "PRIMARY"}]}]}
+    )
     aws_client.return_value = client
     cluster = "ecs-cluster"
     service = "ecs-service"
     response = service_is_deploying(cluster, service)
-    client.describe_services.assert_called_with(
-        cluster=cluster, services=[service])
+    client.describe_services.assert_called_with(cluster=cluster, services=[service])
     assert response is False
 
 
-@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+@patch("chaosaws.ecs.probes.aws_client", autospec=True)
 def test_ecs_service_is_deploying(aws_client):
     client = MagicMock()
-    client.describe_services = MagicMock(return_value={
-        'services': [{
-            'deployments': [
-                {'status': 'PRIMARY'},
-                {'status': 'ACTIVE'}
-            ]
-        }]
-    })
+    client.describe_services = MagicMock(
+        return_value={
+            "services": [{"deployments": [{"status": "PRIMARY"}, {"status": "ACTIVE"}]}]
+        }
+    )
     aws_client.return_value = client
     cluster = "ecs-cluster"
     service = "ecs-service"
     response = service_is_deploying(cluster, service)
-    client.describe_services.assert_called_with(
-        cluster=cluster, services=[service])
+    client.describe_services.assert_called_with(cluster=cluster, services=[service])
     assert response is True
 
 
-@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+@patch("chaosaws.ecs.probes.aws_client", autospec=True)
 def test_error_checking_ecs_service_is_not_deploying(aws_client):
     client = MagicMock()
-    client.describe_services = MagicMock(return_value={
-        'services': [],
-        'failures': [{
-            'reason': 'some_reason',
-            'arn': 'some_arn'
-        }]
-    })
+    client.describe_services = MagicMock(
+        return_value={
+            "services": [],
+            "failures": [{"reason": "some_reason", "arn": "some_arn"}],
+        }
+    )
     aws_client.return_value = client
     cluster = "ecs-cluster"
     service = "ecs-service"
     with pytest.raises(FailedActivity) as exceptionInfo:
         service_is_deploying(cluster, service)
 
-    client.describe_services.assert_called_with(
-        cluster=cluster, services=[service])
-    assert 'Error retrieving service data from AWS' in str(exceptionInfo.value)
+    client.describe_services.assert_called_with(cluster=cluster, services=[service])
+    assert "Error retrieving service data from AWS" in str(exceptionInfo.value)
 
 
-@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+@patch("chaosaws.ecs.probes.aws_client", autospec=True)
 def test_are_all_tasks_running_true(aws_client):
     client = MagicMock()
     client.describe_services = MagicMock(
         return_value={
-            'services': [{
-                'serviceName': 'MyGenericService',
-                'desiredCount': 3,
-                'runningCount': 3
-            }]
+            "services": [
+                {
+                    "serviceName": "MyGenericService",
+                    "desiredCount": 3,
+                    "runningCount": 3,
+                }
+            ]
         }
     )
     aws_client.return_value = client
-    cluster = 'ecs-cluster'
-    service = 'MyGenericService'
+    cluster = "ecs-cluster"
+    service = "MyGenericService"
     response = are_all_desired_tasks_running(cluster, service)
-    client.describe_services.assert_called_with(
-        cluster=cluster, services=[service])
+    client.describe_services.assert_called_with(cluster=cluster, services=[service])
     assert response
 
 
-@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+@patch("chaosaws.ecs.probes.aws_client", autospec=True)
 def test_are_all_tasks_running_false(aws_client):
     client = MagicMock()
     client.describe_services = MagicMock(
         return_value={
-            'services': [{
-                'serviceName': 'MyGenericService',
-                'desiredCount': 3,
-                'runningCount': 2
-            }]
+            "services": [
+                {
+                    "serviceName": "MyGenericService",
+                    "desiredCount": 3,
+                    "runningCount": 2,
+                }
+            ]
         }
     )
     aws_client.return_value = client
-    cluster = 'ecs-cluster'
-    service = 'MyGenericService'
+    cluster = "ecs-cluster"
+    service = "MyGenericService"
     response = are_all_desired_tasks_running(cluster, service)
-    client.describe_services.assert_called_with(
-        cluster=cluster, services=[service])
+    client.describe_services.assert_called_with(cluster=cluster, services=[service])
     assert not response
 
 
-@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+@patch("chaosaws.ecs.probes.aws_client", autospec=True)
 def test_are_all_tasks_running_exception(aws_client):
     client = MagicMock()
-    client.describe_services = MagicMock(return_value={'services': []})
+    client.describe_services = MagicMock(return_value={"services": []})
     aws_client.return_value = client
-    cluster = 'ecs-cluster'
-    service = 'MyGenericService'
+    cluster = "ecs-cluster"
+    service = "MyGenericService"
     with pytest.raises(FailedActivity) as e:
         are_all_desired_tasks_running(cluster, service)
-    client.describe_services.assert_called_with(
-        cluster=cluster, services=[service])
-    assert 'Error retrieving service data from AWS' in str(e.value)
+    client.describe_services.assert_called_with(cluster=cluster, services=[service])
+    assert "Error retrieving service data from AWS" in str(e.value)
 
 
-@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+@patch("chaosaws.ecs.probes.aws_client", autospec=True)
 def test_describe_clusters(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.describe_clusters.return_value = {
-        'clusters': [{
-            'clusterArn': 'arn:aws:ecs:region:012345678910:cluster/MyCluster',
-            'clusterName': 'MyCluster',
-            'status': 'ACTIVE'
-        }]
+        "clusters": [
+            {
+                "clusterArn": "arn:aws:ecs:region:012345678910:cluster/MyCluster",
+                "clusterName": "MyCluster",
+                "status": "ACTIVE",
+            }
+        ]
     }
-    response = describe_cluster(cluster='MyCluster')
-    client.describe_clusters.assert_called_with(clusters=['MyCluster'])
-    assert response['clusters'][0]['clusterName'] == 'MyCluster'
+    response = describe_cluster(cluster="MyCluster")
+    client.describe_clusters.assert_called_with(clusters=["MyCluster"])
+    assert response["clusters"][0]["clusterName"] == "MyCluster"
 
 
-@patch('chaosaws.ecs.probes.aws_client', autospec=True)
+@patch("chaosaws.ecs.probes.aws_client", autospec=True)
 def test_describe_service(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     client.describe_services.return_value = {
-        'services': [{
-            'clusterArn': 'arn:aws:ecs:region:012345678910:cluster/MyCluster',
-            'serviceArn': 'arn:aws:ecs:region:012345678910:service/MyService',
-            'serviceName': 'MyService',
-            'status': 'ACTIVE'
-        }]
-    }
-    response = describe_service(cluster='MyCluster', service='MyService')
-    client.describe_services.assert_called_with(
-        cluster='MyCluster', services=['MyService'])
-    assert response['services'][0]['serviceName'] == 'MyService'
-
-
-@patch('chaosaws.ecs.probes.aws_client', autospec=True)
-def test_describe_tasks(aws_client):
-    client = MagicMock()
-    aws_client.return_value = client
-    client.get_paginator.return_value.paginate.return_value = [{
-        'taskArns': [
-            'arn:aws:ecs:region:012345678910:task/MyCluster/123456789'
-        ]
-    }]
-    client.describe_tasks.return_value = {
-        'tasks': [
+        "services": [
             {
-                'clusterArn': 'arn:aws:ecs:region:012345678910:cluster/'
-                              'MyCluster',
-                'taskArn': 'arn:aws:ecs:region:012345678910:task/MyCluster/'
-                           '123456789',
-                'version': 22
+                "clusterArn": "arn:aws:ecs:region:012345678910:cluster/MyCluster",
+                "serviceArn": "arn:aws:ecs:region:012345678910:service/MyService",
+                "serviceName": "MyService",
+                "status": "ACTIVE",
             }
         ]
     }
-    response = describe_tasks(cluster='MyCluster')
-    client.get_paginator.return_value.paginate.assert_called_with(
-        cluster='MyCluster')
+    response = describe_service(cluster="MyCluster", service="MyService")
+    client.describe_services.assert_called_with(
+        cluster="MyCluster", services=["MyService"]
+    )
+    assert response["services"][0]["serviceName"] == "MyService"
+
+
+@patch("chaosaws.ecs.probes.aws_client", autospec=True)
+def test_describe_tasks(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    client.get_paginator.return_value.paginate.return_value = [
+        {"taskArns": ["arn:aws:ecs:region:012345678910:task/MyCluster/123456789"]}
+    ]
+    client.describe_tasks.return_value = {
+        "tasks": [
+            {
+                "clusterArn": "arn:aws:ecs:region:012345678910:cluster/" "MyCluster",
+                "taskArn": "arn:aws:ecs:region:012345678910:task/MyCluster/"
+                "123456789",
+                "version": 22,
+            }
+        ]
+    }
+    response = describe_tasks(cluster="MyCluster")
+    client.get_paginator.return_value.paginate.assert_called_with(cluster="MyCluster")
     client.describe_tasks.assert_called_with(
-        cluster='MyCluster',
-        tasks=['arn:aws:ecs:region:012345678910:task/MyCluster/123456789'])
-    assert response['tasks'][0]['version'] == 22
+        cluster="MyCluster",
+        tasks=["arn:aws:ecs:region:012345678910:task/MyCluster/123456789"],
+    )
+    assert response["tasks"][0]["version"] == 22

--- a/tests/eks/test_eks_actions.py
+++ b/tests/eks/test_eks_actions.py
@@ -3,23 +3,20 @@ from unittest.mock import MagicMock, patch
 from chaosaws.eks.actions import create_cluster, delete_cluster
 
 
-@patch('chaosaws.eks.actions.aws_client', autospec=True)
+@patch("chaosaws.eks.actions.aws_client", autospec=True)
 def test_create_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client
     cluster = "eks-cluster"
     arn = "arn:aws:iam::123456:role/EKSrole"
-    vpc_config = {
-        "subnetIds": ["sub1"],
-        "securityGroupIds": ["sg1"]
-    }
-    create_cluster(
-        name=cluster, role_arn=arn, vpc_config=vpc_config)
+    vpc_config = {"subnetIds": ["sub1"], "securityGroupIds": ["sg1"]}
+    create_cluster(name=cluster, role_arn=arn, vpc_config=vpc_config)
     client.create_cluster.assert_called_with(
-        name=cluster, roleArn=arn, version=None, resourcesVpcConfig=vpc_config)
+        name=cluster, roleArn=arn, version=None, resourcesVpcConfig=vpc_config
+    )
 
 
-@patch('chaosaws.eks.actions.aws_client', autospec=True)
+@patch("chaosaws.eks.actions.aws_client", autospec=True)
 def test_delete_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client

--- a/tests/eks/test_eks_probes.py
+++ b/tests/eks/test_eks_probes.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from chaosaws.eks.probes import describe_cluster, list_clusters
 
 
-@patch('chaosaws.eks.probes.aws_client', autospec=True)
+@patch("chaosaws.eks.probes.aws_client", autospec=True)
 def test_describe_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -12,7 +12,7 @@ def test_describe_cluster(aws_client):
     client.describe_cluster.assert_called_with(name=cluster)
 
 
-@patch('chaosaws.eks.probes.aws_client', autospec=True)
+@patch("chaosaws.eks.probes.aws_client", autospec=True)
 def test_describe_missing_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -24,7 +24,7 @@ def test_describe_missing_cluster(aws_client):
     assert response is None
 
 
-@patch('chaosaws.eks.probes.aws_client', autospec=True)
+@patch("chaosaws.eks.probes.aws_client", autospec=True)
 def test_list_clusters(aws_client):
     client = MagicMock()
     aws_client.return_value = client

--- a/tests/elasticache/test_elasticache_actions.py
+++ b/tests/elasticache/test_elasticache_actions.py
@@ -1,207 +1,244 @@
 from unittest.mock import MagicMock, patch
-from chaosaws.elasticache.actions import (
-    reboot_cache_clusters, delete_replication_groups, delete_cache_clusters)
 
 import pytest
+
+from chaosaws.elasticache.actions import (
+    delete_cache_clusters,
+    delete_replication_groups,
+    reboot_cache_clusters,
+)
 
 
 def test_reboot_cache_clusters_invalid():
     with pytest.raises(TypeError) as x:
         reboot_cache_clusters()
-    assert "reboot_cache_clusters() missing 1 required positional " \
-           "argument: 'cluster_ids'" in str(x.value)
+    assert (
+        "reboot_cache_clusters() missing 1 required positional "
+        "argument: 'cluster_ids'" in str(x.value)
+    )
 
 
 def test_delete_cache_clusters_no_cluster():
     with pytest.raises(TypeError) as x:
-        delete_cache_clusters(final_snapshot_id='MyClusterFinalSnapshot')
-    assert "delete_cache_clusters() missing 1 required positional " \
-           "argument: 'cluster_ids'" in str(x.value)
+        delete_cache_clusters(final_snapshot_id="MyClusterFinalSnapshot")
+    assert (
+        "delete_cache_clusters() missing 1 required positional "
+        "argument: 'cluster_ids'" in str(x.value)
+    )
 
 
-@patch('chaosaws.elasticache.actions.aws_client', autospec=True)
+@patch("chaosaws.elasticache.actions.aws_client", autospec=True)
 def test_reboot_cache_clusters_select_nodes(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    cluster_ids = ['MyTestCacheCluster']
-    node_ids = ['0001', '0003']
+    cluster_ids = ["MyTestCacheCluster"]
+    node_ids = ["0001", "0003"]
 
     client.describe_cache_clusters.return_value = {
-        'CacheClusters': [{
-            'CacheClusterId': 'MyTestCacheCluster',
-            'CacheNodes': [
-                {'CacheNodeId': '0001'},
-                {'CacheNodeId': '0002'},
-                {'CacheNodeId': '0003'},
-                {'CacheNodeId': '0004'}]}]}
+        "CacheClusters": [
+            {
+                "CacheClusterId": "MyTestCacheCluster",
+                "CacheNodes": [
+                    {"CacheNodeId": "0001"},
+                    {"CacheNodeId": "0002"},
+                    {"CacheNodeId": "0003"},
+                    {"CacheNodeId": "0004"},
+                ],
+            }
+        ]
+    }
     client.reboot_cache_cluster.return_value = {
-        'CacheCluster': {
-            'CacheClusterId': 'MyTestCacheCluster',
-            'CacheNodes': [
-                {'CacheNodeId': '0001'},
-                {'CacheNodeId': '0002'},
-                {'CacheNodeId': '0003'},
-                {'CacheNodeId': '0004'}]}}
+        "CacheCluster": {
+            "CacheClusterId": "MyTestCacheCluster",
+            "CacheNodes": [
+                {"CacheNodeId": "0001"},
+                {"CacheNodeId": "0002"},
+                {"CacheNodeId": "0003"},
+                {"CacheNodeId": "0004"},
+            ],
+        }
+    }
 
     results = reboot_cache_clusters(cluster_ids, node_ids)
     client.describe_cache_clusters.assert_called_with(
-        CacheClusterId=cluster_ids[0],
-        ShowCacheNodeInfo=True)
+        CacheClusterId=cluster_ids[0], ShowCacheNodeInfo=True
+    )
     client.reboot_cache_cluster.assert_called_with(
-        CacheClusterId=cluster_ids[0],
-        CacheNodeIdsToReboot=node_ids)
-    assert results[0]['CacheClusterId'] == cluster_ids[0]
+        CacheClusterId=cluster_ids[0], CacheNodeIdsToReboot=node_ids
+    )
+    assert results[0]["CacheClusterId"] == cluster_ids[0]
 
 
-@patch('chaosaws.elasticache.actions.aws_client', autospec=True)
+@patch("chaosaws.elasticache.actions.aws_client", autospec=True)
 def test_reboot_cache_clusters_all_nodes(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    cluster_ids = ['MyTestCacheCluster']
+    cluster_ids = ["MyTestCacheCluster"]
 
     client.describe_cache_clusters.return_value = {
-        'CacheClusters': [{
-            'CacheClusterId': 'MyTestCacheCluster',
-            'CacheNodes': [
-                {'CacheNodeId': '0001'},
-                {'CacheNodeId': '0002'},
-                {'CacheNodeId': '0003'},
-                {'CacheNodeId': '0004'}]}]}
+        "CacheClusters": [
+            {
+                "CacheClusterId": "MyTestCacheCluster",
+                "CacheNodes": [
+                    {"CacheNodeId": "0001"},
+                    {"CacheNodeId": "0002"},
+                    {"CacheNodeId": "0003"},
+                    {"CacheNodeId": "0004"},
+                ],
+            }
+        ]
+    }
     client.reboot_cache_cluster.return_value = {
-        'CacheCluster': {
-            'CacheClusterId': 'MyTestCacheCluster',
-            'CacheNodes': [
-                {'CacheNodeId': '0001'},
-                {'CacheNodeId': '0002'},
-                {'CacheNodeId': '0003'},
-                {'CacheNodeId': '0004'}]}}
+        "CacheCluster": {
+            "CacheClusterId": "MyTestCacheCluster",
+            "CacheNodes": [
+                {"CacheNodeId": "0001"},
+                {"CacheNodeId": "0002"},
+                {"CacheNodeId": "0003"},
+                {"CacheNodeId": "0004"},
+            ],
+        }
+    }
 
     results = reboot_cache_clusters(cluster_ids)
     client.describe_cache_clusters.assert_called_with(
-        CacheClusterId=cluster_ids[0],
-        ShowCacheNodeInfo=True)
+        CacheClusterId=cluster_ids[0], ShowCacheNodeInfo=True
+    )
     client.reboot_cache_cluster.assert_called_with(
         CacheClusterId=cluster_ids[0],
-        CacheNodeIdsToReboot=['0001', '0002', '0003', '0004'])
-    assert results[0]['CacheClusterId'] == cluster_ids[0]
+        CacheNodeIdsToReboot=["0001", "0002", "0003", "0004"],
+    )
+    assert results[0]["CacheClusterId"] == cluster_ids[0]
 
 
-@patch('chaosaws.elasticache.actions.aws_client', autospec=True)
+@patch("chaosaws.elasticache.actions.aws_client", autospec=True)
 def test_delete_cache_clusters_snapshot(aws_client):
     client = MagicMock()
     aws_client.return_value = client
 
     client.describe_cache_clusters.return_value = {
-        'CacheClusters': [{
-            'CacheClusterId': 'MyTestCacheCluster',
-            'CacheClusterStatus': 'available',
-            'CacheNodes': [
-                {'CacheNodeId': '0001'},
-                {'CacheNodeId': '0002'}]}]}
+        "CacheClusters": [
+            {
+                "CacheClusterId": "MyTestCacheCluster",
+                "CacheClusterStatus": "available",
+                "CacheNodes": [{"CacheNodeId": "0001"}, {"CacheNodeId": "0002"}],
+            }
+        ]
+    }
     client.delete_cache_cluster.return_value = {
-        'CacheCluster': {
-            'CacheClusterId': 'MyTestCacheCluster',
-            'CacheClusterStatus': 'snapshotting',
-            'CacheNodes': [
-                {'CacheNodeId': '0001'},
-                {'CacheNodeId': '0002'}]}}
+        "CacheCluster": {
+            "CacheClusterId": "MyTestCacheCluster",
+            "CacheClusterStatus": "snapshotting",
+            "CacheNodes": [{"CacheNodeId": "0001"}, {"CacheNodeId": "0002"}],
+        }
+    }
 
-    results = delete_cache_clusters(cluster_ids=['MyTestCacheCluster'],
-                                    final_snapshot_id='MyClusterFinalSnap')
+    results = delete_cache_clusters(
+        cluster_ids=["MyTestCacheCluster"], final_snapshot_id="MyClusterFinalSnap"
+    )
     client.describe_cache_clusters.assert_called_with(
-        CacheClusterId='MyTestCacheCluster',
-        ShowCacheNodeInfo=True)
+        CacheClusterId="MyTestCacheCluster", ShowCacheNodeInfo=True
+    )
     client.delete_cache_cluster.assert_called_with(
-        CacheClusterId='MyTestCacheCluster',
-        FinalSnapshotIdentifier='MyClusterFinalSnap')
-    assert results[0]['CacheClusterId'] == 'MyTestCacheCluster'
-    assert results[0]['CacheClusterStatus'] == 'snapshotting'
+        CacheClusterId="MyTestCacheCluster",
+        FinalSnapshotIdentifier="MyClusterFinalSnap",
+    )
+    assert results[0]["CacheClusterId"] == "MyTestCacheCluster"
+    assert results[0]["CacheClusterStatus"] == "snapshotting"
 
 
-@patch('chaosaws.elasticache.actions.aws_client', autospec=True)
+@patch("chaosaws.elasticache.actions.aws_client", autospec=True)
 def test_delete_cache_clusters_no_snapshot(aws_client):
     client = MagicMock()
     aws_client.return_value = client
 
     client.describe_cache_clusters.return_value = {
-        'CacheClusters': [{
-            'CacheClusterId': 'MyTestCacheCluster',
-            'CacheClusterStatus': 'available',
-            'CacheNodes': [
-                {'CacheNodeId': '0001'},
-                {'CacheNodeId': '0002'}]}]}
+        "CacheClusters": [
+            {
+                "CacheClusterId": "MyTestCacheCluster",
+                "CacheClusterStatus": "available",
+                "CacheNodes": [{"CacheNodeId": "0001"}, {"CacheNodeId": "0002"}],
+            }
+        ]
+    }
     client.delete_cache_cluster.return_value = {
-        'CacheCluster': {
-            'CacheClusterId': 'MyTestCacheCluster',
-            'CacheClusterStatus': 'deleting',
-            'CacheNodes': [
-                {'CacheNodeId': '0001'},
-                {'CacheNodeId': '0002'}]}}
+        "CacheCluster": {
+            "CacheClusterId": "MyTestCacheCluster",
+            "CacheClusterStatus": "deleting",
+            "CacheNodes": [{"CacheNodeId": "0001"}, {"CacheNodeId": "0002"}],
+        }
+    }
 
-    results = delete_cache_clusters(cluster_ids=['MyTestCacheCluster'])
+    results = delete_cache_clusters(cluster_ids=["MyTestCacheCluster"])
     client.describe_cache_clusters.assert_called_with(
-        CacheClusterId='MyTestCacheCluster',
-        ShowCacheNodeInfo=True)
-    client.delete_cache_cluster.assert_called_with(
-        CacheClusterId='MyTestCacheCluster')
-    assert results[0]['CacheClusterId'] == 'MyTestCacheCluster'
-    assert results[0]['CacheClusterStatus'] == 'deleting'
+        CacheClusterId="MyTestCacheCluster", ShowCacheNodeInfo=True
+    )
+    client.delete_cache_cluster.assert_called_with(CacheClusterId="MyTestCacheCluster")
+    assert results[0]["CacheClusterId"] == "MyTestCacheCluster"
+    assert results[0]["CacheClusterStatus"] == "deleting"
 
 
-@patch('chaosaws.elasticache.actions.aws_client', autospec=True)
+@patch("chaosaws.elasticache.actions.aws_client", autospec=True)
 def test_delete_replication_group_snapshot(aws_client):
     client = MagicMock()
     aws_client.return_value = client
 
-    group_ids = ['MyRedisReplicationGroup']
-    final_snapshot_id = 'MyReplicationGroupFinalSnap'
+    group_ids = ["MyRedisReplicationGroup"]
+    final_snapshot_id = "MyReplicationGroupFinalSnap"
 
     client.describe_replication_groups.return_value = {
-        'ReplicationGroups': [{
-            'ReplicationGroupId': group_ids[0],
-            'Status': 'available'}]}
+        "ReplicationGroups": [
+            {"ReplicationGroupId": group_ids[0], "Status": "available"}
+        ]
+    }
     client.delete_replication_group.return_value = {
-        'ReplicationGroup': {
-            'ReplicationGroupId': group_ids[0],
-            'Status': 'snapshotting'}}
+        "ReplicationGroup": {
+            "ReplicationGroupId": group_ids[0],
+            "Status": "snapshotting",
+        }
+    }
 
     results = delete_replication_groups(
-        group_ids=group_ids, final_snapshot_id=final_snapshot_id)
+        group_ids=group_ids, final_snapshot_id=final_snapshot_id
+    )
 
     client.describe_replication_groups.assert_called_with(
-        ReplicationGroupId=group_ids[0])
+        ReplicationGroupId=group_ids[0]
+    )
     client.delete_replication_group.assert_called_with(
         ReplicationGroupId=group_ids[0],
         RetainPrimaryCluster=True,
-        FinalSnapshotIdentifier=final_snapshot_id)
+        FinalSnapshotIdentifier=final_snapshot_id,
+    )
 
-    assert results[0]['ReplicationGroupId'] == group_ids[0]
-    assert results[0]['Status'] == 'snapshotting'
+    assert results[0]["ReplicationGroupId"] == group_ids[0]
+    assert results[0]["Status"] == "snapshotting"
 
 
-@patch('chaosaws.elasticache.actions.aws_client', autospec=True)
+@patch("chaosaws.elasticache.actions.aws_client", autospec=True)
 def test_delete_replication_group_no_snapshot(aws_client):
     client = MagicMock()
     aws_client.return_value = client
 
-    group_ids = ['MyRedisReplicationGroup']
+    group_ids = ["MyRedisReplicationGroup"]
 
     client.describe_replication_groups.return_value = {
-        'ReplicationGroups': [{
-            'ReplicationGroupId': group_ids[0],
-            'Status': 'available'}]}
+        "ReplicationGroups": [
+            {"ReplicationGroupId": group_ids[0], "Status": "available"}
+        ]
+    }
     client.delete_replication_group.return_value = {
-        'ReplicationGroup': {
-            'ReplicationGroupId': group_ids[0],
-            'Status': 'deleting'}}
+        "ReplicationGroup": {"ReplicationGroupId": group_ids[0], "Status": "deleting"}
+    }
 
     results = delete_replication_groups(group_ids=group_ids)
 
     client.describe_replication_groups.assert_called_with(
-        ReplicationGroupId=group_ids[0])
+        ReplicationGroupId=group_ids[0]
+    )
     client.delete_replication_group.assert_called_with(
-        ReplicationGroupId=group_ids[0],
-        RetainPrimaryCluster=True)
+        ReplicationGroupId=group_ids[0], RetainPrimaryCluster=True
+    )
 
-    assert results[0]['ReplicationGroupId'] == group_ids[0]
-    assert results[0]['Status'] == 'deleting'
+    assert results[0]["ReplicationGroupId"] == group_ids[0]
+    assert results[0]["Status"] == "deleting"

--- a/tests/elasticache/test_elasticache_probes.py
+++ b/tests/elasticache/test_elasticache_probes.py
@@ -1,86 +1,103 @@
 from unittest.mock import MagicMock, patch
-from chaosaws.elasticache.probes import (
-    describe_cache_cluster, get_cache_node_status, get_cache_node_count, count_cache_clusters_from_replication_group)
 
 import pytest
 
+from chaosaws.elasticache.probes import (
+    count_cache_clusters_from_replication_group,
+    describe_cache_cluster,
+    get_cache_node_count,
+    get_cache_node_status,
+)
+
 TestClusterFrame = {
-    'CacheClusters': [
+    "CacheClusters": [
         {
-            'CacheClusterId': 'MyTestCacheCluster',
-            'CacheClusterStatus': 'available',
-            'Engine': 'memcached',
-            'NumCacheNodes': 1
+            "CacheClusterId": "MyTestCacheCluster",
+            "CacheClusterStatus": "available",
+            "Engine": "memcached",
+            "NumCacheNodes": 1,
         }
     ]
 }
 
-NodeInfoFrame = [{
-    'CacheNodeId': '0001',
-    'CacheNodeStatus': 'available',
-    'ParameterGroupStatus': 'in-sync'
-}]
+NodeInfoFrame = [
+    {
+        "CacheNodeId": "0001",
+        "CacheNodeStatus": "available",
+        "ParameterGroupStatus": "in-sync",
+    }
+]
 
 
 def test_describe_elasticache_invalid():
     with pytest.raises(TypeError) as x:
         describe_cache_cluster()
-    assert "describe_cache_cluster() missing 1 required positional " \
-           "argument: 'cluster_id'" in str(x.value)
+    assert (
+        "describe_cache_cluster() missing 1 required positional "
+        "argument: 'cluster_id'" in str(x.value)
+    )
 
 
 def test_get_node_status_invalid():
     with pytest.raises(TypeError) as x:
         get_cache_node_status()
-    assert "get_cache_node_status() missing 1 required positional " \
-           "argument: 'cluster_id'" in str(x.value)
+    assert (
+        "get_cache_node_status() missing 1 required positional "
+        "argument: 'cluster_id'" in str(x.value)
+    )
 
 
 def test_get_node_count_invalid():
     with pytest.raises(TypeError) as x:
         get_cache_node_count()
-    assert "get_cache_node_count() missing 1 required positional " \
-           "argument: 'cluster_id'" in str(x.value)
+    assert (
+        "get_cache_node_count() missing 1 required positional "
+        "argument: 'cluster_id'" in str(x.value)
+    )
 
 
 def test_count_cache_clusters_from_replication_group():
     with pytest.raises(TypeError) as x:
         count_cache_clusters_from_replication_group()
-    assert "count_cache_clusters_from_replication_group() missing 1 " \
-           "required positional argument: 'replication_group_id'" \
-           in str(x.value)
+    assert (
+        "count_cache_clusters_from_replication_group() missing 1 "
+        "required positional argument: 'replication_group_id'" in str(x.value)
+    )
 
 
-@patch('chaosaws.elasticache.probes.aws_client', autospec=True)
+@patch("chaosaws.elasticache.probes.aws_client", autospec=True)
 def test_describe_cache_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client
 
     client.describe_cache_clusters.return_value = TestClusterFrame
-    response = describe_cache_cluster(cluster_id='MyTestCacheCluster')
+    response = describe_cache_cluster(cluster_id="MyTestCacheCluster")
     client.describe_cache_clusters.assert_called_with(
-        CacheClusterId='MyTestCacheCluster', ShowCacheNodeInfo=False)
-    assert response['CacheClusters'][0][
-               'CacheClusterId'] == 'MyTestCacheCluster'
+        CacheClusterId="MyTestCacheCluster", ShowCacheNodeInfo=False
+    )
+    assert response["CacheClusters"][0]["CacheClusterId"] == "MyTestCacheCluster"
 
 
-@patch('chaosaws.elasticache.probes.aws_client', autospec=True)
+@patch("chaosaws.elasticache.probes.aws_client", autospec=True)
 def test_describe_cache_cluster_show_node_info(aws_client):
     client = MagicMock()
     aws_client.return_value = client
 
-    TestClusterFrame['CacheClusters'][0]['CacheNodes'] = NodeInfoFrame
+    TestClusterFrame["CacheClusters"][0]["CacheNodes"] = NodeInfoFrame
     client.describe_cache_clusters.return_value = TestClusterFrame
     response = describe_cache_cluster(
-        cluster_id='MyTestCacheCluster', show_node_info=True)
+        cluster_id="MyTestCacheCluster", show_node_info=True
+    )
 
     client.describe_cache_clusters.assert_called_with(
-        CacheClusterId='MyTestCacheCluster', ShowCacheNodeInfo=True)
-    assert response['CacheClusters'][0][
-               'CacheNodes'][0]['CacheNodeStatus'] == 'available'
+        CacheClusterId="MyTestCacheCluster", ShowCacheNodeInfo=True
+    )
+    assert (
+        response["CacheClusters"][0]["CacheNodes"][0]["CacheNodeStatus"] == "available"
+    )
 
 
-@patch('chaosaws.elasticache.probes.aws_client', autospec=True)
+@patch("chaosaws.elasticache.probes.aws_client", autospec=True)
 def test_get_node_status(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -89,13 +106,14 @@ def test_get_node_status(aws_client):
     aws_client.return_value = client
 
     client.describe_cache_clusters.return_value = TestClusterFrame
-    response = get_cache_node_status(cluster_id='MyTestCacheCluster')
+    response = get_cache_node_status(cluster_id="MyTestCacheCluster")
     client.describe_cache_clusters.assert_called_with(
-        CacheClusterId='MyTestCacheCluster', ShowCacheNodeInfo=False)
-    assert response == 'available'
+        CacheClusterId="MyTestCacheCluster", ShowCacheNodeInfo=False
+    )
+    assert response == "available"
 
 
-@patch('chaosaws.elasticache.probes.aws_client', autospec=True)
+@patch("chaosaws.elasticache.probes.aws_client", autospec=True)
 def test_get_node_count(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -104,7 +122,8 @@ def test_get_node_count(aws_client):
     aws_client.return_value = client
 
     client.describe_cache_clusters.return_value = TestClusterFrame
-    response = get_cache_node_count(cluster_id='MyTestCacheCluster')
+    response = get_cache_node_count(cluster_id="MyTestCacheCluster")
     client.describe_cache_clusters.assert_called_with(
-        CacheClusterId='MyTestCacheCluster', ShowCacheNodeInfo=False)
+        CacheClusterId="MyTestCacheCluster", ShowCacheNodeInfo=False
+    )
     assert response == 1

--- a/tests/elbv2/test_elbv2_actions.py
+++ b/tests/elbv2/test_elbv2_actions.py
@@ -1,372 +1,373 @@
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from chaoslib.exceptions import FailedActivity
 
-from chaosaws.elbv2.actions import (deregister_target, delete_load_balancer,
-                                    set_subnets, set_security_groups)
+from chaosaws.elbv2.actions import (
+    delete_load_balancer,
+    deregister_target,
+    set_security_groups,
+    set_subnets,
+)
 
 
-@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+@patch("chaosaws.elbv2.actions.aws_client", autospec=True)
 def test_deregister_target(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tg_name = 'TestTargetGroup1'
-    tg_arn = 'arn:aws:elasticloadbalancing:eu-west-1:111111111111:' \
-             'targetgroup/TestTargetGroup1/1234567890abcdef'
-    target_id = 'i-0123456789abcdef0'
-    client.describe_target_groups.return_value = {"TargetGroups": [
-        {
-            'TargetGroupArn': tg_arn,
-            'TargetGroupName': tg_name
-        }
-    ]}
+    tg_name = "TestTargetGroup1"
+    tg_arn = (
+        "arn:aws:elasticloadbalancing:eu-west-1:111111111111:"
+        "targetgroup/TestTargetGroup1/1234567890abcdef"
+    )
+    target_id = "i-0123456789abcdef0"
+    client.describe_target_groups.return_value = {
+        "TargetGroups": [{"TargetGroupArn": tg_arn, "TargetGroupName": tg_name}]
+    }
     client.describe_target_health.return_value = {
-        'TargetHealthDescriptions': [{
-            'Target': {
-                'Id': target_id,
-                'Port': 80
-            }
-        }]
+        "TargetHealthDescriptions": [{"Target": {"Id": target_id, "Port": 80}}]
     }
     deregister_target(tg_name=tg_name)
     client.deregister_targets.assert_called_with(
-        TargetGroupArn=tg_arn, Targets=[{'Id': target_id, 'Port': 80}])
+        TargetGroupArn=tg_arn, Targets=[{"Id": target_id, "Port": 80}]
+    )
 
 
-@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+@patch("chaosaws.elbv2.actions.aws_client", autospec=True)
 def test_set_security_groups(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
-    security_group_ids = ['sg-0123456789abcdef0', 'sg-0fedcba9876543210']
+    alb_names = ["test-loadbalancer-01", "test-loadbalancer-02"]
+    security_group_ids = ["sg-0123456789abcdef0", "sg-0fedcba9876543210"]
 
     client.describe_security_groups.return_value = {
-        'SecurityGroups': [
-            {'GroupId': 'sg-0123456789abcdef0'},
-            {'GroupId': 'sg-0fedcba9876543210'}
+        "SecurityGroups": [
+            {"GroupId": "sg-0123456789abcdef0"},
+            {"GroupId": "sg-0fedcba9876543210"},
         ]
     }
     client.describe_load_balancers.return_value = {
-        'LoadBalancers': [
+        "LoadBalancers": [
             {
-                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
-                                   '000000000000:loadbalancer/app/'
-                                   'test-loadbalancer-01/0f158eab895ab000',
-                'State': {'Code': 'active'},
-                'Type': 'application',
-                'LoadBalancerName': alb_names[0]
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:"
+                "000000000000:loadbalancer/app/"
+                "test-loadbalancer-01/0f158eab895ab000",
+                "State": {"Code": "active"},
+                "Type": "application",
+                "LoadBalancerName": alb_names[0],
             },
             {
-                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
-                                   '000000000000:loadbalancer/app/'
-                                   'test-loadbalancer-02/010aec0000fae123',
-                'State': {'Code': 'active'},
-                'Type': 'application',
-                'LoadBalancerName': alb_names[1]
-            }
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:"
+                "000000000000:loadbalancer/app/"
+                "test-loadbalancer-02/010aec0000fae123",
+                "State": {"Code": "active"},
+                "Type": "application",
+                "LoadBalancerName": alb_names[1],
+            },
         ]
-
     }
     set_security_groups(alb_names, security_group_ids)
 
     calls = [
         call(
-            LoadBalancerArn='arn:aws:elasticloadbalancing:us-east-1:'
-                            '000000000000:loadbalancer/app/'
-                            'test-loadbalancer-01/0f158eab895ab000',
-            SecurityGroups=security_group_ids),
+            LoadBalancerArn="arn:aws:elasticloadbalancing:us-east-1:"
+            "000000000000:loadbalancer/app/"
+            "test-loadbalancer-01/0f158eab895ab000",
+            SecurityGroups=security_group_ids,
+        ),
         call(
-            LoadBalancerArn='arn:aws:elasticloadbalancing:us-east-1:'
-                            '000000000000:loadbalancer/app/'
-                            'test-loadbalancer-02/010aec0000fae123',
-            SecurityGroups=security_group_ids)]
+            LoadBalancerArn="arn:aws:elasticloadbalancing:us-east-1:"
+            "000000000000:loadbalancer/app/"
+            "test-loadbalancer-02/010aec0000fae123",
+            SecurityGroups=security_group_ids,
+        ),
+    ]
     client.set_security_groups.assert_has_calls(calls, any_order=True)
 
 
-@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+@patch("chaosaws.elbv2.actions.aws_client", autospec=True)
 def test_set_security_groups_invalid_alb_type(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
-    security_group_ids = ['sg-0123456789abcdef0', 'sg-0fedcba9876543210']
+    alb_names = ["test-loadbalancer-01", "test-loadbalancer-02"]
+    security_group_ids = ["sg-0123456789abcdef0", "sg-0fedcba9876543210"]
 
     client.describe_security_groups.return_value = {
-        'SecurityGroups': [
-            {'GroupId': 'sg-0123456789abcdef0'},
-            {'GroupId': 'sg-0fedcba9876543210'}
+        "SecurityGroups": [
+            {"GroupId": "sg-0123456789abcdef0"},
+            {"GroupId": "sg-0fedcba9876543210"},
         ]
     }
     client.describe_load_balancers.return_value = {
-        'LoadBalancers': [
+        "LoadBalancers": [
             {
-                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
-                                   '000000000000:loadbalancer/app/'
-                                   'test-loadbalancer-01/0f158eab895ab000',
-                'State': {'Code': 'active'},
-                'Type': 'application',
-                'LoadBalancerName': alb_names[0]
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:"
+                "000000000000:loadbalancer/app/"
+                "test-loadbalancer-01/0f158eab895ab000",
+                "State": {"Code": "active"},
+                "Type": "application",
+                "LoadBalancerName": alb_names[0],
             },
             {
-                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
-                                   '000000000000:loadbalancer/app/'
-                                   'test-loadbalancer-02/010aec0000fae123',
-                'State': {'Code': 'active'},
-                'Type': 'network',
-                'LoadBalancerName': alb_names[1]
-            }
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:"
+                "000000000000:loadbalancer/app/"
+                "test-loadbalancer-02/010aec0000fae123",
+                "State": {"Code": "active"},
+                "Type": "network",
+                "LoadBalancerName": alb_names[1],
+            },
         ]
-
     }
     with pytest.raises(FailedActivity) as x:
         set_security_groups(alb_names, security_group_ids)
-    assert 'Cannot change security groups of network load balancers.' in str(x.value)
+    assert "Cannot change security groups of network load balancers." in str(x.value)
 
 
-@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+@patch("chaosaws.elbv2.actions.aws_client", autospec=True)
 def test_set_security_group_invalid_alb_name(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
-    security_group_ids = ['sg-0123456789abcdef0', 'sg-0fedcba9876543210']
+    alb_names = ["test-loadbalancer-01", "test-loadbalancer-02"]
+    security_group_ids = ["sg-0123456789abcdef0", "sg-0fedcba9876543210"]
 
     client.describe_security_groups.return_value = {
-        'SecurityGroups': [
-            {'GroupId': 'sg-0123456789abcdef0'},
-            {'GroupId': 'sg-0fedcba9876543210'}
+        "SecurityGroups": [
+            {"GroupId": "sg-0123456789abcdef0"},
+            {"GroupId": "sg-0fedcba9876543210"},
         ]
     }
     client.describe_load_balancers.return_value = {
-        'LoadBalancers': [
+        "LoadBalancers": [
             {
-                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
-                                   '000000000000:loadbalancer/app/'
-                                   'test-loadbalancer-01/0f158eab895ab000',
-                'State': {'Code': 'active'},
-                'Type': 'application',
-                'LoadBalancerName': alb_names[0]
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:"
+                "000000000000:loadbalancer/app/"
+                "test-loadbalancer-01/0f158eab895ab000",
+                "State": {"Code": "active"},
+                "Type": "application",
+                "LoadBalancerName": alb_names[0],
             }
         ]
-
     }
     with pytest.raises(FailedActivity) as x:
         set_security_groups(alb_names, security_group_ids)
-    assert 'Unable to locate load balancer(s): {}'.format(
-        [alb_names[1]]) in str(x.value)
+    assert "Unable to locate load balancer(s): {}".format([alb_names[1]]) in str(
+        x.value
+    )
 
 
-@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+@patch("chaosaws.elbv2.actions.aws_client", autospec=True)
 def test_set_security_groups_invalid_group(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
-    security_group_ids = ['sg-0123456789abcdef0', 'sg-0fedcba9876543210']
+    alb_names = ["test-loadbalancer-01", "test-loadbalancer-02"]
+    security_group_ids = ["sg-0123456789abcdef0", "sg-0fedcba9876543210"]
 
     client.describe_security_groups.return_value = {
-        'SecurityGroups': [
-            {'GroupId': 'sg-0123456789abcdef0'}
-        ]
+        "SecurityGroups": [{"GroupId": "sg-0123456789abcdef0"}]
     }
 
     with pytest.raises(FailedActivity) as x:
         set_security_groups(alb_names, security_group_ids)
-    assert 'Invalid security group id(s): {}'.format(
-        [security_group_ids[1]]) in str(x.value)
+    assert "Invalid security group id(s): {}".format([security_group_ids[1]]) in str(
+        x.value
+    )
 
 
 def test_set_security_group_no_subnets():
-    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    alb_names = ["test-loadbalancer-01", "test-loadbalancer-02"]
     with pytest.raises(TypeError) as x:
         set_security_groups(alb_names)
-    assert "set_security_groups() missing 1 required positional " \
-           "argument: 'security_group_ids'" in str(x.value)
+    assert (
+        "set_security_groups() missing 1 required positional "
+        "argument: 'security_group_ids'" in str(x.value)
+    )
 
 
 def test_set_security_group_no_args():
     with pytest.raises(TypeError) as x:
         set_security_groups()
-    assert "set_security_groups() missing 2 required positional arguments: " \
-           "'load_balancer_names' and 'security_group_ids" in str(x.value)
+    assert (
+        "set_security_groups() missing 2 required positional arguments: "
+        "'load_balancer_names' and 'security_group_ids" in str(x.value)
+    )
 
 
-@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+@patch("chaosaws.elbv2.actions.aws_client", autospec=True)
 def test_set_subnets(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
-    subnet_ids = ['subnet-012345678', 'subnet-abcdefg0']
+    alb_names = ["test-loadbalancer-01", "test-loadbalancer-02"]
+    subnet_ids = ["subnet-012345678", "subnet-abcdefg0"]
 
     client.describe_subnets.return_value = {
-        'Subnets': [
-            {'SubnetId': 'subnet-012345678'},
-            {'SubnetId': 'subnet-abcdefg0'}
-        ]
+        "Subnets": [{"SubnetId": "subnet-012345678"}, {"SubnetId": "subnet-abcdefg0"}]
     }
     client.describe_load_balancers.return_value = {
-        'LoadBalancers': [
+        "LoadBalancers": [
             {
-                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
-                                   '000000000000:loadbalancer/app/'
-                                   'test-loadbalancer-01/0f158eab895ab000',
-                'State': {'Code': 'active'},
-                'Type': 'application',
-                'LoadBalancerName': alb_names[0]
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:"
+                "000000000000:loadbalancer/app/"
+                "test-loadbalancer-01/0f158eab895ab000",
+                "State": {"Code": "active"},
+                "Type": "application",
+                "LoadBalancerName": alb_names[0],
             },
             {
-                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
-                                   '000000000000:loadbalancer/app/'
-                                   'test-loadbalancer-02/010aec0000fae123',
-                'State': {'Code': 'active'},
-                'Type': 'application',
-                'LoadBalancerName': alb_names[1]
-            }
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:"
+                "000000000000:loadbalancer/app/"
+                "test-loadbalancer-02/010aec0000fae123",
+                "State": {"Code": "active"},
+                "Type": "application",
+                "LoadBalancerName": alb_names[1],
+            },
         ]
-
     }
     set_subnets(alb_names, subnet_ids)
 
     calls = [
         call(
-            LoadBalancerArn='arn:aws:elasticloadbalancing:us-east-1:'
-                            '000000000000:loadbalancer/app/'
-                            'test-loadbalancer-01/0f158eab895ab000',
-            Subnets=subnet_ids),
+            LoadBalancerArn="arn:aws:elasticloadbalancing:us-east-1:"
+            "000000000000:loadbalancer/app/"
+            "test-loadbalancer-01/0f158eab895ab000",
+            Subnets=subnet_ids,
+        ),
         call(
-            LoadBalancerArn='arn:aws:elasticloadbalancing:us-east-1:'
-                            '000000000000:loadbalancer/app/'
-                            'test-loadbalancer-02/010aec0000fae123',
-            Subnets=subnet_ids)]
+            LoadBalancerArn="arn:aws:elasticloadbalancing:us-east-1:"
+            "000000000000:loadbalancer/app/"
+            "test-loadbalancer-02/010aec0000fae123",
+            Subnets=subnet_ids,
+        ),
+    ]
     client.set_subnets.assert_has_calls(calls, any_order=True)
 
 
-@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+@patch("chaosaws.elbv2.actions.aws_client", autospec=True)
 def test_set_subnets_invalid_alb_type(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
-    subnet_ids = ['subnet-012345678', 'subnet-abcdefg0']
+    alb_names = ["test-loadbalancer-01", "test-loadbalancer-02"]
+    subnet_ids = ["subnet-012345678", "subnet-abcdefg0"]
 
     client.describe_subnets.return_value = {
-        'Subnets': [
-            {'SubnetId': 'subnet-012345678'},
-            {'SubnetId': 'subnet-abcdefg0'}
-        ]
+        "Subnets": [{"SubnetId": "subnet-012345678"}, {"SubnetId": "subnet-abcdefg0"}]
     }
     client.describe_load_balancers.return_value = {
-        'LoadBalancers': [
+        "LoadBalancers": [
             {
-                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
-                                   '000000000000:loadbalancer/app/'
-                                   'test-loadbalancer-01/0f158eab895ab000',
-                'State': {'Code': 'active'},
-                'Type': 'application',
-                'LoadBalancerName': alb_names[0]
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:"
+                "000000000000:loadbalancer/app/"
+                "test-loadbalancer-01/0f158eab895ab000",
+                "State": {"Code": "active"},
+                "Type": "application",
+                "LoadBalancerName": alb_names[0],
             },
             {
-                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
-                                   '000000000000:loadbalancer/app/'
-                                   'test-loadbalancer-02/010aec0000fae123',
-                'State': {'Code': 'active'},
-                'Type': 'network',
-                'LoadBalancerName': alb_names[1]
-            }
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:"
+                "000000000000:loadbalancer/app/"
+                "test-loadbalancer-02/010aec0000fae123",
+                "State": {"Code": "active"},
+                "Type": "network",
+                "LoadBalancerName": alb_names[1],
+            },
         ]
-
     }
     with pytest.raises(FailedActivity) as x:
         set_subnets(alb_names, subnet_ids)
-    assert 'Cannot change subnets of network load balancers.' in str(x.value)
+    assert "Cannot change subnets of network load balancers." in str(x.value)
 
 
-@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+@patch("chaosaws.elbv2.actions.aws_client", autospec=True)
 def test_set_subnets_invalid_alb_name(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
-    subnet_ids = ['subnet-012345678', 'subnet-abcdefg0']
+    alb_names = ["test-loadbalancer-01", "test-loadbalancer-02"]
+    subnet_ids = ["subnet-012345678", "subnet-abcdefg0"]
 
     client.describe_subnets.return_value = {
-        'Subnets': [
-            {'SubnetId': 'subnet-012345678'},
-            {'SubnetId': 'subnet-abcdefg0'}
-        ]
+        "Subnets": [{"SubnetId": "subnet-012345678"}, {"SubnetId": "subnet-abcdefg0"}]
     }
     client.describe_load_balancers.return_value = {
-        'LoadBalancers': [
+        "LoadBalancers": [
             {
-                'LoadBalancerArn': 'arn:aws:elasticloadbalancing:us-east-1:'
-                                   '000000000000:loadbalancer/app/'
-                                   'test-loadbalancer-01/0f158eab895ab000',
-                'State': {'Code': 'active'},
-                'Type': 'application',
-                'LoadBalancerName': alb_names[0]
+                "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:"
+                "000000000000:loadbalancer/app/"
+                "test-loadbalancer-01/0f158eab895ab000",
+                "State": {"Code": "active"},
+                "Type": "application",
+                "LoadBalancerName": alb_names[0],
             }
         ]
-
     }
     with pytest.raises(FailedActivity) as x:
         set_subnets(alb_names, subnet_ids)
-    assert 'Unable to locate load balancer(s): {}'.format(
-        [alb_names[1]]) in str(x.value)
+    assert "Unable to locate load balancer(s): {}".format([alb_names[1]]) in str(
+        x.value
+    )
 
 
-@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+@patch("chaosaws.elbv2.actions.aws_client", autospec=True)
 def test_set_subnets_invalid_subnet(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
-    subnet_ids = ['subnet-012345678', 'subnet-abcdefg0']
+    alb_names = ["test-loadbalancer-01", "test-loadbalancer-02"]
+    subnet_ids = ["subnet-012345678", "subnet-abcdefg0"]
 
     client.describe_subnets.return_value = {
-        'Subnets': [
-            {'SubnetId': 'subnet-012345678'}
-        ]
+        "Subnets": [{"SubnetId": "subnet-012345678"}]
     }
 
     with pytest.raises(FailedActivity) as x:
         set_subnets(alb_names, subnet_ids)
-    assert 'Invalid subnet id(s): {}'.format([subnet_ids[1]]) in str(x.value)
+    assert "Invalid subnet id(s): {}".format([subnet_ids[1]]) in str(x.value)
 
 
 def test_set_subnet_no_subnets():
-    alb_names = ['test-loadbalancer-01', 'test-loadbalancer-02']
+    alb_names = ["test-loadbalancer-01", "test-loadbalancer-02"]
     with pytest.raises(TypeError) as x:
         set_subnets(alb_names)
 
-    assert "set_subnets() missing 1 required " \
-           "positional argument: 'subnet_ids'" in str(x.value)
+    assert (
+        "set_subnets() missing 1 required "
+        "positional argument: 'subnet_ids'" in str(x.value)
+    )
 
 
 def test_set_subnet_no_args():
     with pytest.raises(TypeError) as x:
         set_subnets()
-    assert "set_subnets() missing 2 required positional " \
-           "arguments: 'load_balancer_names' and 'subnet_ids'" in str(x.value)
+    assert (
+        "set_subnets() missing 2 required positional "
+        "arguments: 'load_balancer_names' and 'subnet_ids'" in str(x.value)
+    )
 
 
 def test_delete_load_balancer_invalid():
     with pytest.raises(TypeError) as x:
         delete_load_balancer()
-    assert "delete_load_balancer() missing 1 required positional argument: " \
-           "'load_balancer_names'" in str(x.value)
+    assert (
+        "delete_load_balancer() missing 1 required positional argument: "
+        "'load_balancer_names'" in str(x.value)
+    )
 
 
-@patch('chaosaws.elbv2.actions.aws_client', autospec=True)
+@patch("chaosaws.elbv2.actions.aws_client", autospec=True)
 def test_delete_load_balancr(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    alb_names = ['test-loadbalancer-01']
-    lb_arn = 'arn:aws:elasticloadbalancing:us-east-1:' \
-             '000000000000:loadbalancer/app/' \
-             'test-loadbalancer-01/0f158eab895ab000'
+    alb_names = ["test-loadbalancer-01"]
+    lb_arn = (
+        "arn:aws:elasticloadbalancing:us-east-1:"
+        "000000000000:loadbalancer/app/"
+        "test-loadbalancer-01/0f158eab895ab000"
+    )
 
     client.describe_load_balancers.return_value = {
-        'LoadBalancers': [
+        "LoadBalancers": [
             {
-                'LoadBalancerArn': lb_arn,
-                'State': {'Code': 'active'},
-                'Type': 'application',
-                'LoadBalancerName': alb_names[0]
+                "LoadBalancerArn": lb_arn,
+                "State": {"Code": "active"},
+                "Type": "application",
+                "LoadBalancerName": alb_names[0],
             }
         ]
     }

--- a/tests/elbv2/test_elbv2_probes.py
+++ b/tests/elbv2/test_elbv2_probes.py
@@ -1,112 +1,94 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from chaosaws.elbv2.probes import all_targets_healthy, targets_health_count
 from chaoslib.exceptions import FailedActivity
 
+from chaosaws.elbv2.probes import all_targets_healthy, targets_health_count
 
-@patch('chaosaws.elbv2.probes.aws_client', autospec=True)
+
+@patch("chaosaws.elbv2.probes.aws_client", autospec=True)
 def test_targets_health_count(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tg_names = ['TestTargetGroup1', 'TestTargetGroup2']
-    client.describe_target_groups.return_value = {"TargetGroups": [
-        {
-            'TargetGroupArn': """
+    tg_names = ["TestTargetGroup1", "TestTargetGroup2"]
+    client.describe_target_groups.return_value = {
+        "TargetGroups": [
+            {
+                "TargetGroupArn": """
             arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/TestTargetGroup1/1234567890abcdef
             """,
-            'TargetGroupName': 'TestTargetGroup1'
-        },
-        {
-            'TargetGroupArn': """
+                "TargetGroupName": "TestTargetGroup1",
+            },
+            {
+                "TargetGroupArn": """
             arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/TestTargetGroup2/234567890abcdef0
             """,
-            'TargetGroupName': 'TestTargetGroup2'
-        }
-    ]}
+                "TargetGroupName": "TestTargetGroup2",
+            },
+        ]
+    }
     client.describe_target_health.side_effect = [
-        {
-            'TargetHealthDescriptions': [{
-                'TargetHealth': {'State': 'healthy'}
-            }]
-        },
-        {
-            'TargetHealthDescriptions': [{
-                'TargetHealth': {'State': 'unhealthy'}
-            }]
-        }
+        {"TargetHealthDescriptions": [{"TargetHealth": {"State": "healthy"}}]},
+        {"TargetHealthDescriptions": [{"TargetHealth": {"State": "unhealthy"}}]},
     ]
     response = targets_health_count(tg_names=tg_names)
-    assert {'healthy': 1} in response.values()
-    assert {'unhealthy': 1} in response.values()
+    assert {"healthy": 1} in response.values()
+    assert {"unhealthy": 1} in response.values()
 
 
-@patch('chaosaws.elbv2.probes.aws_client', autospec=True)
+@patch("chaosaws.elbv2.probes.aws_client", autospec=True)
 def test_all_targets_healthy_true(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tg_names = ['TestTargetGroup1', 'TestTargetGroup2']
-    client.describe_target_groups.return_value = {"TargetGroups": [
-        {
-            'TargetGroupArn': """
+    tg_names = ["TestTargetGroup1", "TestTargetGroup2"]
+    client.describe_target_groups.return_value = {
+        "TargetGroups": [
+            {
+                "TargetGroupArn": """
             arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/TestTargetGroup1/1234567890abcdef
             """,
-            'TargetGroupName': 'TestTargetGroup1'
-        },
-        {
-            'TargetGroupArn': """
+                "TargetGroupName": "TestTargetGroup1",
+            },
+            {
+                "TargetGroupArn": """
             arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/TestTargetGroup2/234567890abcdef0
             """,
-            'TargetGroupName': 'TestTargetGroup2'
-        }
-    ]}
+                "TargetGroupName": "TestTargetGroup2",
+            },
+        ]
+    }
     client.describe_target_health.side_effect = [
-        {
-            'TargetHealthDescriptions': [{
-                'TargetHealth': {'State': 'healthy'}
-            }]
-        },
-        {
-            'TargetHealthDescriptions': [{
-                'TargetHealth': {'State': 'healthy'}
-            }]
-        }
+        {"TargetHealthDescriptions": [{"TargetHealth": {"State": "healthy"}}]},
+        {"TargetHealthDescriptions": [{"TargetHealth": {"State": "healthy"}}]},
     ]
     response = all_targets_healthy(tg_names=tg_names)
     assert response is True
 
 
-@patch('chaosaws.elbv2.probes.aws_client', autospec=True)
+@patch("chaosaws.elbv2.probes.aws_client", autospec=True)
 def test_all_targets_healthy_false(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    tg_names = ['TestTargetGroup1', 'TestTargetGroup2']
-    client.describe_target_groups.return_value = {"TargetGroups": [
-        {
-            'TargetGroupArn': """
+    tg_names = ["TestTargetGroup1", "TestTargetGroup2"]
+    client.describe_target_groups.return_value = {
+        "TargetGroups": [
+            {
+                "TargetGroupArn": """
             arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/TestTargetGroup1/1234567890abcdef
             """,
-            'TargetGroupName': 'TestTargetGroup1'
-        },
-        {
-            'TargetGroupArn': """
+                "TargetGroupName": "TestTargetGroup1",
+            },
+            {
+                "TargetGroupArn": """
             arn:aws:elasticloadbalancing:eu-west-1:111111111111:targetgroup/TestTargetGroup2/234567890abcdef0
             """,
-            'TargetGroupName': 'TestTargetGroup2'
-        }
-    ]}
+                "TargetGroupName": "TestTargetGroup2",
+            },
+        ]
+    }
     client.describe_target_health.side_effect = [
-        {
-            'TargetHealthDescriptions': [{
-                'TargetHealth': {'State': 'healthy'}
-            }]
-        },
-        {
-            'TargetHealthDescriptions': [{
-                'TargetHealth': {'State': 'unhealthy'}
-            }]
-        }
+        {"TargetHealthDescriptions": [{"TargetHealth": {"State": "healthy"}}]},
+        {"TargetHealthDescriptions": [{"TargetHealth": {"State": "unhealthy"}}]},
     ]
     response = all_targets_healthy(tg_names=tg_names)
     assert response is False

--- a/tests/emr/test_emr_actions.py
+++ b/tests/emr/test_emr_actions.py
@@ -9,121 +9,124 @@ from chaoslib.exceptions import FailedActivity
 from moto import mock_emr
 
 from chaosaws.emr.actions import (
-    modify_instance_groups_instance_count, modify_instance_groups_shrink_policy,
-    modify_instance_fleet, modify_cluster)
+    modify_cluster,
+    modify_instance_fleet,
+    modify_instance_groups_instance_count,
+    modify_instance_groups_shrink_policy,
+)
 from chaosaws.emr.probes import describe_instance_group
 
-data_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+data_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 
 def read_configs(filename):
     config = os.path.join(data_path, filename)
-    with open(config, 'r') as fh:
+    with open(config, "r") as fh:
         return loads(fh.read())
 
 
 def mock_client_error(*args, **kwargs):
     return ClientError(
-        operation_name=kwargs['op'],
-        error_response={'Error': {
-            'Code': kwargs['Code'],
-            'Message': kwargs['Message']
-        }}
+        operation_name=kwargs["op"],
+        error_response={
+            "Error": {"Code": kwargs["Code"], "Message": kwargs["Message"]}
+        },
     )
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 @mock_emr
 def start_cluster():
-    config = os.path.join(data_path, 'cluster_properties.json')
-    with open(config, 'r') as fh:
+    config = os.path.join(data_path, "cluster_properties.json")
+    with open(config, "r") as fh:
         config_data = loads(fh.read())
 
-    client = boto3.client('emr', region_name='us-east-1')
+    client = boto3.client("emr", region_name="us-east-1")
     client.run_job_flow(**config_data)
 
 
 @mock_emr
-@pytest.mark.usefixtures('start_cluster')
+@pytest.mark.usefixtures("start_cluster")
 class TestEmrActionsMoto:
     def setup(self):
-        client = boto3.client('emr', region_name='us-east-1')
-        clusters = client.list_clusters()['Clusters']
-        self.cluster_id = clusters[0]['Id']
-        self.instance_groups = client.list_instance_groups(
-            ClusterId=self.cluster_id)['InstanceGroups']
-        self.group_id0 = self.instance_groups[0]['Id']
+        client = boto3.client("emr", region_name="us-east-1")
+        clusters = client.list_clusters()["Clusters"]
+        self.cluster_id = clusters[0]["Id"]
+        self.instance_groups = client.list_instance_groups(ClusterId=self.cluster_id)[
+            "InstanceGroups"
+        ]
+        self.group_id0 = self.instance_groups[0]["Id"]
 
     def test_modify_instance_groups_instance_count(self):
         # assert original cluster RequestedInstanceCount
         params = {
-            'cluster_id': self.cluster_id,
-            'group_id': self.group_id0,
-            'configuration': {'aws_region': 'us-east-1'}
+            "cluster_id": self.cluster_id,
+            "group_id": self.group_id0,
+            "configuration": {"aws_region": "us-east-1"},
         }
         response = describe_instance_group(**params)
-        group = response['InstanceGroups']
-        assert group['Name'] == 'MasterGroupNodes'
-        assert group['RequestedInstanceCount'] == 3
+        group = response["InstanceGroups"]
+        assert group["Name"] == "MasterGroupNodes"
+        assert group["RequestedInstanceCount"] == 3
 
         # modify RequestedInstanceCount and assert changed value
         params = {
-            'cluster_id': self.cluster_id,
-            'group_id': self.instance_groups[0]['Id'],
-            'instance_count': 2,
-            'configuration': {'aws_region': 'us-east-1'}
+            "cluster_id": self.cluster_id,
+            "group_id": self.instance_groups[0]["Id"],
+            "instance_count": 2,
+            "configuration": {"aws_region": "us-east-1"},
         }
         response = modify_instance_groups_instance_count(**params)
-        group = response['InstanceGroups']
-        assert group['Name'] == 'MasterGroupNodes'
-        assert group['RequestedInstanceCount'] == 2
+        group = response["InstanceGroups"]
+        assert group["Name"] == "MasterGroupNodes"
+        assert group["RequestedInstanceCount"] == 2
 
 
 class TestEmrActionsMock:
     def setup(self):
-        self.fleet_id = 'i-IJKLMNOPQ8912'
-        self.cluster_id = 'j-BC86D9AZOOHIA'
-        self.group_id = 'i-123456789EFGH'
+        self.fleet_id = "i-IJKLMNOPQ8912"
+        self.cluster_id = "j-BC86D9AZOOHIA"
+        self.group_id = "i-123456789EFGH"
 
-    @patch('chaosaws.emr.actions.aws_client', autospec=True)
+    @patch("chaosaws.emr.actions.aws_client", autospec=True)
     def test_modify_instance_groups_invalid_cluster(self, aws_client):
-        cluster_id = 'j-123456789AAZ'
+        cluster_id = "j-123456789AAZ"
         mocked_response = mock_client_error(
-            op='ModifyInstanceGroups',
-            Code='ValidationException',
-            Message="Cluster id '%s' is not valid." % cluster_id
+            op="ModifyInstanceGroups",
+            Code="ValidationException",
+            Message="Cluster id '%s' is not valid." % cluster_id,
         )
         client = MagicMock()
         aws_client.return_value = client
         client.modify_instance_groups.side_effect = mocked_response
         params = {
-            'cluster_id': cluster_id,
-            'group_id': self.group_id,
-            'instance_count': 2
+            "cluster_id": cluster_id,
+            "group_id": self.group_id,
+            "instance_count": 2,
         }
         with pytest.raises(FailedActivity) as e:
             modify_instance_groups_instance_count(**params)
         assert "Cluster id '%s' is not valid" % cluster_id in str(e.value)
 
-    @patch('chaosaws.emr.actions.aws_client', autospec=True)
+    @patch("chaosaws.emr.actions.aws_client", autospec=True)
     def test_modify_cluster(self, aws_client):
-        mocked_response = {'StepConcurrencyLevel': 25}
+        mocked_response = {"StepConcurrencyLevel": 25}
         client = MagicMock()
         aws_client.return_value = client
         client.modify_cluster.return_value = mocked_response
 
         modify_cluster(cluster_id=self.cluster_id, concurrency=25)
         client.modify_cluster.assert_called_with(
-            ClusterId=self.cluster_id,
-            StepConcurrencyLevel=25)
+            ClusterId=self.cluster_id, StepConcurrencyLevel=25
+        )
 
-    @patch('chaosaws.emr.actions.aws_client', autospec=True)
+    @patch("chaosaws.emr.actions.aws_client", autospec=True)
     def test_modify_cluster_invalid_cluster(self, aws_client):
-        cluster_id = 'j-123456789AAZ'
+        cluster_id = "j-123456789AAZ"
         mocked_response = mock_client_error(
-            op='ModifyCluster',
-            Code='ValidationException',
-            Message="Cluster id '%s' is not valid." % cluster_id
+            op="ModifyCluster",
+            Code="ValidationException",
+            Message="Cluster id '%s' is not valid." % cluster_id,
         )
         client = MagicMock()
         aws_client.return_value = client
@@ -133,9 +136,9 @@ class TestEmrActionsMock:
             modify_cluster(cluster_id=self.cluster_id, concurrency=10)
         assert "Cluster id '%s' is not valid" % cluster_id in str(e.value)
 
-    @patch('chaosaws.emr.actions.aws_client', autospec=True)
+    @patch("chaosaws.emr.actions.aws_client", autospec=True)
     def test_modify_instance_groups_shrink_policy(self, aws_client):
-        mocked_response = read_configs('list_instance_groups_1.json')
+        mocked_response = read_configs("list_instance_groups_1.json")
         client = MagicMock()
         aws_client.return_value = client
         client.list_instance_groups.return_value = mocked_response
@@ -143,50 +146,50 @@ class TestEmrActionsMock:
 
         # modify RequestedInstanceCount and assert changed value
         params = {
-            'cluster_id': self.cluster_id,
-            'group_id': self.group_id,
-            'decommission_timeout': 180,
-            'terminate_instances': ['i-123456789123'],
-            'protect_instances': ['i-111111111111'],
-            'termination_timeout': 500
+            "cluster_id": self.cluster_id,
+            "group_id": self.group_id,
+            "decommission_timeout": 180,
+            "terminate_instances": ["i-123456789123"],
+            "protect_instances": ["i-111111111111"],
+            "termination_timeout": 500,
         }
         modify_instance_groups_shrink_policy(**params)
         client.modify_instance_groups.assert_called_with(
             ClusterId=self.cluster_id,
             InstanceGroups=[
                 {
-                    'InstanceGroupId': self.group_id,
-                    'ShrinkPolicy': {
-                        'DecommissionTimeout': 180,
-                        'InstanceResizePolicy': {
-                            'InstancesToTerminate': ['i-123456789123'],
-                            'InstancesToProtect': ['i-111111111111'],
-                            'InstanceTerminationTimeout': 500
-                        }
-                    }
+                    "InstanceGroupId": self.group_id,
+                    "ShrinkPolicy": {
+                        "DecommissionTimeout": 180,
+                        "InstanceResizePolicy": {
+                            "InstancesToTerminate": ["i-123456789123"],
+                            "InstancesToProtect": ["i-111111111111"],
+                            "InstanceTerminationTimeout": 500,
+                        },
+                    },
                 }
-            ]
+            ],
         )
 
-    @patch('chaosaws.emr.actions.aws_client', autospec=True)
+    @patch("chaosaws.emr.actions.aws_client", autospec=True)
     def test_modify_instance_groups_shrink_policy_bad_group(self, aws_client):
-        group_id = 'i-INVALIDGROUP'
+        group_id = "i-INVALIDGROUP"
         mocked_response = mock_client_error(
-            op='ModifyInstanceGroups',
-            Code='ValidationException',
-            Message="Group id '%s' is not valid." % group_id
+            op="ModifyInstanceGroups",
+            Code="ValidationException",
+            Message="Group id '%s' is not valid." % group_id,
         )
         client = MagicMock()
         aws_client.return_value = client
         client.modify_instance_groups.side_effect = mocked_response
 
         params = {
-            'cluster_id': self.cluster_id,
-            'group_id': group_id,
-            'decommission_timeout': 180,
-            'terminate_instances': ['i-123456789123'],
-            'protect_instances': ['i-111111111111'],
-            'termination_timeout': 500
+            "cluster_id": self.cluster_id,
+            "group_id": group_id,
+            "decommission_timeout": 180,
+            "terminate_instances": ["i-123456789123"],
+            "protect_instances": ["i-111111111111"],
+            "termination_timeout": 500,
         }
         with pytest.raises(FailedActivity) as e:
             modify_instance_groups_shrink_policy(**params)
@@ -194,57 +197,57 @@ class TestEmrActionsMock:
         assert "Group id '%s' is not valid" % group_id in str(e.value)
 
     def test_modify_instance_groups_shrink_policy_bad_args_1(self):
-        params = {
-            'cluster_id': self.cluster_id,
-            'group_id': self.group_id
-        }
+        params = {"cluster_id": self.cluster_id, "group_id": self.group_id}
         with pytest.raises(FailedActivity) as e:
             modify_instance_groups_shrink_policy(**params)
-        assert 'Must provide at least one of' in str(e)
+        assert "Must provide at least one of" in str(e)
 
     def test_modify_instance_groups_shrink_policy_bad_args_2(self):
         params = {
-            'cluster_id': self.cluster_id,
-            'group_id': self.group_id,
-            'decommission_timeout': 180,
-            'termination_timeout': 500
+            "cluster_id": self.cluster_id,
+            "group_id": self.group_id,
+            "decommission_timeout": 180,
+            "termination_timeout": 500,
         }
         with pytest.raises(FailedActivity) as e:
             modify_instance_groups_shrink_policy(**params)
         assert 'Must provide "terminate_instances" when' in str(e)
 
-    @patch('chaosaws.emr.actions.aws_client', autospec=True)
+    @patch("chaosaws.emr.actions.aws_client", autospec=True)
     def test_modify_instance_fleet(self, aws_client):
-        mocked_response = read_configs('list_instance_fleets_1.json')
+        mocked_response = read_configs("list_instance_fleets_1.json")
         client = MagicMock()
         aws_client.return_value = client
         client.list_instance_fleets.return_value = mocked_response
         client.modify_instance_fleet.return_value = None
 
         modify_instance_fleet(
-            cluster_id=self.cluster_id, fleet_id=self.fleet_id,
-            on_demand_capacity=3, spot_capacity=2)
+            cluster_id=self.cluster_id,
+            fleet_id=self.fleet_id,
+            on_demand_capacity=3,
+            spot_capacity=2,
+        )
         client.modify_instance_fleet.assert_called_with(
             ClusterId=self.cluster_id,
             InstanceFleet={
-                'InstanceFleetId': self.fleet_id,
-                'TargetOnDemandCapacity': 3,
-                'TargetSpotCapacity': 2
-            })
+                "InstanceFleetId": self.fleet_id,
+                "TargetOnDemandCapacity": 3,
+                "TargetSpotCapacity": 2,
+            },
+        )
 
     def test_modify_instance_fleet_no_args(self):
         with pytest.raises(FailedActivity) as e:
-            modify_instance_fleet(
-                cluster_id=self.cluster_id, fleet_id=self.fleet_id)
-        assert 'Must provide at least one of' in str(e)
+            modify_instance_fleet(cluster_id=self.cluster_id, fleet_id=self.fleet_id)
+        assert "Must provide at least one of" in str(e)
 
-    @patch('chaosaws.emr.actions.aws_client', autospec=True)
+    @patch("chaosaws.emr.actions.aws_client", autospec=True)
     def test_modify_instance_fleet_invalid_fleet(self, aws_client):
-        fleet_id = 'i-JKEIDBGHSJ34'
+        fleet_id = "i-JKEIDBGHSJ34"
         mocked_response = mock_client_error(
-            op='ModifyInstanceFleet',
-            Code='ValidationException',
-            Message="Fleet id '%s' is not valid." % fleet_id
+            op="ModifyInstanceFleet",
+            Code="ValidationException",
+            Message="Fleet id '%s' is not valid." % fleet_id,
         )
         client = MagicMock()
         aws_client.return_value = client
@@ -252,6 +255,9 @@ class TestEmrActionsMock:
 
         with pytest.raises(FailedActivity) as e:
             modify_instance_fleet(
-                cluster_id=self.cluster_id, fleet_id=fleet_id,
-                on_demand_capacity=3, spot_capacity=2)
+                cluster_id=self.cluster_id,
+                fleet_id=fleet_id,
+                on_demand_capacity=3,
+                spot_capacity=2,
+            )
         assert "Fleet id '%s' is not valid" % fleet_id in str(e.value)

--- a/tests/emr/test_emr_probes.py
+++ b/tests/emr/test_emr_probes.py
@@ -9,117 +9,121 @@ from chaoslib.exceptions import FailedActivity
 from moto import mock_emr
 
 from chaosaws.emr.probes import (
-    describe_cluster, describe_instance_group, describe_instance_fleet,
-    list_cluster_group_instances, list_cluster_fleet_instances,
-    list_emr_clusters)
+    describe_cluster,
+    describe_instance_fleet,
+    describe_instance_group,
+    list_cluster_fleet_instances,
+    list_cluster_group_instances,
+    list_emr_clusters,
+)
 
-data_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+data_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 
 def read_configs(filename):
     config = os.path.join(data_path, filename)
-    with open(config, 'r') as fh:
+    with open(config, "r") as fh:
         return loads(fh.read())
 
 
 def mock_client_error(*args, **kwargs):
     return ClientError(
-        operation_name=kwargs['op'],
-        error_response={'Error': {
-            'Code': kwargs['Code'],
-            'Message': kwargs['Message']
-        }}
+        operation_name=kwargs["op"],
+        error_response={
+            "Error": {"Code": kwargs["Code"], "Message": kwargs["Message"]}
+        },
     )
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope="class")
 @mock_emr
 def start_cluster():
-    config = os.path.join(data_path, 'cluster_properties.json')
-    with open(config, 'r') as fh:
+    config = os.path.join(data_path, "cluster_properties.json")
+    with open(config, "r") as fh:
         config_data = loads(fh.read())
 
-    client = boto3.client('emr', region_name='us-east-1')
+    client = boto3.client("emr", region_name="us-east-1")
     client.run_job_flow(**config_data)
 
 
 @mock_emr
-@pytest.mark.usefixtures('start_cluster')
+@pytest.mark.usefixtures("start_cluster")
 class TestEmrProbesMoto:
     def setup(self):
-        client = boto3.client('emr', region_name='us-east-1')
-        clusters = client.list_clusters()['Clusters']
-        self.cluster_id = clusters[0]['Id']
-        self.instance_groups = client.list_instance_groups(
-            ClusterId=self.cluster_id)['InstanceGroups']
+        client = boto3.client("emr", region_name="us-east-1")
+        clusters = client.list_clusters()["Clusters"]
+        self.cluster_id = clusters[0]["Id"]
+        self.instance_groups = client.list_instance_groups(ClusterId=self.cluster_id)[
+            "InstanceGroups"
+        ]
 
     def test_describe_cluster(self):
         params = {
-            'cluster_id': self.cluster_id,
-            'configuration': {'aws_region': 'us-east-1'}
+            "cluster_id": self.cluster_id,
+            "configuration": {"aws_region": "us-east-1"},
         }
         response = describe_cluster(**params)
-        assert response['Cluster']['Name'] == 'MyTestCluster'
+        assert response["Cluster"]["Name"] == "MyTestCluster"
 
     def test_describe_instance_group(self):
         params = {
-            'cluster_id': self.cluster_id,
-            'group_id': self.instance_groups[0]['Id'],
-            'configuration': {'aws_region': 'us-east-1'}
+            "cluster_id": self.cluster_id,
+            "group_id": self.instance_groups[0]["Id"],
+            "configuration": {"aws_region": "us-east-1"},
         }
         response = describe_instance_group(**params)
-        group = response['InstanceGroups']
-        assert group['Name'] == 'MasterGroupNodes'
+        group = response["InstanceGroups"]
+        assert group["Name"] == "MasterGroupNodes"
 
     def test_list_emr_clusters(self):
-        params = {'configuration': {'aws_region': 'us-east-1'}}
+        params = {"configuration": {"aws_region": "us-east-1"}}
         response = list_emr_clusters(**params)
-        assert response['Clusters'][0]['Id'] == self.cluster_id
+        assert response["Clusters"][0]["Id"] == self.cluster_id
 
 
 class TestEmrProbesMocked:
     def setup(self):
-        self.cluster_id = 'j-BC86D9AZOOHIA'
-        self.group_id = 'i-123456789ABCD'
-        self.fleet_id = 'i-987654321ZYWXW'
+        self.cluster_id = "j-BC86D9AZOOHIA"
+        self.group_id = "i-123456789ABCD"
+        self.fleet_id = "i-987654321ZYWXW"
 
-    @patch('chaosaws.emr.probes.aws_client', autospec=True)
+    @patch("chaosaws.emr.probes.aws_client", autospec=True)
     def test_list_cluster_fleet_instances(self, aws_client):
-        mocked_response = read_configs('list_instances_1.json')
+        mocked_response = read_configs("list_instances_1.json")
         client = MagicMock()
         aws_client.return_value = client
         client.list_instances.return_value = mocked_response
 
         response = list_cluster_fleet_instances(self.cluster_id, self.fleet_id)
-        group = response['Instances']
+        group = response["Instances"]
         assert len(group) == 2
 
         client.list_instances.assert_called_with(
-            ClusterId=self.cluster_id,
-            InstanceFleetId=self.fleet_id)
+            ClusterId=self.cluster_id, InstanceFleetId=self.fleet_id
+        )
 
-    @patch('chaosaws.emr.probes.aws_client', autospec=True)
+    @patch("chaosaws.emr.probes.aws_client", autospec=True)
     def test_list_cluster_group_instances(self, aws_client):
-        mocked_response = read_configs('list_instances_2.json')
+        mocked_response = read_configs("list_instances_2.json")
         client = MagicMock()
         aws_client.return_value = client
         client.list_instances.return_value = mocked_response
 
         response = list_cluster_group_instances(self.cluster_id, self.group_id)
-        group = response['Instances']
+        group = response["Instances"]
         assert len(group) == 4
 
         client.list_instances.assert_called_with(
-            ClusterId=self.cluster_id,
-            InstanceGroupId=self.group_id)
+            ClusterId=self.cluster_id, InstanceGroupId=self.group_id
+        )
 
-    @patch('chaosaws.emr.probes.aws_client', autospec=True)
+    @patch("chaosaws.emr.probes.aws_client", autospec=True)
     def test_list_cluster_group_instances_invalid_group(self, aws_client):
-        group_id = 'i-INVALID'
+        group_id = "i-INVALID"
         mocked_response = mock_client_error(
-            op='DescribeCluster',
-            Code='InvalidRequestException',
-            Message="Instance group id '%s' is not valid" % group_id
+            op="DescribeCluster",
+            Code="InvalidRequestException",
+            Message="Instance group id '%s' is not valid" % group_id,
         )
         client = MagicMock()
         aws_client.return_value = client
@@ -129,43 +133,42 @@ class TestEmrProbesMocked:
             list_cluster_group_instances(self.cluster_id, group_id)
         assert "Instance group id '%s' is not valid" % group_id in str(e.value)
 
-    @patch('chaosaws.emr.probes.aws_client', autospec=True)
+    @patch("chaosaws.emr.probes.aws_client", autospec=True)
     def test_describe_instance_group_invalid_cluster(self, aws_client):
-        cluster_id = 'i-INVALIDCLUSTER'
+        cluster_id = "i-INVALIDCLUSTER"
         mocked_response = mock_client_error(
-            op='DescribeCluster',
-            Code='InvalidRequestException',
-            Message="Cluster id '%s' is not valid" % cluster_id
+            op="DescribeCluster",
+            Code="InvalidRequestException",
+            Message="Cluster id '%s' is not valid" % cluster_id,
         )
         client = MagicMock()
         aws_client.return_value = client
         client.list_instance_groups.side_effect = mocked_response
 
         with pytest.raises(FailedActivity) as e:
-            describe_instance_group(cluster_id, 'i-IJKLMNOPQ8912')
+            describe_instance_group(cluster_id, "i-IJKLMNOPQ8912")
         assert "Cluster id '%s' is not valid" % cluster_id in str(e.value)
 
-    @patch('chaosaws.emr.probes.aws_client', autospec=True)
+    @patch("chaosaws.emr.probes.aws_client", autospec=True)
     def test_describe_instance_fleet(self, aws_client):
-        mocked_response = read_configs('list_instance_fleets_1.json')
+        mocked_response = read_configs("list_instance_fleets_1.json")
         client = MagicMock()
         aws_client.return_value = client
         client.list_instance_fleets.return_value = mocked_response
 
-        response = describe_instance_fleet(self.cluster_id, 'i-IJKLMNOPQ8912')
-        fleet = response['InstanceFleets']
-        assert fleet['Name'] == 'TaskFleetNodes'
+        response = describe_instance_fleet(self.cluster_id, "i-IJKLMNOPQ8912")
+        fleet = response["InstanceFleets"]
+        assert fleet["Name"] == "TaskFleetNodes"
 
-        client.list_instance_fleets.assert_called_with(
-            ClusterId=self.cluster_id)
+        client.list_instance_fleets.assert_called_with(ClusterId=self.cluster_id)
 
-    @patch('chaosaws.emr.probes.aws_client', autospec=True)
+    @patch("chaosaws.emr.probes.aws_client", autospec=True)
     def test_describe_cluster_invalid(self, aws_client):
-        cluster_id = 'i-INVALIDCLUSTER'
+        cluster_id = "i-INVALIDCLUSTER"
         mocked_response = mock_client_error(
-            op='DescribeCluster',
-            Code='InvalidRequestException',
-            Message="Cluster id '%s' is not valid" % cluster_id
+            op="DescribeCluster",
+            Code="InvalidRequestException",
+            Message="Cluster id '%s' is not valid" % cluster_id,
         )
         client = MagicMock()
         aws_client.return_value = client
@@ -175,18 +178,18 @@ class TestEmrProbesMocked:
             describe_cluster(cluster_id=cluster_id)
         assert "Cluster id '%s' is not valid" % cluster_id in str(e.value)
 
-    @patch('chaosaws.emr.probes.aws_client', autospec=True)
+    @patch("chaosaws.emr.probes.aws_client", autospec=True)
     def test_describe_instance_fleet_invalid_cluster(self, aws_client):
-        cluster_id = 'i-INVALIDCLUSTER'
+        cluster_id = "i-INVALIDCLUSTER"
         mocked_response = mock_client_error(
-            op='DescribeCluster',
-            Code='InvalidRequestException',
-            Message="Cluster id '%s' is not valid" % cluster_id
+            op="DescribeCluster",
+            Code="InvalidRequestException",
+            Message="Cluster id '%s' is not valid" % cluster_id,
         )
         client = MagicMock()
         aws_client.return_value = client
         client.list_instance_fleets.side_effect = mocked_response
 
         with pytest.raises(FailedActivity) as e:
-            describe_instance_fleet(cluster_id, 'i-IJKLMNOPQ8912')
+            describe_instance_fleet(cluster_id, "i-IJKLMNOPQ8912")
         assert "Cluster id '%s' is not valid" % cluster_id in str(e.value)

--- a/tests/iam/test_iam_actions.py
+++ b/tests/iam/test_iam_actions.py
@@ -1,11 +1,10 @@
 import json
 from unittest.mock import MagicMock, patch
 
-from chaosaws.iam.actions import (attach_role_policy, create_policy,
-                                  detach_role_policy)
+from chaosaws.iam.actions import attach_role_policy, create_policy, detach_role_policy
 
 
-@patch('chaosaws.iam.actions.aws_client', autospec=True)
+@patch("chaosaws.iam.actions.aws_client", autospec=True)
 def test_create_policy(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -16,19 +15,21 @@ def test_create_policy(aws_client):
             {
                 "Effect": "Allow",
                 "Action": "logs:CreateLogGroup",
-                "Resource": "RESOURCE_ARN"
+                "Resource": "RESOURCE_ARN",
             }
-        ]
+        ],
     }
 
     create_policy("mypolicy", policy, "/user/Jon")
     client.create_policy.assert_called_with(
-        PolicyName="mypolicy", Path="/user/Jon",
+        PolicyName="mypolicy",
+        Path="/user/Jon",
         PolicyDocument=json.dumps(policy),
-        Description="")
+        Description="",
+    )
 
 
-@patch('chaosaws.iam.actions.aws_client', autospec=True)
+@patch("chaosaws.iam.actions.aws_client", autospec=True)
 def test_attach_role_policy(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -36,11 +37,10 @@ def test_attach_role_policy(aws_client):
     arn = "aws:iam:whatever"
     role = "somerole"
     attach_role_policy(arn, role)
-    client.attach_role_policy.assert_called_with(
-        PolicyArn=arn, RoleName=role)
+    client.attach_role_policy.assert_called_with(PolicyArn=arn, RoleName=role)
 
 
-@patch('chaosaws.iam.actions.aws_client', autospec=True)
+@patch("chaosaws.iam.actions.aws_client", autospec=True)
 def test_detach_role_policy(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -48,5 +48,4 @@ def test_detach_role_policy(aws_client):
     arn = "aws:iam:whatever"
     role = "somerole"
     detach_role_policy(arn, role)
-    client.detach_role_policy.assert_called_with(
-        PolicyArn=arn, RoleName=role)
+    client.detach_role_policy.assert_called_with(PolicyArn=arn, RoleName=role)

--- a/tests/iam/test_iam_probes.py
+++ b/tests/iam/test_iam_probes.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from chaosaws.iam.probes import get_policy
 
 
-@patch('chaosaws.iam.probes.aws_client', autospec=True)
+@patch("chaosaws.iam.probes.aws_client", autospec=True)
 def test_get_role_policy(aws_client):
     client = MagicMock()
     aws_client.return_value = client

--- a/tests/rds/test_rds_actions.py
+++ b/tests/rds/test_rds_actions.py
@@ -3,119 +3,127 @@ from unittest.mock import MagicMock, patch
 import pytest
 from chaoslib.exceptions import FailedActivity
 
-from chaosaws.rds.actions import (failover_db_cluster, reboot_db_instance,
-                                  stop_db_instance, stop_db_cluster,
-                                  delete_db_instance, delete_db_cluster,
-                                  delete_db_cluster_endpoint)
+from chaosaws.rds.actions import (
+    delete_db_cluster,
+    delete_db_cluster_endpoint,
+    delete_db_instance,
+    failover_db_cluster,
+    reboot_db_instance,
+    stop_db_cluster,
+    stop_db_instance,
+)
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_failover_db_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_cluster_identifier = 'my-db-cluster-identifier'
+    db_cluster_identifier = "my-db-cluster-identifier"
     failover_db_cluster(db_cluster_identifier)
     client.failover_db_cluster.assert_called_with(
-        DBClusterIdentifier=db_cluster_identifier,
-        TargetDBInstanceIdentifier=None)
+        DBClusterIdentifier=db_cluster_identifier, TargetDBInstanceIdentifier=None
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_failover_db_cluster_with_instance_identifier(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_cluster_identifier = 'my-db-cluser-identifier'
-    target_db_instance_identifer = 'my-target-instance-identifier'
+    db_cluster_identifier = "my-db-cluser-identifier"
+    target_db_instance_identifer = "my-target-instance-identifier"
     failover_db_cluster(db_cluster_identifier, target_db_instance_identifer)
     client.failover_db_cluster.assert_called_with(
         DBClusterIdentifier=db_cluster_identifier,
-        TargetDBInstanceIdentifier=target_db_instance_identifer)
+        TargetDBInstanceIdentifier=target_db_instance_identifer,
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_failover_db_cluster_empty_string(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_cluster_identifier = ''
+    db_cluster_identifier = ""
     with pytest.raises(FailedActivity):
         failover_db_cluster(db_cluster_identifier)
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_failover_db_cluster_exception(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_cluster_identifier = 'my-db-cluster-identifier'
+    db_cluster_identifier = "my-db-cluster-identifier"
 
-    with patch.object(client, 'failover_db_cluster', FailedActivity):
+    with patch.object(client, "failover_db_cluster", FailedActivity):
         with pytest.raises(Exception):
             failover_db_cluster(db_cluster_identifier)
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_reboot_db_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_instance_identifier = 'my-db-instance-identifier'
+    db_instance_identifier = "my-db-instance-identifier"
     reboot_db_instance(db_instance_identifier)
     client.reboot_db_instance.assert_called_with(
-        DBInstanceIdentifier=db_instance_identifier,
-        ForceFailover=False)
+        DBInstanceIdentifier=db_instance_identifier, ForceFailover=False
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_reboot_db_instance_empty_string(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_instance_identifier = ''
+    db_instance_identifier = ""
     with pytest.raises(FailedActivity):
         reboot_db_instance(db_instance_identifier)
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_reboot_db_instance_exception(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_instance_identifier = 'my-db-instance-identifier'
+    db_instance_identifier = "my-db-instance-identifier"
 
-    with patch.object(client, 'reboot_db_instance', FailedActivity):
+    with patch.object(client, "reboot_db_instance", FailedActivity):
         with pytest.raises(Exception):
             reboot_db_instance(db_instance_identifier)
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_stop_db_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_id = 'some-rds-instance-identifier'
+    db_id = "some-rds-instance-identifier"
     stop_db_instance(db_instance_identifier=db_id)
     client.stop_db_instance.assert_called_with(DBInstanceIdentifier=db_id)
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_stop_db_instance_snapshot(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_id = 'some-rds-instance-identifier'
-    ss_id = 'some-rds-snapshot-identifier'
-    stop_db_instance(db_instance_identifier=db_id,
-                     db_snapshot_identifier=ss_id)
+    db_id = "some-rds-instance-identifier"
+    ss_id = "some-rds-snapshot-identifier"
+    stop_db_instance(db_instance_identifier=db_id, db_snapshot_identifier=ss_id)
     client.stop_db_instance.assert_called_with(
-        DBInstanceIdentifier=db_id, DBSnapshotIdentifier=ss_id)
+        DBInstanceIdentifier=db_id, DBSnapshotIdentifier=ss_id
+    )
 
 
 def test_stop_db_instance_exception():
     with pytest.raises(TypeError) as x:
         stop_db_instance()
-    assert "stop_db_instance() missing 1 required positional argument: " \
-           "'db_instance_identifier'" in str(x.value)
+    assert (
+        "stop_db_instance() missing 1 required positional argument: "
+        "'db_instance_identifier'" in str(x.value)
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_stop_db_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    cluster_id = 'some-aurora-cluster-identifier'
+    cluster_id = "some-aurora-cluster-identifier"
     stop_db_cluster(db_cluster_identifier=cluster_id)
     client.stop_db_cluster.assert_called_with(DBClusterIdentifier=cluster_id)
 
@@ -123,116 +131,128 @@ def test_stop_db_cluster(aws_client):
 def test_stop_db_cluster_exception():
     with pytest.raises(TypeError) as x:
         stop_db_cluster()
-    assert "stop_db_cluster() missing 1 required positional argument: " \
-           "'db_cluster_identifier'" in str(x.value)
+    assert (
+        "stop_db_cluster() missing 1 required positional argument: "
+        "'db_cluster_identifier'" in str(x.value)
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_delete_db_instance(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_id = 'some-rds-instance-identifier'
+    db_id = "some-rds-instance-identifier"
     delete_db_instance(
         db_instance_identifier=db_id,
         skip_final_snapshot=False,
-        db_snapshot_identifier='%s-final-snapshot' % db_id)
+        db_snapshot_identifier="%s-final-snapshot" % db_id,
+    )
 
     client.delete_db_instance.assert_called_with(
         DBInstanceIdentifier=db_id,
         SkipFinalSnapshot=False,
         DeleteAutomatedBackups=True,
-        FinalDBSnapshotIdentifier='%s-final-snapshot' % db_id)
+        FinalDBSnapshotIdentifier="%s-final-snapshot" % db_id,
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_delete_db_instance_snapshot(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_id = 'some-rds-instance-identifier'
-    ss_id = 'some-rds-snapshot-identifier'
+    db_id = "some-rds-instance-identifier"
+    ss_id = "some-rds-snapshot-identifier"
     delete_db_instance(
         db_instance_identifier=db_id,
         skip_final_snapshot=False,
-        db_snapshot_identifier=ss_id)
+        db_snapshot_identifier=ss_id,
+    )
 
     client.delete_db_instance.assert_called_with(
         DBInstanceIdentifier=db_id,
         SkipFinalSnapshot=False,
         DeleteAutomatedBackups=True,
-        FinalDBSnapshotIdentifier=ss_id)
+        FinalDBSnapshotIdentifier=ss_id,
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_delete_db_instance_no_snapshot(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    db_id = 'some-rds-instance-identifier'
-    delete_db_instance(
-        db_instance_identifier=db_id)
+    db_id = "some-rds-instance-identifier"
+    delete_db_instance(db_instance_identifier=db_id)
 
     client.delete_db_instance.assert_called_with(
-        DBInstanceIdentifier=db_id,
-        SkipFinalSnapshot=True,
-        DeleteAutomatedBackups=True)
+        DBInstanceIdentifier=db_id, SkipFinalSnapshot=True, DeleteAutomatedBackups=True
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_delete_db_cluster(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    cluster_id = 'some-aurora-identifier'
+    cluster_id = "some-aurora-identifier"
     delete_db_cluster(
         db_cluster_identifier=cluster_id,
         skip_final_snapshot=False,
-        db_snapshot_identifier='%s-final-snapshot' % cluster_id)
+        db_snapshot_identifier="%s-final-snapshot" % cluster_id,
+    )
 
     client.delete_db_cluster.assert_called_with(
         DBClusterIdentifier=cluster_id,
         SkipFinalSnapshot=False,
-        FinalDBSnapshotIdentifier='%s-final-snapshot' % cluster_id)
+        FinalDBSnapshotIdentifier="%s-final-snapshot" % cluster_id,
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_delete_db_cluster_snapshot(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    cluster_id = 'some-aurora-identifier'
-    snapshot_id = 'some-aurora-snapshot-identifier'
+    cluster_id = "some-aurora-identifier"
+    snapshot_id = "some-aurora-snapshot-identifier"
     delete_db_cluster(
         db_cluster_identifier=cluster_id,
         db_snapshot_identifier=snapshot_id,
-        skip_final_snapshot=False)
+        skip_final_snapshot=False,
+    )
 
     client.delete_db_cluster.assert_called_with(
         DBClusterIdentifier=cluster_id,
         SkipFinalSnapshot=False,
-        FinalDBSnapshotIdentifier=snapshot_id)
+        FinalDBSnapshotIdentifier=snapshot_id,
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_delete_db_cluster_no_snapshot(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    cluster_id = 'some-aurora-identifier'
-    delete_db_cluster(
-        db_cluster_identifier=cluster_id, skip_final_snapshot=True)
+    cluster_id = "some-aurora-identifier"
+    delete_db_cluster(db_cluster_identifier=cluster_id, skip_final_snapshot=True)
 
     client.delete_db_cluster.assert_called_with(
-        DBClusterIdentifier=cluster_id,
-        SkipFinalSnapshot=True)
+        DBClusterIdentifier=cluster_id, SkipFinalSnapshot=True
+    )
 
 
-@patch('chaosaws.rds.actions.aws_client', autospec=True)
+@patch("chaosaws.rds.actions.aws_client", autospec=True)
 def test_delete_db_cluster_endpoint(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    cluster_id = 'some-aurora-identifier'
+    cluster_id = "some-aurora-identifier"
 
     client.describe_db_clusters.return_value = {
-        'DBClusters': [{
-            'DBClusterIdentifier': cluster_id,
-            'Endpoint': '%s.domain.endpoint' % cluster_id}]}
+        "DBClusters": [
+            {
+                "DBClusterIdentifier": cluster_id,
+                "Endpoint": "%s.domain.endpoint" % cluster_id,
+            }
+        ]
+    }
 
     delete_db_cluster_endpoint(db_cluster_identifier=cluster_id)
     client.delete_db_cluster_endpoint.assert_called_with(
-        DBClusterEndpointIdentifier='%s.domain.endpoint' % cluster_id)
+        DBClusterEndpointIdentifier="%s.domain.endpoint" % cluster_id
+    )

--- a/tests/rds/test_rds_probes.py
+++ b/tests/rds/test_rds_probes.py
@@ -7,84 +7,94 @@ import pytest
 from chaoslib.exceptions import FailedActivity
 
 from chaosaws.rds.probes import (
-    instance_status, cluster_status, cluster_membership_count)
+    cluster_membership_count,
+    cluster_status,
+    instance_status,
+)
 
 
 class TestRDSProbes(TestCase):
     def setUp(self) -> None:
         data_file = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), 'rds_data.json')
-        with open(data_file, 'r') as fh:
+            os.path.dirname(os.path.abspath(__file__)), "rds_data.json"
+        )
+        with open(data_file, "r") as fh:
             self.test_data = json.loads(fh.read())
 
-    @patch('chaosaws.rds.probes.aws_client', autospec=True)
+    @patch("chaosaws.rds.probes.aws_client", autospec=True)
     def test_get_instance_status_instance_id(self, aws_client):
-        instance_id = 'MyTestInstanceRDS'
+        instance_id = "MyTestInstanceRDS"
         client = MagicMock()
         aws_client.return_value = client
-        client.get_paginator.return_value.paginate.\
-            return_value = self.test_data['instances']['single']
+        client.get_paginator.return_value.paginate.return_value = self.test_data[
+            "instances"
+        ]["single"]
 
         response = instance_status(instance_id=instance_id)
         client.get_paginator.return_value.paginate.assert_called_with(
-            DBInstanceIdentifier=instance_id)
-        self.assertEqual(response, 'available')
+            DBInstanceIdentifier=instance_id
+        )
+        self.assertEqual(response, "available")
 
-    @patch('chaosaws.rds.probes.aws_client', autospec=True)
+    @patch("chaosaws.rds.probes.aws_client", autospec=True)
     def test_get_instance_status_filters(self, aws_client):
         client = MagicMock()
         aws_client.return_value = client
-        client.get_paginator.return_value.paginate. \
-            return_value = self.test_data['instances']['multiple']
+        client.get_paginator.return_value.paginate.return_value = self.test_data[
+            "instances"
+        ]["multiple"]
 
-        filters = [{'Name': 'engine', 'Values': ['mysql']}]
+        filters = [{"Name": "engine", "Values": ["mysql"]}]
         response = instance_status(filters=filters)
-        client.get_paginator.return_value.paginate.assert_called_with(
-            Filters=filters)
-        self.assertEqual(response, 'available')
+        client.get_paginator.return_value.paginate.assert_called_with(Filters=filters)
+        self.assertEqual(response, "available")
 
     def test_get_instance_status_no_parameters(self):
         with pytest.raises(FailedActivity) as x:
             instance_status()
         self.assertIn("instance_id or filters are required", str(x))
 
-    @patch('chaosaws.rds.probes.aws_client', autospec=True)
+    @patch("chaosaws.rds.probes.aws_client", autospec=True)
     def test_get_cluster_status_cluster_id(self, aws_client):
-        cluster_id = 'MyTestClusterRDS'
+        cluster_id = "MyTestClusterRDS"
         client = MagicMock()
         aws_client.return_value = client
-        client.get_paginator.return_value.paginate. \
-            return_value = self.test_data['clusters']['single']
+        client.get_paginator.return_value.paginate.return_value = self.test_data[
+            "clusters"
+        ]["single"]
 
         response = cluster_status(cluster_id=cluster_id)
         client.get_paginator.return_value.paginate.assert_called_with(
-            DBClusterIdentifier=cluster_id)
-        self.assertEqual(response, 'available')
+            DBClusterIdentifier=cluster_id
+        )
+        self.assertEqual(response, "available")
 
-    @patch('chaosaws.rds.probes.aws_client', autospec=True)
+    @patch("chaosaws.rds.probes.aws_client", autospec=True)
     def test_get_cluster_status_filters(self, aws_client):
         client = MagicMock()
         aws_client.return_value = client
-        client.get_paginator.return_value.paginate. \
-            return_value = self.test_data['clusters']['multiple']
+        client.get_paginator.return_value.paginate.return_value = self.test_data[
+            "clusters"
+        ]["multiple"]
 
-        filters = [{'Name': 'engine', 'Values': ['mysql']}]
+        filters = [{"Name": "engine", "Values": ["mysql"]}]
         response = cluster_status(filters=filters)
-        client.get_paginator.return_value.paginate.assert_called_with(
-            Filters=filters)
-        self.assertEqual(response, 'available')
+        client.get_paginator.return_value.paginate.assert_called_with(Filters=filters)
+        self.assertEqual(response, "available")
 
-    @patch('chaosaws.rds.probes.aws_client', autospec=True)
+    @patch("chaosaws.rds.probes.aws_client", autospec=True)
     def test_get_cluster_membership_count(self, aws_client):
-        cluster_id = 'MyTestClusterRDS'
+        cluster_id = "MyTestClusterRDS"
         client = MagicMock()
         aws_client.return_value = client
-        client.get_paginator.return_value.paginate. \
-            return_value = self.test_data['clusters']['single']
+        client.get_paginator.return_value.paginate.return_value = self.test_data[
+            "clusters"
+        ]["single"]
 
         response = cluster_membership_count(cluster_id=cluster_id)
         client.get_paginator.return_value.paginate.assert_called_with(
-            DBClusterIdentifier=cluster_id)
+            DBClusterIdentifier=cluster_id
+        )
         self.assertEqual(response, 3)
 
     def test_get_cluster_status_no_parameters(self):

--- a/tests/route53/test_route53_actions.py
+++ b/tests/route53/test_route53_actions.py
@@ -6,14 +6,13 @@ import pytest
 from botocore.exceptions import ClientError
 from chaoslib.exceptions import FailedActivity
 
-from chaosaws.route53.actions import (
-    associate_vpc_with_zone, disassociate_vpc_from_zone)
+from chaosaws.route53.actions import associate_vpc_with_zone, disassociate_vpc_from_zone
 
 module_path = os.path.dirname(os.path.abspath(__file__))
 
 
 def read_in_data(filename):
-    with open(os.path.join(module_path, 'data', filename), 'r') as fh:
+    with open(os.path.join(module_path, "data", filename), "r") as fh:
         data = json.loads(fh.read())
     return data
 
@@ -21,94 +20,81 @@ def read_in_data(filename):
 def mocked_client_error(op: str):
     return ClientError(
         operation_name=op,
-        error_response={
-            'Error': {
-                'Message': 'Test Error',
-                'Code': 'Test Error'
-            }
-        }
+        error_response={"Error": {"Message": "Test Error", "Code": "Test Error"}},
     )
 
 
-@patch('chaosaws.route53.actions.aws_client', autospec=True)
+@patch("chaosaws.route53.actions.aws_client", autospec=True)
 def test_associate_vpc_with_zone(m_client):
-    mock_response = read_in_data('associate_vpc_1.json')
+    mock_response = read_in_data("associate_vpc_1.json")
     client = MagicMock()
     m_client.return_value = client
     client.associate_vpc_with_hosted_zone.return_value = mock_response
 
     response = associate_vpc_with_zone(
-        zone_id='AAAAAAAAAAAAA',
-        vpc_id='vpc-00000000',
-        vpc_region='us-east-1',
-        comment='CTK Associate'
+        zone_id="AAAAAAAAAAAAA",
+        vpc_id="vpc-00000000",
+        vpc_region="us-east-1",
+        comment="CTK Associate",
     )
 
     client.associate_vpc_with_hosted_zone.assert_called_with(
-        HostedZoneId='AAAAAAAAAAAAA',
-        VPC={
-            'VPCId': 'vpc-00000000',
-            'VPCRegion': 'us-east-1'
-        },
-        Comment='CTK Associate'
+        HostedZoneId="AAAAAAAAAAAAA",
+        VPC={"VPCId": "vpc-00000000", "VPCRegion": "us-east-1"},
+        Comment="CTK Associate",
     )
 
-    assert response['ChangeInfo']['Status'] == 'Pending'
+    assert response["ChangeInfo"]["Status"] == "Pending"
 
 
-@patch('chaosaws.route53.actions.aws_client', autospec=True)
+@patch("chaosaws.route53.actions.aws_client", autospec=True)
 def test_associate_vpc_with_zone_exception(m_client):
     client = MagicMock()
     m_client.return_value = client
     client.associate_vpc_with_hosted_zone.side_effect = mocked_client_error(
-        'associate_vpc_with_hosted_zone')
+        "associate_vpc_with_hosted_zone"
+    )
 
     with pytest.raises(FailedActivity) as e:
         associate_vpc_with_zone(
-            zone_id='1234567890123',
-            vpc_id='vpc-00000000',
-            vpc_region='us-east-1'
+            zone_id="1234567890123", vpc_id="vpc-00000000", vpc_region="us-east-1"
         )
-    assert 'Test Error' in str(e)
+    assert "Test Error" in str(e)
 
 
-@patch('chaosaws.route53.actions.aws_client', autospec=True)
+@patch("chaosaws.route53.actions.aws_client", autospec=True)
 def test_disassociate_vpc_from_zone(m_client):
-    mock_response = read_in_data('disassociate_vpc_1.json')
+    mock_response = read_in_data("disassociate_vpc_1.json")
     client = MagicMock()
     m_client.return_value = client
     client.disassociate_vpc_from_hosted_zone.return_value = mock_response
 
     response = disassociate_vpc_from_zone(
-        zone_id='AAAAAAAAAAAAA',
-        vpc_id='vpc-00000000',
-        vpc_region='us-east-1',
-        comment='CTK Disassociate'
+        zone_id="AAAAAAAAAAAAA",
+        vpc_id="vpc-00000000",
+        vpc_region="us-east-1",
+        comment="CTK Disassociate",
     )
 
     client.disassociate_vpc_from_hosted_zone.assert_called_with(
-        HostedZoneId='AAAAAAAAAAAAA',
-        VPC={
-            'VPCId': 'vpc-00000000',
-            'VPCRegion': 'us-east-1'
-        },
-        Comment='CTK Disassociate'
+        HostedZoneId="AAAAAAAAAAAAA",
+        VPC={"VPCId": "vpc-00000000", "VPCRegion": "us-east-1"},
+        Comment="CTK Disassociate",
     )
 
-    assert response['ChangeInfo']['Status'] == 'Pending'
+    assert response["ChangeInfo"]["Status"] == "Pending"
 
 
-@patch('chaosaws.route53.actions.aws_client', autospec=True)
+@patch("chaosaws.route53.actions.aws_client", autospec=True)
 def test_disassociate_vpc_with_zone_exception(m_client):
     client = MagicMock()
     m_client.return_value = client
     client.disassociate_vpc_from_hosted_zone.side_effect = mocked_client_error(
-        'disassociate_vpc_from_hosted_zone')
+        "disassociate_vpc_from_hosted_zone"
+    )
 
     with pytest.raises(FailedActivity) as e:
         disassociate_vpc_from_zone(
-            zone_id='1234567890123',
-            vpc_id='vpc-00000000',
-            vpc_region='us-east-1'
+            zone_id="1234567890123", vpc_id="vpc-00000000", vpc_region="us-east-1"
         )
-    assert 'Test Error' in str(e)
+    assert "Test Error" in str(e)

--- a/tests/route53/test_route53_probes.py
+++ b/tests/route53/test_route53_probes.py
@@ -7,121 +7,123 @@ from botocore.exceptions import ClientError
 from chaoslib.exceptions import FailedActivity
 
 from chaosaws.route53.probes import (
-    get_hosted_zone, get_dns_answer, get_health_check_status)
+    get_dns_answer,
+    get_health_check_status,
+    get_hosted_zone,
+)
 
 module_path = os.path.dirname(os.path.abspath(__file__))
 
 
 def read_in_data(filename):
-    with open(os.path.join(module_path, 'data', filename), 'r') as fh:
+    with open(os.path.join(module_path, "data", filename), "r") as fh:
         data = json.loads(fh.read())
     return data
 
 
-@patch('chaosaws.route53.probes.aws_client', autospec=True)
+@patch("chaosaws.route53.probes.aws_client", autospec=True)
 def test_get_hosted_zone(m_client):
-    mock_response = read_in_data('get_hosted_zone_1.json')
+    mock_response = read_in_data("get_hosted_zone_1.json")
     client = MagicMock()
     m_client.return_value = client
     client.get_hosted_zone.return_value = mock_response
 
-    response = get_hosted_zone(zone_id='AAAAAAAAAAAAA')
-    client.get_hosted_zone.assert_called_with(Id='AAAAAAAAAAAAA')
-    assert response['HostedZone']['Name'] == 'aws.testrecord.com.'
+    response = get_hosted_zone(zone_id="AAAAAAAAAAAAA")
+    client.get_hosted_zone.assert_called_with(Id="AAAAAAAAAAAAA")
+    assert response["HostedZone"]["Name"] == "aws.testrecord.com."
 
 
-@patch('chaosaws.route53.probes.aws_client', autospec=True)
+@patch("chaosaws.route53.probes.aws_client", autospec=True)
 def test_get_hosted_zone_not_found(m_client):
     mock_response = ClientError(
-        operation_name='get_hosted_zone',
-        error_response={'Error': {'Message': 'Test Error',
-                                  'Code': 'NoSuchHostedZone'}})
+        operation_name="get_hosted_zone",
+        error_response={"Error": {"Message": "Test Error", "Code": "NoSuchHostedZone"}},
+    )
     client = MagicMock()
     m_client.return_value = client
     client.get_hosted_zone.side_effect = mock_response
 
     with pytest.raises(FailedActivity) as e:
-        get_hosted_zone(zone_id='BBBBBBBBBBBBB')
-    assert 'Hosted Zone BBBBBBBBBBBBB not found.' in str(e)
+        get_hosted_zone(zone_id="BBBBBBBBBBBBB")
+    assert "Hosted Zone BBBBBBBBBBBBB not found." in str(e)
 
 
-@patch('chaosaws.route53.probes.aws_client', autospec=True)
+@patch("chaosaws.route53.probes.aws_client", autospec=True)
 def test_get_health_check_status(m_client):
-    mock_response = read_in_data('get_health_check_status_1.json')
+    mock_response = read_in_data("get_health_check_status_1.json")
     client = MagicMock()
     m_client.return_value = client
     client.get_health_check_status.return_value = mock_response
 
-    response = get_health_check_status(
-        check_id='00000000-0000-0000-0000-000000000000')
+    response = get_health_check_status(check_id="00000000-0000-0000-0000-000000000000")
 
     client.get_health_check_status.assert_called_with(
-        HealthCheckId='00000000-0000-0000-0000-000000000000')
-    assert len(response['HealthCheckObservations']) == 2
+        HealthCheckId="00000000-0000-0000-0000-000000000000"
+    )
+    assert len(response["HealthCheckObservations"]) == 2
 
 
-@patch('chaosaws.route53.probes.aws_client', autospec=True)
+@patch("chaosaws.route53.probes.aws_client", autospec=True)
 def test_get_health_check_status_not_found(m_client):
     mock_response = ClientError(
-        operation_name='get_hosted_zone',
-        error_response={'Error': {'Message': 'Test Error',
-                                  'Code': 'NoSuchHealthCheck'}})
+        operation_name="get_hosted_zone",
+        error_response={
+            "Error": {"Message": "Test Error", "Code": "NoSuchHealthCheck"}
+        },
+    )
     client = MagicMock()
     m_client.return_value = client
     client.get_health_check_status.side_effect = mock_response
 
     with pytest.raises(FailedActivity) as e:
-        get_health_check_status(
-            check_id='00000000-1111-1111-1111-000000000000')
-    assert 'Test Error' in str(e)
+        get_health_check_status(check_id="00000000-1111-1111-1111-000000000000")
+    assert "Test Error" in str(e)
 
 
-@patch('chaosaws.route53.probes.aws_client', autospec=True)
+@patch("chaosaws.route53.probes.aws_client", autospec=True)
 def test_get_health_check_status_no_results(m_client):
-    mock_response = {'HealthCheckObservations': []}
+    mock_response = {"HealthCheckObservations": []}
     client = MagicMock()
     m_client.return_value = client
     client.get_health_check_status.return_value = mock_response
 
     with pytest.raises(FailedActivity) as e:
-        get_health_check_status(
-            check_id='00000000-2222-2222-2222-000000000000')
-    assert 'No results found for' in str(e)
+        get_health_check_status(check_id="00000000-2222-2222-2222-000000000000")
+    assert "No results found for" in str(e)
 
 
-@patch('chaosaws.route53.probes.aws_client', autospec=True)
+@patch("chaosaws.route53.probes.aws_client", autospec=True)
 def test_get_dns_answer(m_client):
-    mock_response = read_in_data('test_dns_answer_1.json')
+    mock_response = read_in_data("test_dns_answer_1.json")
     client = MagicMock()
     m_client.return_value = client
     client.test_dns_answer.return_value = mock_response
 
     response = get_dns_answer(
-        zone_id='AAAAAAAAAAAAA',
-        record_name='aws.testrecord.com',
-        record_type='A')
+        zone_id="AAAAAAAAAAAAA", record_name="aws.testrecord.com", record_type="A"
+    )
 
     client.test_dns_answer.assert_called_with(
-        HostedZoneId='AAAAAAAAAAAAA',
-        RecordName='aws.testrecord.com',
-        RecordType='A')
+        HostedZoneId="AAAAAAAAAAAAA", RecordName="aws.testrecord.com", RecordType="A"
+    )
 
-    assert response['ResponseCode'] == 'NOERROR'
+    assert response["ResponseCode"] == "NOERROR"
 
 
-@patch('chaosaws.route53.probes.aws_client', autospec=True)
+@patch("chaosaws.route53.probes.aws_client", autospec=True)
 def test_get_dns_answer_not_found(m_client):
     mock_response = ClientError(
-        operation_name='get_hosted_zone',
-        error_response={'Error': {'Message': 'Test Error',
-                                  'Code': 'NoSuchHealthCheck'}})
+        operation_name="get_hosted_zone",
+        error_response={
+            "Error": {"Message": "Test Error", "Code": "NoSuchHealthCheck"}
+        },
+    )
     client = MagicMock()
     m_client.return_value = client
     client.test_dns_answer.side_effect = mock_response
 
     with pytest.raises(FailedActivity) as e:
         get_dns_answer(
-            zone_id='BBBBBBBBBBBBB',
-            record_name='aws.testrecord.com',
-            record_type='A')
-    assert 'Test Error' in str(e)
+            zone_id="BBBBBBBBBBBBB", record_name="aws.testrecord.com", record_type="A"
+        )
+    assert "Test Error" in str(e)

--- a/tests/ssm/test_ssm_actions.py
+++ b/tests/ssm/test_ssm_actions.py
@@ -1,51 +1,69 @@
-from unittest.mock import MagicMock, patch,mock_open
 import os
+from unittest.mock import MagicMock, mock_open, patch
+
 import pytest
 from chaoslib.exceptions import ActivityFailed
-from chaosaws.ssm.actions import (create_document, send_command,
-                                  delete_document)
+
+from chaosaws.ssm.actions import create_document, delete_document, send_command
 
 
-@patch('chaosaws.ssm.actions.aws_client', autospec=True)
+@patch("chaosaws.ssm.actions.aws_client", autospec=True)
 def test_create_documente_with_params_required_empty(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    name=''
-    content=''
+    name = ""
+    content = ""
     with pytest.raises(ActivityFailed):
-        create_document(path_content=content,name=name)
+        create_document(path_content=content, name=name)
 
 
-@patch('chaosaws.ssm.actions.aws_client', autospec=True)
+@patch("chaosaws.ssm.actions.aws_client", autospec=True)
 def test_send_command_with_params_required_empty(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    document_name=''
+    document_name = ""
     with pytest.raises(ActivityFailed):
         send_command(document_name=document_name)
 
-@patch('chaosaws.ssm.actions.aws_client', autospec=True)
+
+@patch("chaosaws.ssm.actions.aws_client", autospec=True)
 def test_send_command(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    document_name='some_document_name'
-    send_command(document_name=document_name,document_version='some_Document_version',max_concurrency="1",max_errors="2",parameters={'value':'some_value'},region='some_region')
-    client.send_command(DocumentName=document_name,DocumentVersion='some_Document_version',MaxConcurrency="1",MaxErrors="2",Parameters=[{'value':'some_value'}],Region='some_region')
+    document_name = "some_document_name"
+    send_command(
+        document_name=document_name,
+        document_version="some_Document_version",
+        max_concurrency="1",
+        max_errors="2",
+        parameters={"value": "some_value"},
+        region="some_region",
+    )
+    client.send_command(
+        DocumentName=document_name,
+        DocumentVersion="some_Document_version",
+        MaxConcurrency="1",
+        MaxErrors="2",
+        Parameters=[{"value": "some_value"}],
+        Region="some_region",
+    )
 
 
-@patch('chaosaws.ssm.actions.aws_client', autospec=True)
+@patch("chaosaws.ssm.actions.aws_client", autospec=True)
 def test_delete_document_with_params_required_empty(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    name=''
+    name = ""
     with pytest.raises(ActivityFailed):
         delete_document(name=name)
 
-@patch('chaosaws.ssm.actions.aws_client', autospec=True)
+
+@patch("chaosaws.ssm.actions.aws_client", autospec=True)
 def test_delete_document(aws_client):
     client = MagicMock()
     aws_client.return_value = client
-    name='some_name'
-    delete_document(name=name,version_name='some_version',force='some_force')
-    client.delete_document(Name=name,DocumentVersion='some_version',Force='some_force')
-
+    name = "some_name"
+    delete_document(name=name, version_name="some_version", force="some_force")
+    client.delete_document(
+        Name=name, DocumentVersion="some_version", Force="some_force"
+    )

--- a/tests/ssm/test_ssm_actions.py
+++ b/tests/ssm/test_ssm_actions.py
@@ -1,5 +1,4 @@
-import os
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from chaoslib.exceptions import ActivityFailed

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -123,7 +123,6 @@ def test_create_client_from_profile_name(boto3: object):
 def test_create_client_with_aws_role_arn(boto3: object):
     boto3.DEFAULT_SESSION = None
     creds = get_credentials(dict())
-    finalArgs = {}
 
     aws_client("ecs", configuration=CONFIG_WITH_ARN)
     boto3.client.assert_any_call("sts", region_name="us-east-1", **creds)
@@ -153,7 +152,6 @@ def test_create_client_with_aws_role_arn(boto3: object):
 def test_create_client_with_aws_role_arn_and_profile(boto3: object):
     boto3.DEFAULT_SESSION = None
     creds = get_credentials(dict())
-    finalArgs = {}
 
     aws_client("ecs", configuration=CONFIG_WITH_ARN_AND_PROFILE)
     boto3.client.assert_any_call("sts", region_name="us-east-1", **creds)
@@ -183,7 +181,6 @@ def test_create_client_with_aws_role_arn_and_profile(boto3: object):
 @patch("chaosaws.logger", autospec=True)
 def test_region_must_be_set(logger: logging.Logger, boto3: object):
     boto3.DEFAULT_SESSION = None
-    creds = get_credentials(dict())
 
     with pytest.raises(InterruptExecution):
         aws_client("ecs")
@@ -197,7 +194,6 @@ def test_region_must_be_set(logger: logging.Logger, boto3: object):
 @patch("chaosaws.logger", autospec=True)
 def test_region_can_be_set_as_AWS_REGION(logger: logging.Logger, boto3: object):
     boto3.DEFAULT_SESSION = None
-    creds = get_credentials(dict())
 
     try:
         os.environ["AWS_REGION"] = "us-west-2"
@@ -208,7 +204,7 @@ def test_region_can_be_set_as_AWS_REGION(logger: logging.Logger, boto3: object):
         )
         logger.warning.assert_not_called()
         logger.debug.assert_any_call("Using AWS region 'us-west2'")
-    except:
+    except Exception:
         os.environ.pop("AWS_REGION", None)
 
 
@@ -216,7 +212,6 @@ def test_region_can_be_set_as_AWS_REGION(logger: logging.Logger, boto3: object):
 @patch("chaosaws.logger", autospec=True)
 def test_region_can_be_set_as_AWS_DEFAULT_REGION(logger: logging.Logger, boto3: object):
     boto3.DEFAULT_SESSION = None
-    creds = get_credentials(dict())
 
     try:
         os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
@@ -227,7 +222,7 @@ def test_region_can_be_set_as_AWS_DEFAULT_REGION(logger: logging.Logger, boto3: 
         )
         logger.warning.assert_not_called()
         logger.debug.assert_any_call("Using AWS region 'us-west2'")
-    except:
+    except Exception:
         os.environ.pop("AWS_DEFAULT_REGION", None)
 
 
@@ -235,7 +230,6 @@ def test_region_can_be_set_as_AWS_DEFAULT_REGION(logger: logging.Logger, boto3: 
 @patch("chaosaws.logger", autospec=True)
 def test_region_can_be_set_via_config(logger: logging.Logger, boto3: object):
     boto3.DEFAULT_SESSION = None
-    creds = get_credentials(dict())
 
     aws_client("ecs", configuration={"aws_region": "us-west2"})
     logger.debug.assert_any_call("Using AWS region 'us-west2'")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,15 +1,14 @@
 import json
 import logging
 import os
-from unittest.mock import MagicMock, patch, ANY
-from urllib.parse import urlparse, parse_qs
+from unittest.mock import ANY, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
-from chaoslib.exceptions import InterruptExecution
 import pytest
 import requests_mock
+from chaoslib.exceptions import InterruptExecution
 
 from chaosaws import aws_client, get_credentials, signed_api_call
-
 
 CONFIGURATION = {
     "aws_region": "us-east-1",
@@ -17,20 +16,14 @@ CONFIGURATION = {
     "aws_endpoint_scheme": "http",
 }
 
-CONFIG_WITH_PROFILE = {
-    "aws_region": "us-east-1",
-    "aws_profile_name": "myprofile"
-}
+CONFIG_WITH_PROFILE = {"aws_region": "us-east-1", "aws_profile_name": "myprofile"}
 
-CONFIG_WITH_ARN = {
-    "aws_region": "us-east-1",
-    "aws_assume_role_arn": "myarn"
-}
+CONFIG_WITH_ARN = {"aws_region": "us-east-1", "aws_assume_role_arn": "myarn"}
 
 CONFIG_WITH_ARN_AND_PROFILE = {
     "aws_region": "us-east-1",
     "aws_profile_name": "myprofile",
-    "aws_assume_role_arn": "myarn"
+    "aws_assume_role_arn": "myarn",
 }
 
 SECRETS = {
@@ -44,21 +37,18 @@ ENDPOINT = "http://eks.us-east-1.localhost"
 
 def test_signed_api_call_with_params():
     with requests_mock.Mocker() as m:
-        url = '{}/some/path'.format(ENDPOINT)
+        url = "{}/some/path".format(ENDPOINT)
         m.get(url, complete_qs=False, text="someresponse")
 
         r = signed_api_call(
-            'eks',
-            path='/some/path',
+            "eks",
+            path="/some/path",
             configuration=CONFIGURATION,
             secrets=SECRETS,
-            params={
-                "Action": "Terminate",
-                "NodeId.1": "12345"
-            }
+            params={"Action": "Terminate", "NodeId.1": "12345"},
         )
 
-        assert 'Authorization' in r.request.headers
+        assert "Authorization" in r.request.headers
         assert r.text == "someresponse"
 
         p = urlparse(r.request.url)
@@ -75,25 +65,22 @@ def test_signed_api_call_with_params():
 
 def test_signed_api_call_with_body():
     with requests_mock.Mocker() as m:
-        url = '{}/some/path'.format(ENDPOINT)
+        url = "{}/some/path".format(ENDPOINT)
         m.post(url, complete_qs=False, text="someresponse")
 
         r = signed_api_call(
-            'eks',
-            path='/some/path',
+            "eks",
+            path="/some/path",
             configuration=CONFIGURATION,
             secrets=SECRETS,
-            method='POST',
-            params={
-                "Action": "Terminate",
-                "NodeId.1": "12345"
-            }
+            method="POST",
+            params={"Action": "Terminate", "NodeId.1": "12345"},
         )
 
-        assert 'Authorization' in r.request.headers
+        assert "Authorization" in r.request.headers
         assert r.text == "someresponse"
 
-        body = json.loads(r.request.body.decode('utf-8'))
+        body = json.loads(r.request.body.decode("utf-8"))
 
         assert "Action" in body
         assert body["Action"] == "Terminate"
@@ -102,159 +89,154 @@ def test_signed_api_call_with_body():
         assert body["NodeId.1"] == "12345"
 
 
-@patch('chaosaws.boto3', autospec=True)
+@patch("chaosaws.boto3", autospec=True)
 def test_create_client_from_cred_keys(boto3: object):
     boto3.DEFAULT_SESSION = None
     creds = get_credentials(SECRETS)
 
-    aws_client('ecs', configuration=CONFIGURATION, secrets=SECRETS)
-    boto3.client.assert_called_with(
-        'ecs', region_name="us-east-1", **creds)
+    aws_client("ecs", configuration=CONFIGURATION, secrets=SECRETS)
+    boto3.client.assert_called_with("ecs", region_name="us-east-1", **creds)
 
-    aws_client('ecs', configuration=CONFIGURATION, secrets=SECRETS)
+    aws_client("ecs", configuration=CONFIGURATION, secrets=SECRETS)
     boto3.setup_default_session.assert_called_with(
-        profile_name=None, region_name="us-east-1", **creds)
-    boto3.client.assert_called_with(
-        'ecs', region_name="us-east-1", **creds)
+        profile_name=None, region_name="us-east-1", **creds
+    )
+    boto3.client.assert_called_with("ecs", region_name="us-east-1", **creds)
 
 
-@patch('chaosaws.boto3', autospec=True)
+@patch("chaosaws.boto3", autospec=True)
 def test_create_client_from_profile_name(boto3: object):
     boto3.DEFAULT_SESSION = None
     creds = get_credentials(dict())
 
-    aws_client(
-        'ecs', configuration=CONFIG_WITH_PROFILE)
-    boto3.client.assert_called_with(
-        'ecs', region_name="us-east-1", **creds)
+    aws_client("ecs", configuration=CONFIG_WITH_PROFILE)
+    boto3.client.assert_called_with("ecs", region_name="us-east-1", **creds)
 
-    aws_client(
-        'ecs', configuration=CONFIG_WITH_PROFILE)
+    aws_client("ecs", configuration=CONFIG_WITH_PROFILE)
     boto3.setup_default_session.assert_called_with(
-        profile_name="myprofile", region_name="us-east-1", **creds)
-    boto3.client.assert_called_with(
-        'ecs', region_name="us-east-1", **creds)
+        profile_name="myprofile", region_name="us-east-1", **creds
+    )
+    boto3.client.assert_called_with("ecs", region_name="us-east-1", **creds)
 
 
-@patch('chaosaws.boto3', autospec=True)
+@patch("chaosaws.boto3", autospec=True)
 def test_create_client_with_aws_role_arn(boto3: object):
     boto3.DEFAULT_SESSION = None
     creds = get_credentials(dict())
     finalArgs = {}
 
-    aws_client(
-        'ecs', configuration=CONFIG_WITH_ARN)
-    boto3.client.assert_any_call(
-        'sts', region_name="us-east-1", **creds)
+    aws_client("ecs", configuration=CONFIG_WITH_ARN)
+    boto3.client.assert_any_call("sts", region_name="us-east-1", **creds)
     boto3.client.assert_called_with(
-            'ecs',
-            region_name="us-east-1",
-            aws_access_key_id=ANY,
-            aws_secret_access_key=ANY,
-            aws_session_token=ANY)
+        "ecs",
+        region_name="us-east-1",
+        aws_access_key_id=ANY,
+        aws_secret_access_key=ANY,
+        aws_session_token=ANY,
+    )
 
-    aws_client(
-        'ecs', configuration=CONFIG_WITH_ARN)
-    boto3.client.assert_any_call(
-        'sts', region_name="us-east-1", **creds)
+    aws_client("ecs", configuration=CONFIG_WITH_ARN)
+    boto3.client.assert_any_call("sts", region_name="us-east-1", **creds)
     boto3.setup_default_session.assert_called_with(
-            profile_name=None, region_name="us-east-1", **creds)
+        profile_name=None, region_name="us-east-1", **creds
+    )
     boto3.client.assert_called_with(
-            'ecs',
-            region_name="us-east-1",
-            aws_access_key_id=ANY,
-            aws_secret_access_key=ANY,
-            aws_session_token=ANY)
+        "ecs",
+        region_name="us-east-1",
+        aws_access_key_id=ANY,
+        aws_secret_access_key=ANY,
+        aws_session_token=ANY,
+    )
 
 
-@patch('chaosaws.boto3', autospec=True)
+@patch("chaosaws.boto3", autospec=True)
 def test_create_client_with_aws_role_arn_and_profile(boto3: object):
     boto3.DEFAULT_SESSION = None
     creds = get_credentials(dict())
     finalArgs = {}
 
-    aws_client(
-        'ecs', configuration=CONFIG_WITH_ARN_AND_PROFILE)
-    boto3.client.assert_any_call(
-        'sts', region_name="us-east-1", **creds)
+    aws_client("ecs", configuration=CONFIG_WITH_ARN_AND_PROFILE)
+    boto3.client.assert_any_call("sts", region_name="us-east-1", **creds)
     boto3.client.assert_called_with(
-            'ecs',
-            region_name="us-east-1",
-            aws_access_key_id=ANY,
-            aws_secret_access_key=ANY,
-            aws_session_token=ANY)
+        "ecs",
+        region_name="us-east-1",
+        aws_access_key_id=ANY,
+        aws_secret_access_key=ANY,
+        aws_session_token=ANY,
+    )
 
-    aws_client(
-        'ecs', configuration=CONFIG_WITH_ARN_AND_PROFILE)
-    boto3.client.assert_any_call(
-        'sts', region_name="us-east-1", **creds)
+    aws_client("ecs", configuration=CONFIG_WITH_ARN_AND_PROFILE)
+    boto3.client.assert_any_call("sts", region_name="us-east-1", **creds)
     boto3.setup_default_session.assert_called_with(
-            profile_name="myprofile", region_name="us-east-1", **creds)
+        profile_name="myprofile", region_name="us-east-1", **creds
+    )
     boto3.client.assert_called_with(
-            'ecs',
-            region_name="us-east-1",
-            aws_access_key_id=ANY,
-            aws_secret_access_key=ANY,
-            aws_session_token=ANY)
+        "ecs",
+        region_name="us-east-1",
+        aws_access_key_id=ANY,
+        aws_secret_access_key=ANY,
+        aws_session_token=ANY,
+    )
 
 
-@patch('chaosaws.boto3', autospec=True)
-@patch('chaosaws.logger', autospec=True)
+@patch("chaosaws.boto3", autospec=True)
+@patch("chaosaws.logger", autospec=True)
 def test_region_must_be_set(logger: logging.Logger, boto3: object):
     boto3.DEFAULT_SESSION = None
     creds = get_credentials(dict())
 
     with pytest.raises(InterruptExecution):
-        aws_client('ecs')
+        aws_client("ecs")
         logger.debug.assert_any_call(
-            'The configuration key `aws_region` is not set, looking in the '
-            'environment instead for `AWS_REGION` or `AWS_DEFAULT_REGION`')
+            "The configuration key `aws_region` is not set, looking in the "
+            "environment instead for `AWS_REGION` or `AWS_DEFAULT_REGION`"
+        )
 
 
-@patch('chaosaws.boto3', autospec=True)
-@patch('chaosaws.logger', autospec=True)
+@patch("chaosaws.boto3", autospec=True)
+@patch("chaosaws.logger", autospec=True)
 def test_region_can_be_set_as_AWS_REGION(logger: logging.Logger, boto3: object):
     boto3.DEFAULT_SESSION = None
     creds = get_credentials(dict())
 
     try:
         os.environ["AWS_REGION"] = "us-west-2"
-        aws_client('ecs')
+        aws_client("ecs")
         logger.debug.assert_any_call(
-            'The configuration key `aws_region` is not set, looking in the '
-            'environment instead for `AWS_REGION` or `AWS_DEFAULT_REGION`')
+            "The configuration key `aws_region` is not set, looking in the "
+            "environment instead for `AWS_REGION` or `AWS_DEFAULT_REGION`"
+        )
         logger.warning.assert_not_called()
         logger.debug.assert_any_call("Using AWS region 'us-west2'")
     except:
         os.environ.pop("AWS_REGION", None)
 
 
-@patch('chaosaws.boto3', autospec=True)
-@patch('chaosaws.logger', autospec=True)
-def test_region_can_be_set_as_AWS_DEFAULT_REGION(
-        logger: logging.Logger, boto3: object):
+@patch("chaosaws.boto3", autospec=True)
+@patch("chaosaws.logger", autospec=True)
+def test_region_can_be_set_as_AWS_DEFAULT_REGION(logger: logging.Logger, boto3: object):
     boto3.DEFAULT_SESSION = None
     creds = get_credentials(dict())
 
     try:
         os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
-        aws_client('ecs')
+        aws_client("ecs")
         logger.debug.assert_any_call(
-            'The configuration key `aws_region` is not set, looking in the '
-            'environment instead for `AWS_REGION` or `AWS_DEFAULT_REGION`')
+            "The configuration key `aws_region` is not set, looking in the "
+            "environment instead for `AWS_REGION` or `AWS_DEFAULT_REGION`"
+        )
         logger.warning.assert_not_called()
         logger.debug.assert_any_call("Using AWS region 'us-west2'")
     except:
         os.environ.pop("AWS_DEFAULT_REGION", None)
 
 
-@patch('chaosaws.boto3', autospec=True)
-@patch('chaosaws.logger', autospec=True)
-def test_region_can_be_set_via_config(
-        logger: logging.Logger, boto3: object):
+@patch("chaosaws.boto3", autospec=True)
+@patch("chaosaws.logger", autospec=True)
+def test_region_can_be_set_via_config(logger: logging.Logger, boto3: object):
     boto3.DEFAULT_SESSION = None
     creds = get_credentials(dict())
 
-    aws_client('ecs', configuration={"aws_region": "us-west2"})
+    aws_client("ecs", configuration={"aws_region": "us-west2"})
     logger.debug.assert_any_call("Using AWS region 'us-west2'")
     logger.warning.assert_not_called()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 #
 from unittest import TestCase
+
 from chaosaws.utils import breakup_iterable
 
 
@@ -7,7 +8,7 @@ class TestUtilities(TestCase):
     def test_breakup_iterable(self):
         iterable = []
         for i in range(0, 100):
-            iterable.append('Object%s' % i)
+            iterable.append("Object%s" % i)
 
         iteration = []
         for group in breakup_iterable(iterable, 25):


### PR DESCRIPTION
This PR applies `black`, `flake8`, and `isort` across the whole codebase

In general it:
- Removes unused imports
- Formats whitespace around : as per blacks setting
- Renames single letter variables
- Ignores W503 - not black compatible
- Remove unused variables and fix blank except blocks
