### PR TITLE
fix: changed key and value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.18.0...HEAD
 
 ### Added
-
 - workflow to mark issues as `stale` and remove them after 7 days of being `stale`
 - added `chaosaws.elasticache.actions.test_failover` for testing automatic failover on specified shards 
 - adding `put_parameter` to ssm actions
+- updated `aws_region` configuration in Readme
+
 
 ## [0.18.0][] - 2021-10-11
 [0.18.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-aws/compare/0.17.0...0.18.0

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ or
 {
     "configuration": {
         "aws_region": {
-            "env": "type",
+            "type": "env",
             "key": "AWS_REGION"
         }
     }


### PR DESCRIPTION
As first mentioned [here](https://github.com/chaostoolkit/chaostoolkit/issues/253), the key and value in the **_Setting the Region_** section is configured incorrectly.