### PR TITLE
Add `fis.actions.start_experiment` for AWS FIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - adding put_metric_data to cloudwatch actions
 - added GitHub Actions Workflows for Build and Test, Build and Discover, and Releasing
 - added `Makefile` to abstract away common commands: `install`, `install-dev`, `lint`, `format`, `tests`
+- added `chaosaws.fis.actions.start_experiment` to start an AWS FIS experiment
 
 ### Removed
 - Removed TravisCI related files

--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -254,4 +254,5 @@ def load_exported_activities() -> List[DiscoveredActivities]:
     activities.extend(discover_actions("chaosaws.route53.actions"))
     activities.extend(discover_probes("chaosaws.route53.probes"))
     activities.extend(discover_probes("chaosaws.ssm.actions"))
+    activities.extend(discover_actions("chaosaws.fis.actions"))
     return activities

--- a/chaosaws/fis/actions.py
+++ b/chaosaws/fis/actions.py
@@ -1,0 +1,41 @@
+from typing import Dict
+
+from chaoslib.exceptions import FailedActivity
+from chaoslib.types import Configuration, Secrets
+
+from chaosaws import aws_client
+from chaosaws.types import AWSResponse
+
+
+__all__ = ["start_experiment"]
+
+
+def start_experiment(
+    experiment_template_id: str,
+    client_token: str = None,
+    tags: Dict[str, str] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
+
+    if not experiment_template_id:
+        raise FailedActivity(
+            "You must pass a valid experiment template id, id provided was empty"
+        )
+
+    fis_client = aws_client(
+        resource_name="fis", configuration=configuration, secrets=secrets
+    )
+
+    params = {"experimentTemplateId": experiment_template_id}
+    if client_token:
+        params["clientToken"] = client_token
+    if tags:
+        params["tags"] = tags
+
+    try:
+        return fis_client.start_experiment(**params)
+    except Exception as ex:
+        raise FailedActivity(
+            f"Start Experiment failed, reason was: {ex}"
+        )

--- a/chaosaws/fis/actions.py
+++ b/chaosaws/fis/actions.py
@@ -16,6 +16,40 @@ def start_experiment(
     configuration: Configuration = None,
     secrets: Secrets = None,
 ) -> AWSResponse:
+    """
+    Starts running an experiment from the specified experiment template.
+
+    :param experiment_template_id: str representing the id of the experiment template
+        to run
+    :param client_token: str representing the unique identifier for this experiment run.
+        If a value is not provided, boto3 generates one for you
+    :param tags: Dict[str, str] representing tags to apply to the experiment that is
+        started
+    :param configuration: Configuration object representing the CTK Configuration
+    :param secrets: Secret object representing the CTK Secrets
+    :returns: AWSResponse representing the response from FIS upon starting the
+        experiment
+
+    Examples
+    --------
+    >>> start_experiment(
+    ...     experiment_template_id="EXT6oWVA1WrLNy4XS"
+    ... )
+    {
+    'ResponseMetadata': {'RequestId': '1ceaedae-5897-4b64-9ade-9e94449f1262',
+    'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Thu, 12 Aug 2021 14:21:19 GMT',
+    ...
+    'experiment': {'id': 'EXPXDPecuQBFiZs1Jz',
+    'experimentTemplateId': 'EXT6oWVA1WrLNy4XS',
+    ...
+    }
+
+    >>> start_experiment(
+    ...     experiment_template_id="EXT6oWVA1WrLNy4XS",
+    ...     client_token="my-unique-token",
+    ...     tags={"a-key": "a-value"}
+    ... )
+    """
 
     if not experiment_template_id:
         raise FailedActivity(

--- a/chaosaws/fis/actions.py
+++ b/chaosaws/fis/actions.py
@@ -6,7 +6,6 @@ from chaoslib.types import Configuration, Secrets
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-
 __all__ = ["start_experiment"]
 
 
@@ -36,6 +35,4 @@ def start_experiment(
     try:
         return fis_client.start_experiment(**params)
     except Exception as ex:
-        raise FailedActivity(
-            f"Start Experiment failed, reason was: {ex}"
-        )
+        raise FailedActivity(f"Start Experiment failed, reason was: {ex}")

--- a/tests/fis/test_fis_actions.py
+++ b/tests/fis/test_fis_actions.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from chaoslib.exceptions import FailedActivity
+
+from chaosaws.fis.actions import start_experiment
+
+
+def test_that_fis_module_exposes_correct_all_attributes():
+    import chaosaws.fis.actions as actions
+    all = actions.__all__
+    assert "start_experiment" in all
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_start_experiment_invoked_correctly_if_only_given_template_id(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+
+    start_experiment(experiment_template_id="an-id")
+    client.start_experiment.assert_called_once_with(experimentTemplateId="an-id")
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_start_experiment_invoked_correctly_if_given_all_params(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+
+    start_experiment(
+        experiment_template_id="an-id",
+        client_token="a-token",
+        tags={"test-tag": "a-value"},
+    )
+    client.start_experiment.assert_called_once_with(
+        experimentTemplateId="an-id",
+        clientToken="a-token",
+        tags={"test-tag": "a-value"},
+    )
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_start_experiment_fails_if_template_id_empty_or_none(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+
+    with pytest.raises(FailedActivity) as ex:
+        start_experiment(experiment_template_id="")
+    assert str(ex.value) == (
+        "You must pass a valid experiment template id, id provided was empty"
+    )
+
+    with pytest.raises(FailedActivity) as ex:
+        start_experiment(experiment_template_id=None)
+    assert str(ex.value) == (
+        "You must pass a valid experiment template id, id provided was empty"
+    )
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_start_experiment_fails_if_exception_raised(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    client.start_experiment.side_effect = Exception("Something went wrong")
+
+    with pytest.raises(FailedActivity) as ex:
+        start_experiment(experiment_template_id="an-id")
+    assert str(ex.value) == "Start Experiment failed, reason was: Something went wrong"
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_start_experiment_returns_client_response(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    resp = {"a-key": "a-value"}
+    client.start_experiment.return_value = resp
+
+    actual_resp = start_experiment(experiment_template_id="an-id")
+    assert actual_resp == resp

--- a/tests/fis/test_fis_actions.py
+++ b/tests/fis/test_fis_actions.py
@@ -8,6 +8,7 @@ from chaosaws.fis.actions import start_experiment
 
 def test_that_fis_module_exposes_correct_all_attributes():
     import chaosaws.fis.actions as actions
+
     all = actions.__all__
     assert "start_experiment" in all
 

--- a/tests/fis/test_fis_actions.py
+++ b/tests/fis/test_fis_actions.py
@@ -6,7 +6,7 @@ from chaoslib.exceptions import FailedActivity
 from chaosaws.fis.actions import start_experiment
 
 
-def test_that_fis_module_exposes_correct_all_attributes():
+def test_that_fis_modules___all___attribute_exposed_correctly():
     import chaosaws.fis.actions as actions
 
     all = actions.__all__


### PR DESCRIPTION
This PR adds the `chaosaws.fis.actions.start_experiment` activity to start an AWS FIS Experiment
