### PR TITLE
added probe: count_min_instances to validate whether minimum number o…

### DIFF
--- a/chaosaws/ec2/probes.py
+++ b/chaosaws/ec2/probes.py
@@ -6,7 +6,8 @@ from chaoslib.types import Configuration, Secrets
 from chaosaws import aws_client
 from chaosaws.types import AWSResponse
 
-__all__ = ["describe_instances", "count_instances", "instance_state"]
+__all__ = ["describe_instances", "count_instances",
+           "instance_state", "count_min_instances"]
 
 
 def describe_instances(
@@ -74,3 +75,20 @@ def instance_state(
         if i["State"]["Name"] != state:
             return False
     return True
+
+
+def count_min_instances(
+    filters: List[Dict[str, Any]],
+    min_count: int = 0,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> bool:
+    """
+    Returns whether minimum number of instances available matching the specified filters.
+
+    """
+
+    count = count_instances(filters=filters,
+                            configuration=configuration ,
+                            secrets=secrets)
+    return count >= min_count

--- a/tests/ec2/test_ec2_probes.py
+++ b/tests/ec2/test_ec2_probes.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from chaoslib.exceptions import FailedActivity
 
-from chaosaws.ec2.probes import count_instances, describe_instances, instance_state
+from chaosaws.ec2.probes import count_instances, describe_instances, instance_state, count_min_instances
 
 
 @patch("chaosaws.ec2.probes.aws_client", autospec=True)
@@ -83,3 +83,12 @@ def test_instance_state_filters(aws_client):
     results = instance_state(state="running", filters=filters)
     client.describe_instances.assert_called_with(Filters=filters)
     assert results
+
+
+@patch("chaosaws.ec2.probes.aws_client", autospec=True)
+def test_count_min_instances(aws_client):
+    client = MagicMock()
+    aws_client.return_value = client
+    filters = [{"Name": "availability-zone", "Values": ["us-west-1"]}]
+    count_min_instances(filters)
+    client.describe_instances.assert_called_with(Filters=filters)


### PR DESCRIPTION
We have built our chaos engg platform powered by chaostoolkit. In real world, we notice number of EC2 instances to up or down based on scaling events thus we modified this chaostoolkit-aws in our platform to add new probe 'count_min_instances'. This would return true if minimum number of instances for given condition are met. This is working well for us hence contributing back to the library. Pl let me know if any other hygene factors needed.
Based on learning from this contribution, I could make further enhancements in this beautiful package.