### PR TITLE
Add `chaosaws.fis.actions.stop_experiment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - added GitHub Actions Workflows for Build and Test, Build and Discover, and Releasing
 - added `Makefile` to abstract away common commands: `install`, `install-dev`, `lint`, `format`, `tests`
 - added `chaosaws.fis.actions.start_experiment` to start an AWS FIS experiment
+- added `chaosaws.fis.actions.stop_experiment` to stop an AWS FIS experiment
 
 ### Removed
 - Removed TravisCI related files

--- a/chaosaws/fis/actions.py
+++ b/chaosaws/fis/actions.py
@@ -6,7 +6,7 @@ from chaoslib.types import Configuration, Secrets
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ["start_experiment"]
+__all__ = ["start_experiment", "stop_experiment"]
 
 
 def start_experiment(
@@ -94,4 +94,16 @@ def stop_experiment(
     ...'experiment': {'id': 'EXPTUCK2dxepXgkR38',
     'experimentTemplateId': 'EXT6oWVA1WrLNy4XS', ... }
     """
-    pass
+    if not experiment_id:
+        raise FailedActivity(
+            "You must pass a valid experiment id, id provided was empty"
+        )
+
+    fis_client = aws_client(
+        resource_name="fis", configuration=configuration, secrets=secrets
+    )
+
+    try:
+        return fis_client.stop_experiment(id=experiment_id)
+    except Exception as ex:
+        raise FailedActivity(f"Stop Experiment failed, reason was: {ex}")

--- a/chaosaws/fis/actions.py
+++ b/chaosaws/fis/actions.py
@@ -70,3 +70,28 @@ def start_experiment(
         return fis_client.start_experiment(**params)
     except Exception as ex:
         raise FailedActivity(f"Start Experiment failed, reason was: {ex}")
+
+
+def stop_experiment(
+    experiment_id: str,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> AWSResponse:
+    """
+    Stops the specified experiment.
+
+    :param experiment_id: str representing the running experiment to stop
+    :param configuration: Configuration object representing the CTK Configuration
+    :param secrets: Secret object representing the CTK Secrets
+    :returns: AWSResponse representing the response from FIS upon stopping the
+        experiment
+
+    Examples
+    --------
+    >>> stop_experiment(experiment_id="EXPTUCK2dxepXgkR38")
+    {'ResponseMetadata': {'RequestId': 'e5e9f9a9-f4d0-4d72-8704-1f26cc8b6ad6',
+    'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Fri, 13 Aug 2021 09:12:17 GMT',
+    ...'experiment': {'id': 'EXPTUCK2dxepXgkR38',
+    'experimentTemplateId': 'EXT6oWVA1WrLNy4XS', ... }
+    """
+    pass

--- a/tests/fis/test_fis_actions.py
+++ b/tests/fis/test_fis_actions.py
@@ -11,6 +11,7 @@ def test_that_fis_modules___all___attribute_exposed_correctly():
 
     all = actions.__all__
     assert "start_experiment" in all
+    assert "stop_experiment" in all
 
 
 @patch("chaosaws.fis.actions.aws_client", autospec=True)
@@ -76,4 +77,53 @@ def test_that_start_experiment_returns_client_response(aws_client):
     client.start_experiment.return_value = resp
 
     actual_resp = start_experiment(experiment_template_id="an-id")
+    assert actual_resp == resp
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_stop_experiment_invoked_correctly_when_given_experiment_id(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+
+    stop_experiment(experiment_id="an-id")
+    client.stop_experiment.assert_called_once_with(id="an-id")
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_stop_experiment_fails_if_experiment_id_empty_or_none(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+
+    with pytest.raises(FailedActivity) as ex:
+        stop_experiment(experiment_id="")
+    assert str(ex.value) == (
+        "You must pass a valid experiment id, id provided was empty"
+    )
+
+    with pytest.raises(FailedActivity) as ex:
+        stop_experiment(experiment_id=None)
+    assert str(ex.value) == (
+        "You must pass a valid experiment id, id provided was empty"
+    )
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_stop_experiment_fails_if_exception_raised(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    client.stop_experiment.side_effect = Exception("Something went wrong")
+
+    with pytest.raises(FailedActivity) as ex:
+        stop_experiment(experiment_id="an-id")
+    assert str(ex.value) == "Stop Experiment failed, reason was: Something went wrong"
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_stop_experiment_returns_client_response(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    resp = {"a-key": "a-value"}
+    client.stop_experiment.return_value = resp
+
+    actual_resp = stop_experiment(experiment_id="an-id")
     assert actual_resp == resp

--- a/tests/fis/test_fis_actions.py
+++ b/tests/fis/test_fis_actions.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from chaoslib.exceptions import FailedActivity
 
-from chaosaws.fis.actions import start_experiment
+from chaosaws.fis.actions import start_experiment, stop_experiment
 
 
 def test_that_fis_modules___all___attribute_exposed_correctly():


### PR DESCRIPTION
This PR adds the `chaosaws.fis.actions.stop_experiment` function to stop AWS FIS experiments
