### PR TITLE
Add `chaosaws.fis.probes.get_experiment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - added `Makefile` to abstract away common commands: `install`, `install-dev`, `lint`, `format`, `tests`
 - added `chaosaws.fis.actions.start_experiment` to start an AWS FIS experiment
 - added `chaosaws.fis.actions.stop_experiment` to stop an AWS FIS experiment
+- added `chaosaws.fis.probes.get_experiment` to retrieve an AWS FIS experiments details
 
 ### Removed
 - Removed TravisCI related files

--- a/chaosaws/fis/probes.py
+++ b/chaosaws/fis/probes.py
@@ -1,6 +1,10 @@
+from chaoslib.exceptions import FailedActivity
 from chaoslib.types import Configuration, Secrets
 
+from chaosaws import aws_client
 from chaosaws.types import AWSResponse
+
+__all__ = ["get_experiment"]
 
 
 def get_experiment(
@@ -29,4 +33,17 @@ def get_experiment(
     ...
     }
     """
-    pass
+
+    if not experiment_id:
+        raise FailedActivity(
+            "You must pass a valid experiment id, id provided was empty"
+        )
+
+    fis_client = aws_client(
+        resource_name="fis", configuration=configuration, secrets=secrets
+    )
+
+    try:
+        return fis_client.get_experiment(id=experiment_id)
+    except Exception as ex:
+        raise FailedActivity(f"Get Experiment failed, reason was: {ex}")

--- a/chaosaws/fis/probes.py
+++ b/chaosaws/fis/probes.py
@@ -1,0 +1,32 @@
+from chaoslib.types import Configuration, Secrets
+
+from chaosaws.types import AWSResponse
+
+
+def get_experiment(
+    experiment_id: str, configuration: Configuration = None, secrets: Secrets = None
+) -> AWSResponse:
+    """
+    Gets information about the specified experiment.
+
+    :param experiment_id: str representing the id of the experiment to fetch information
+        of
+    :param configuration: Configuration object representing the CTK Configuration
+    :param secrets: Secret object representing the CTK Secrets
+    :returns: AWSResponse representing the response from FIS upon retrieving the
+        experiment information
+
+    Examples
+    --------
+    >>> get_experiment(
+    ...    experiment_id="EXPTUCK2dxepXgkR38"
+    ... )
+    {'ResponseMetadata': {'RequestId': '0665fe39-2213-400b-b7ff-5f1ab9b7a5ea',
+    'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Fri, 20 Aug 2021 11:08:27 GMT',
+    ...
+    'experiment': {'id': 'EXPTUCK2dxepXgkR38',
+    'experimentTemplateId': 'EXT6oWVA1WrLNy4XS',
+    ...
+    }
+    """
+    pass

--- a/tests/fis/test_fis_actions.py
+++ b/tests/fis/test_fis_actions.py
@@ -6,7 +6,7 @@ from chaoslib.exceptions import FailedActivity
 from chaosaws.fis.actions import start_experiment, stop_experiment
 
 
-def test_that_fis_modules___all___attribute_exposed_correctly():
+def test_that_fis_action_modules___all___attribute_exposed_correctly():
     import chaosaws.fis.actions as actions
 
     all = actions.__all__

--- a/tests/fis/test_fis_probes.py
+++ b/tests/fis/test_fis_probes.py
@@ -6,7 +6,7 @@ from chaoslib.exceptions import FailedActivity
 from chaosaws.fis.probes import get_experiment
 
 
-def test_that_fis_action_modules___all___attribute_exposed_correctly():
+def test_that_fis_probe_modules___all___attribute_exposed_correctly():
     import chaosaws.fis.probes as probes
 
     all = probes.__all__

--- a/tests/fis/test_fis_probes.py
+++ b/tests/fis/test_fis_probes.py
@@ -13,7 +13,7 @@ def test_that_fis_action_modules___all___attribute_exposed_correctly():
     assert "get_experiment" in all
 
 
-@patch("chaosaws.fis.actions.aws_client", autospec=True)
+@patch("chaosaws.fis.probes.aws_client", autospec=True)
 def test_that_get_experiment_invoked_correctly_if_only_given_experiment_id(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -22,7 +22,7 @@ def test_that_get_experiment_invoked_correctly_if_only_given_experiment_id(aws_c
     client.get_experiment.assert_called_once_with(id="an-id")
 
 
-@patch("chaosaws.fis.actions.aws_client", autospec=True)
+@patch("chaosaws.fis.probes.aws_client", autospec=True)
 def test_that_get_experiment_fails_if_experiment_id_empty_or_none(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -36,7 +36,7 @@ def test_that_get_experiment_fails_if_experiment_id_empty_or_none(aws_client):
     assert str(ex.value) == "You must pass a valid experiment id, id provided was empty"
 
 
-@patch("chaosaws.fis.actions.aws_client", autospec=True)
+@patch("chaosaws.fis.probes.aws_client", autospec=True)
 def test_that_get_experiment_fails_if_exception_raised(aws_client):
     client = MagicMock()
     aws_client.return_value = client
@@ -47,7 +47,7 @@ def test_that_get_experiment_fails_if_exception_raised(aws_client):
     assert str(ex.value) == "Get Experiment failed, reason was: Something went wrong"
 
 
-@patch("chaosaws.fis.actions.aws_client", autospec=True)
+@patch("chaosaws.fis.probes.aws_client", autospec=True)
 def test_that_get_experiment_returns_client_response(aws_client):
     client = MagicMock()
     aws_client.return_value = client

--- a/tests/fis/test_fis_probes.py
+++ b/tests/fis/test_fis_probes.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from chaoslib.exceptions import FailedActivity
+
+from chaosaws.fis.probes import get_experiment
+
+
+def test_that_fis_action_modules___all___attribute_exposed_correctly():
+    import chaosaws.fis.probes as probes
+
+    all = probes.__all__
+    assert "get_experiment" in all
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_get_experiment_invoked_correctly_if_only_given_experiment_id(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+
+    get_experiment(experiment_id="an-id")
+    client.get_experiment.assert_called_once_with(id="an-id")
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_get_experiment_fails_if_experiment_id_empty_or_none(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+
+    with pytest.raises(FailedActivity) as ex:
+        get_experiment(experiment_id="")
+    assert str(ex.value) == "You must pass a valid experiment id, id provided was empty"
+
+    with pytest.raises(FailedActivity) as ex:
+        get_experiment(experiment_id=None)
+    assert str(ex.value) == "You must pass a valid experiment id, id provided was empty"
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_get_experiment_fails_if_exception_raised(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    client.get_experiment.side_effect = Exception("Something went wrong")
+
+    with pytest.raises(FailedActivity) as ex:
+        get_experiment(experiment_id="an-id")
+    assert str(ex.value) == "Get Experiment failed, reason was: Something went wrong"
+
+
+@patch("chaosaws.fis.actions.aws_client", autospec=True)
+def test_that_get_experiment_returns_client_response(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    resp = {"a-key", "a-value"}
+    client.get_experiment.return_value = resp
+
+    actual_resp = get_experiment(experiment_id="an-id")
+    assert actual_resp == resp


### PR DESCRIPTION
This PR adds `chaosaws.fis.probes.get_experiment` so that people may retrieve the information of a given AWS FIS experiment run
