### PR TITLE
Fix incorrect line in `chaosaws/__init__.py`

### DIFF
--- a/chaosaws/__init__.py
+++ b/chaosaws/__init__.py
@@ -253,6 +253,6 @@ def load_exported_activities() -> List[DiscoveredActivities]:
     activities.extend(discover_probes("chaosaws.emr.probes"))
     activities.extend(discover_actions("chaosaws.route53.actions"))
     activities.extend(discover_probes("chaosaws.route53.probes"))
-    activities.extend(discover_probes("chaosaws.ssm.actions"))
+    activities.extend(discover_actions("chaosaws.ssm.actions"))
     activities.extend(discover_actions("chaosaws.fis.actions"))
     return activities


### PR DESCRIPTION
I think someone may have copy and pasted the a line in `__init__.py` and not renamed the function call

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
